### PR TITLE
[codex] Document CI assumptions

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,6 +76,25 @@ The production app should eventually use:
 - `quartetmemberfinder.org`
 - optionally `www.quartetmemberfinder.org` redirecting to the canonical host
 
+## GitHub Actions CI
+
+The repository uses `.github/workflows/ci.yml` for baseline validation on pull
+requests and pushes to `main`.
+
+Current CI assumptions:
+
+- Node.js 22 is the supported CI runtime.
+- npm is the package manager, with dependency installation through `npm ci`.
+- Dependency caching uses the npm cache support in `actions/setup-node`.
+- Basic validation does not require secrets or deployed service credentials.
+
+The CI workflow must fail the build if any of these commands fail:
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:run`
+- `npm run build`
+
 ## Supabase
 
 Supabase schema and Row Level Security changes should be managed by committed migrations, not dashboard-only edits.


### PR DESCRIPTION
## Summary

- Documents the GitHub Actions CI workflow assumptions in `docs/deployment.md`.
- Calls out Node.js 22, npm/`npm ci`, npm caching, no-secret baseline validation, and the required blocking commands.

Closes #2.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`

## Notes

The CI workflow itself was added in the issue #1 scaffold PR and already runs on pull requests and pushes to `main`. This PR completes the remaining issue #2 documentation scope without changing app behavior.