### PR TITLE
[codex] Implement Supabase auth shell

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { signOut } from "@/app/auth/actions";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProtectedAppLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-2xl flex-col justify-center px-6 py-16">
+        <h1 className="text-3xl font-bold text-[#172023]">
+          Supabase Auth is not configured
+        </h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          Add `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to
+          the environment before using protected app pages.
+        </p>
+        <Link className="mt-6 font-semibold text-[#2f6f73]" href="/">
+          Back to public home
+        </Link>
+      </main>
+    );
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app");
+  }
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-[#d7cec0] bg-[#fffaf2]/90">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <Link className="text-lg font-bold text-[#172023]" href="/app">
+            Quartet Member Finder
+          </Link>
+          <nav aria-label="App navigation" className="flex flex-wrap gap-3">
+            <Link className="text-sm font-semibold text-[#394548]" href="/app">
+              Home
+            </Link>
+            <Link
+              className="text-sm font-semibold text-[#394548]"
+              href="/app/profile"
+            >
+              Singer profile
+            </Link>
+            <Link
+              className="text-sm font-semibold text-[#394548]"
+              href="/app/listings"
+            >
+              Quartet listings
+            </Link>
+          </nav>
+          <form action={signOut}>
+            <button
+              className="rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
+              type="submit"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-6xl px-6 py-10">{children}</main>
+    </div>
+  );
+}

--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -1,0 +1,16 @@
+export default function ManageListingsPage() {
+  return (
+    <div>
+      <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+        Quartet listings
+      </p>
+      <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+        Manage quartet listings
+      </h1>
+      <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
+        Quartet listing management will live here. Listings can stay private
+        until their owner makes them visible for discovery.
+      </p>
+    </div>
+  );
+}

--- a/app/(protected)/app/page.tsx
+++ b/app/(protected)/app/page.tsx
@@ -1,0 +1,23 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export default async function AppHomePage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  return (
+    <div>
+      <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+        Signed-in workspace
+      </p>
+      <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+        Welcome{user?.email ? `, ${user.email}` : ""}
+      </h1>
+      <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
+        Manage your singer profile and quartet listings here. Public discovery
+        stays separate from this signed-in management area.
+      </p>
+    </div>
+  );
+}

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -1,0 +1,16 @@
+export default function ManageProfilePage() {
+  return (
+    <div>
+      <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+        Singer profile
+      </p>
+      <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+        Manage your singer profile
+      </h1>
+      <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
+        Profile editing will live here. This protected route is ready for the
+        singer profile workflow without exposing management data publicly.
+      </p>
+    </div>
+  );
+}

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { getAppUrl } from "@/lib/supabase/env";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function redirectWithMessage(
+  path: string,
+  key: "error" | "message",
+  value: string,
+): never {
+  redirect(`${path}?${key}=${encodeURIComponent(value)}`);
+}
+
+export async function signInWithEmail(formData: FormData) {
+  const email = String(formData.get("email") ?? "")
+    .trim()
+    .toLowerCase();
+  const next = String(formData.get("next") ?? "/app");
+
+  if (!email) {
+    redirectWithMessage("/sign-in", "error", "Enter an email address.");
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithMessage(
+      "/sign-in",
+      "error",
+      "Supabase Auth is not configured for this environment.",
+    );
+  }
+
+  const requestHeaders = await headers();
+  const origin = requestHeaders.get("origin") ?? getAppUrl();
+  const emailRedirectTo = `${origin}/auth/callback?next=${encodeURIComponent(
+    next.startsWith("/") ? next : "/app",
+  )}`;
+
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: {
+      emailRedirectTo,
+    },
+  });
+
+  if (error) {
+    redirectWithMessage("/sign-in", "error", error.message);
+  }
+
+  redirectWithMessage(
+    "/sign-in",
+    "message",
+    "Check your email for a sign-in link.",
+  );
+}
+
+export async function signOut() {
+  const supabase = await createSupabaseServerClient();
+
+  if (supabase) {
+    await supabase.auth.signOut();
+  }
+
+  redirect("/");
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+  const next = requestUrl.searchParams.get("next") ?? "/app";
+  const safeNext = next.startsWith("/") ? next : "/app";
+
+  if (code) {
+    const supabase = await createSupabaseServerClient();
+    const { error } = supabase
+      ? await supabase.auth.exchangeCodeForSession(code)
+      : { error: new Error("Supabase Auth is not configured.") };
+
+    if (!error) {
+      return NextResponse.redirect(new URL(safeNext, requestUrl.origin));
+    }
+  }
+
+  return NextResponse.redirect(
+    new URL(
+      "/sign-in?error=Unable%20to%20complete%20sign-in.",
+      requestUrl.origin,
+    ),
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { PRODUCT_NAME, PRODUCT_PROMISE } from "@/lib/app-metadata";
+import Link from "next/link";
 
 const discoveryPaths = [
   "Singer profiles for quartet opportunities",
@@ -19,6 +20,20 @@ export default function Home() {
         <p className="mt-6 max-w-2xl text-lg leading-8 text-[#394548]">
           {PRODUCT_PROMISE}
         </p>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link
+            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            href="/sign-in"
+          >
+            Sign in
+          </Link>
+          <Link
+            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+            href="/app"
+          >
+            Manage profile
+          </Link>
+        </div>
       </section>
 
       <section

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { signInWithEmail } from "@/app/auth/actions";
+
+type SignInPageProps = {
+  searchParams: Promise<{
+    error?: string;
+    message?: string;
+    next?: string;
+  }>;
+};
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const params = await searchParams;
+  const next = params.next?.startsWith("/") ? params.next : "/app";
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-16">
+      <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
+        Quartet Member Finder
+      </Link>
+      <h1 className="mt-6 text-3xl font-bold text-[#172023]">Sign in</h1>
+      <p className="mt-3 text-base leading-7 text-[#394548]">
+        Enter your email address and Supabase will send a secure sign-in link.
+      </p>
+
+      {params.error ? (
+        <p className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {params.error}
+        </p>
+      ) : null}
+
+      {params.message ? (
+        <p className="mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+          {params.message}
+        </p>
+      ) : null}
+
+      <form action={signInWithEmail} className="mt-8 space-y-4">
+        <input name="next" type="hidden" value={next} />
+        <label className="block">
+          <span className="text-sm font-semibold text-[#172023]">Email</span>
+          <input
+            autoComplete="email"
+            className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            name="email"
+            placeholder="singer@example.com"
+            required
+            type="email"
+          />
+        </label>
+        <button
+          className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          type="submit"
+        >
+          Send sign-in link
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -101,6 +101,16 @@ Supabase schema and Row Level Security changes should be managed by committed mi
 
 Production deploys should not depend on undocumented manual database changes.
 
+Supabase Auth should be configured with the deployed app URL as the site URL and
+the app callback route as an allowed redirect URL:
+
+- local callback: `http://localhost:3000/auth/callback`
+- production callback: `https://<production-host>/auth/callback`
+
+The app's protected management routes use Supabase's anonymous public key on the
+server and in browser-safe helpers. Service-role keys must stay server-only and
+are not required for basic sign-in, sign-out, or protected route checks.
+
 ## Resend
 
 Resend should be used for transactional email, including auth-related email where appropriate and the app-mediated contact relay.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -22,3 +22,26 @@ The current scaffold includes `.env.example` with safe placeholder keys:
 - `RESEND_FROM_EMAIL`
 
 Do not expose server-only values in browser code.
+
+## Supabase Auth
+
+The app uses Supabase Auth for signed-in management pages.
+
+Required public values:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_APP_URL`
+
+Only the Supabase anonymous browser key should use the `NEXT_PUBLIC_` prefix.
+Do not expose `SUPABASE_SERVICE_ROLE_KEY` in client components, browser helper
+code, or public environment variables.
+
+For local development, configure the Supabase Auth site URL and redirect URLs to
+allow:
+
+- `http://localhost:3000`
+- `http://localhost:3000/auth/callback`
+
+For production, add the deployed app URL and `/auth/callback` URL in the
+Supabase dashboard before enabling sign-in links for users.

--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+import { getSupabasePublicConfig } from "@/lib/supabase/env";
+
+export function createSupabaseBrowserClient() {
+  const config = getSupabasePublicConfig();
+
+  if (!config) {
+    throw new Error(
+      "Supabase public environment variables are not configured.",
+    );
+  }
+
+  return createBrowserClient(config.url, config.anonKey);
+}

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -1,0 +1,19 @@
+export type SupabasePublicConfig = {
+  anonKey: string;
+  url: string;
+};
+
+export function getSupabasePublicConfig(): SupabasePublicConfig | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    return null;
+  }
+
+  return { anonKey, url };
+}
+
+export function getAppUrl() {
+  return process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,30 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { getSupabasePublicConfig } from "@/lib/supabase/env";
+
+export async function createSupabaseServerClient() {
+  const config = getSupabasePublicConfig();
+
+  if (!config) {
+    return null;
+  }
+
+  const cookieStore = await cookies();
+
+  return createServerClient(config.url, config.anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options);
+          });
+        } catch {
+          // Server Components can read cookies but cannot always write them.
+        }
+      },
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "quartet-member-finder",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.10.2",
+        "@supabase/supabase-js": "^2.105.1",
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -2192,6 +2194,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.1.tgz",
+      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.1.tgz",
+      "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.1.tgz",
+      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.1.tgz",
+      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.1",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
+      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.102.1"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.1.tgz",
+      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.1.tgz",
+      "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.1",
+        "@supabase/functions-js": "2.105.1",
+        "@supabase/postgrest-js": "2.105.1",
+        "@supabase/realtime-js": "2.105.1",
+        "@supabase/storage-js": "2.105.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2622,7 +2722,6 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2646,6 +2745,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3895,6 +4003,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5305,6 +5426,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -7988,7 +8118,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8412,6 +8541,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.105.1",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/test/supabase-auth.test.ts
+++ b/test/supabase-auth.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("Supabase public env helpers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when public Supabase values are missing", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+
+    const { getSupabasePublicConfig } = await import("@/lib/supabase/env");
+
+    expect(getSupabasePublicConfig()).toBeNull();
+  });
+
+  it("uses only public Supabase values for client configuration", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+
+    const { getSupabasePublicConfig } = await import("@/lib/supabase/env");
+
+    expect(getSupabasePublicConfig()).toEqual({
+      anonKey: "anon-key",
+      url: "https://example.supabase.co",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Supabase SSR/browser helpers using only public Supabase env values.
- Adds email link sign-in, sign-out, and `/auth/callback` handling for the App Router.
- Adds a protected `/app` management shell with profile and quartet listing placeholder routes.
- Keeps public landing behavior separate while linking to sign-in and management.
- Documents Supabase Auth environment and redirect URL setup.
- Adds tests that ensure Supabase client config uses public env values and ignores service-role secrets.

Closes #4.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --cached --check`
- Production server smoke test with `npm run start -- --hostname 127.0.0.1 --port 3000` returned HTTP 200 for `/`, `/sign-in`, and `/app`.

## Notes

- `next dev` started, but the local macOS file watcher hit `EMFILE: too many open files, watch`, so dev-server route checks returned 404 in this environment. The production server from the successful build served the routes correctly.
- Full Supabase sign-in email delivery requires configured Supabase project values and Auth redirect URLs.