### PR TITLE
[codex] Build singer profile create/edit flow

### DIFF
--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -1,0 +1,111 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  buildPublicLocationLabel,
+  inferLocationPrecision,
+  parseSingerProfileFormData,
+} from "@/lib/profiles/singer-profile-form";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function redirectWithProfileMessage(
+  key: "error" | "message",
+  value: string,
+): never {
+  redirect(`/app/profile?${key}=${encodeURIComponent(value)}`);
+}
+
+export async function saveSingerProfile(formData: FormData) {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithProfileMessage(
+      "error",
+      "Supabase is not configured for this environment.",
+    );
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app/profile");
+  }
+
+  let values;
+
+  try {
+    values = parseSingerProfileFormData(formData);
+  } catch (error) {
+    redirectWithProfileMessage(
+      "error",
+      error instanceof Error ? error.message : "Profile data is invalid.",
+    );
+  }
+
+  const locationLabelPublic = buildPublicLocationLabel(values);
+  const locationPrecision = inferLocationPrecision(values);
+
+  const { data: profile, error: profileError } = await supabase
+    .from("singer_profiles")
+    .upsert(
+      {
+        availability: values.availability,
+        bio: values.bio,
+        country_code: values.countryCode,
+        country_name: values.countryName,
+        display_name: values.displayName,
+        experience_level: values.experienceLevel,
+        goals: values.goals,
+        is_active: true,
+        is_visible: values.isVisible,
+        locality: values.locality,
+        location_label_public: locationLabelPublic,
+        location_precision: locationPrecision,
+        postal_code_private: values.postalCodePrivate,
+        preferred_distance_unit: "km",
+        region: values.region,
+        travel_radius_km: values.travelRadiusKm,
+        user_id: user.id,
+      },
+      { onConflict: "user_id" },
+    )
+    .select("id")
+    .single();
+
+  if (profileError || !profile) {
+    redirectWithProfileMessage(
+      "error",
+      profileError?.message ?? "Unable to save singer profile.",
+    );
+  }
+
+  const { error: deletePartsError } = await supabase
+    .from("singer_profile_parts")
+    .delete()
+    .eq("singer_profile_id", profile.id);
+
+  if (deletePartsError) {
+    redirectWithProfileMessage("error", deletePartsError.message);
+  }
+
+  if (values.parts.length > 0) {
+    const { error: partsError } = await supabase
+      .from("singer_profile_parts")
+      .insert(
+        values.parts.map((part) => ({
+          part,
+          singer_profile_id: profile.id,
+        })),
+      );
+
+    if (partsError) {
+      redirectWithProfileMessage("error", partsError.message);
+    }
+  }
+
+  revalidatePath("/app/profile");
+  redirectWithProfileMessage("message", "Singer profile saved.");
+}

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -1,16 +1,327 @@
-export default function ManageProfilePage() {
+import {
+  BARBERSHOP_PARTS,
+  PROFILE_GOALS,
+  type BarbershopPart,
+  type ProfileGoal,
+} from "@/lib/profiles/singer-profile-form";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { saveSingerProfile } from "./actions";
+
+type SingerProfileRow = {
+  availability: string | null;
+  bio: string | null;
+  country_code: string | null;
+  country_name: string | null;
+  display_name: string;
+  experience_level: string | null;
+  goals: ProfileGoal[];
+  id: string;
+  is_visible: boolean;
+  locality: string | null;
+  location_label_public: string | null;
+  postal_code_private: string | null;
+  region: string | null;
+  travel_radius_km: number | null;
+};
+
+type ManageProfilePageProps = {
+  searchParams: Promise<{
+    error?: string;
+    message?: string;
+  }>;
+};
+
+const partLabels: Record<BarbershopPart, string> = {
+  baritone: "Baritone",
+  bass: "Bass",
+  lead: "Lead",
+  tenor: "Tenor",
+};
+
+const goalLabels: Record<ProfileGoal, string> = {
+  casual: "Casual/social singing",
+  contest: "Contest quartet",
+  learning: "Learning/development",
+  paid_gigs: "Paid gigs",
+  pickup: "Pickup singing",
+  regular_rehearsal: "Regular rehearsing quartet",
+};
+
+function checked(value: string, values: readonly string[] | null | undefined) {
+  return values?.includes(value) ?? false;
+}
+
+function fieldValue(value: string | number | null | undefined) {
+  return value == null ? "" : String(value);
+}
+
+export default async function ManageProfilePage({
+  searchParams,
+}: ManageProfilePageProps) {
+  const params = await searchParams;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  const { data: profile } =
+    supabase && user
+      ? await supabase
+          .from("singer_profiles")
+          .select(
+            "id, availability, bio, country_code, country_name, display_name, experience_level, goals, is_visible, locality, location_label_public, postal_code_private, region, travel_radius_km",
+          )
+          .eq("user_id", user.id)
+          .maybeSingle<SingerProfileRow>()
+      : { data: null };
+
+  const { data: parts } =
+    supabase && profile
+      ? await supabase
+          .from("singer_profile_parts")
+          .select("part")
+          .eq("singer_profile_id", profile.id)
+      : { data: [] };
+
+  const selectedParts =
+    parts?.map((partRow) => partRow.part as BarbershopPart) ?? [];
+
   return (
     <div>
-      <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-        Singer profile
-      </p>
-      <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-        Manage your singer profile
-      </h1>
-      <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
-        Profile editing will live here. This protected route is ready for the
-        singer profile workflow without exposing management data publicly.
-      </p>
+      <div className="max-w-3xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Singer profile
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          Manage your singer profile
+        </h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          Create the profile that quartets and other singers can discover. Keep
+          the public location approximate; postal code stays private for future
+          matching and search.
+        </p>
+      </div>
+
+      {params.error ? (
+        <p className="mt-8 max-w-3xl rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {params.error}
+        </p>
+      ) : null}
+
+      {params.message ? (
+        <p className="mt-8 max-w-3xl rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+          {params.message}
+        </p>
+      ) : null}
+
+      <form action={saveSingerProfile} className="mt-8 max-w-3xl space-y-8">
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Basics</h2>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Display name
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(profile?.display_name)}
+              maxLength={120}
+              name="displayName"
+              required
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Short bio
+            </span>
+            <textarea
+              className="mt-2 min-h-28 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(profile?.bio)}
+              maxLength={2000}
+              name="bio"
+            />
+          </label>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Parts Sung</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {BARBERSHOP_PARTS.map((part) => (
+              <label
+                className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                key={part}
+              >
+                <input
+                  defaultChecked={checked(part, selectedParts)}
+                  name="parts"
+                  type="checkbox"
+                  value={part}
+                />
+                <span className="font-semibold">{partLabels[part]}</span>
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Location</h2>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Public approximate location
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(profile?.location_label_public)}
+              maxLength={160}
+              name="locationLabelPublic"
+              placeholder="Manchester, UK area"
+            />
+          </label>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Locality/city
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.locality)}
+                maxLength={120}
+                name="locality"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Region/admin area
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.region)}
+                maxLength={120}
+                name="region"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Country name
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.country_name)}
+                maxLength={120}
+                name="countryName"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Country code
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base uppercase text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.country_code)}
+                maxLength={2}
+                name="countryCode"
+                placeholder="GB"
+              />
+            </label>
+          </div>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Postal code
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(profile?.postal_code_private)}
+              maxLength={40}
+              name="postalCodePrivate"
+            />
+          </label>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">
+            Quartet Preferences
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {PROFILE_GOALS.map((goal) => (
+              <label
+                className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                key={goal}
+              >
+                <input
+                  defaultChecked={checked(goal, profile?.goals)}
+                  name="goals"
+                  type="checkbox"
+                  value={goal}
+                />
+                <span className="font-semibold">{goalLabels[goal]}</span>
+              </label>
+            ))}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Experience level
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.experience_level)}
+                maxLength={120}
+                name="experienceLevel"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Travel willingness in km
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.travel_radius_km)}
+                min={0}
+                name="travelRadiusKm"
+                type="number"
+              />
+            </label>
+          </div>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Availability
+            </span>
+            <textarea
+              className="mt-2 min-h-24 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(profile?.availability)}
+              maxLength={500}
+              name="availability"
+            />
+          </label>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Visibility</h2>
+          <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
+            <input
+              className="mt-1"
+              defaultChecked={profile?.is_visible ?? false}
+              name="isVisible"
+              type="checkbox"
+            />
+            <span>
+              <span className="block font-semibold text-[#172023]">
+                Show my singer profile in discovery
+              </span>
+              <span className="mt-1 block text-sm leading-6 text-[#596466]">
+                Discovery views include your display name, parts, goals, and
+                approximate location only.
+              </span>
+            </span>
+          </label>
+        </section>
+
+        <button
+          className="rounded-md bg-[#174b4f] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          type="submit"
+        >
+          Save singer profile
+        </button>
+      </form>
     </div>
   );
 }

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -70,6 +70,27 @@ Quartet listing owners must be able to control whether a quartet listing appears
 
 Hidden/inactive profiles and listings should not be returned in public discovery queries.
 
+## Singer profile management
+
+Signed-in users can manage their own singer profile from the protected app area.
+The MVP profile form stores:
+
+- display name
+- barbershop parts sung
+- goals
+- descriptive experience level
+- availability
+- travel willingness in kilometers
+- short bio
+- public approximate location label
+- country, region, locality, and private postal code when provided
+- search visibility
+
+The postal code field is stored for future matching/search work and should not
+be shown in public discovery results. The public discovery label should stay
+approximate, such as a city/region/country area. Location inputs remain globally
+tolerant and do not require US state, ZIP code, address, or phone formats.
+
 ## Contact model
 
 Initial contact should be mediated by the app.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -43,6 +43,10 @@ An `account_profiles` row belongs to one authenticated user by `user_id`.
 A `singer_profiles` row belongs to one authenticated user by `user_id`. The
 initial schema enforces one singer profile per user.
 
+Singer profile edits are saved through the protected app route at
+`/app/profile`. The server action writes `user_id = auth.uid()` and relies on
+RLS to reject writes for any other owner.
+
 A `quartet_listings` row belongs to the authenticated user identified by
 `owner_user_id`. Multi-owner quartet management is not part of the initial
 schema.

--- a/lib/profiles/singer-profile-form.ts
+++ b/lib/profiles/singer-profile-form.ts
@@ -1,0 +1,147 @@
+export const BARBERSHOP_PARTS = ["tenor", "lead", "baritone", "bass"] as const;
+
+export const PROFILE_GOALS = [
+  "casual",
+  "pickup",
+  "regular_rehearsal",
+  "contest",
+  "paid_gigs",
+  "learning",
+] as const;
+
+export type BarbershopPart = (typeof BARBERSHOP_PARTS)[number];
+export type ProfileGoal = (typeof PROFILE_GOALS)[number];
+
+export type SingerProfileFormValues = {
+  availability: string | null;
+  bio: string | null;
+  countryCode: string | null;
+  countryName: string | null;
+  displayName: string;
+  experienceLevel: string | null;
+  goals: ProfileGoal[];
+  isVisible: boolean;
+  locality: string | null;
+  locationLabelPublic: string | null;
+  parts: BarbershopPart[];
+  postalCodePrivate: string | null;
+  region: string | null;
+  travelRadiusKm: number | null;
+};
+
+export function normalizeOptionalText(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function normalizeCountryCode(value: FormDataEntryValue | null) {
+  const normalized = normalizeOptionalText(value)?.toUpperCase() ?? null;
+
+  if (!normalized) {
+    return null;
+  }
+
+  return /^[A-Z]{2}$/.test(normalized) ? normalized : null;
+}
+
+export function parseTravelRadiusKm(value: FormDataEntryValue | null) {
+  const normalized = normalizeOptionalText(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const radius = Number(normalized);
+
+  if (!Number.isInteger(radius) || radius < 0 || radius > 10000) {
+    return null;
+  }
+
+  return radius;
+}
+
+function parseAllowedList<T extends string>(
+  values: FormDataEntryValue[],
+  allowedValues: readonly T[],
+) {
+  const allowed = new Set<string>(allowedValues);
+
+  return values
+    .filter((value): value is string => typeof value === "string")
+    .filter((value): value is T => allowed.has(value));
+}
+
+export function parseSingerProfileFormData(
+  formData: FormData,
+): SingerProfileFormValues {
+  const displayName = normalizeOptionalText(formData.get("displayName"));
+
+  if (!displayName) {
+    throw new Error("Display name is required.");
+  }
+
+  return {
+    availability: normalizeOptionalText(formData.get("availability")),
+    bio: normalizeOptionalText(formData.get("bio")),
+    countryCode: normalizeCountryCode(formData.get("countryCode")),
+    countryName: normalizeOptionalText(formData.get("countryName")),
+    displayName,
+    experienceLevel: normalizeOptionalText(formData.get("experienceLevel")),
+    goals: parseAllowedList(formData.getAll("goals"), PROFILE_GOALS),
+    isVisible: formData.get("isVisible") === "on",
+    locality: normalizeOptionalText(formData.get("locality")),
+    locationLabelPublic: normalizeOptionalText(
+      formData.get("locationLabelPublic"),
+    ),
+    parts: parseAllowedList(formData.getAll("parts"), BARBERSHOP_PARTS),
+    postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
+    region: normalizeOptionalText(formData.get("region")),
+    travelRadiusKm: parseTravelRadiusKm(formData.get("travelRadiusKm")),
+  };
+}
+
+export function inferLocationPrecision(
+  values: Pick<
+    SingerProfileFormValues,
+    "countryCode" | "countryName" | "locality" | "postalCodePrivate" | "region"
+  >,
+) {
+  if (values.postalCodePrivate) {
+    return "postal_code";
+  }
+
+  if (values.locality) {
+    return "locality";
+  }
+
+  if (values.region) {
+    return "region";
+  }
+
+  if (values.countryCode || values.countryName) {
+    return "country";
+  }
+
+  return "unknown";
+}
+
+export function buildPublicLocationLabel(
+  values: Pick<
+    SingerProfileFormValues,
+    "countryName" | "locality" | "locationLabelPublic" | "region"
+  >,
+) {
+  if (values.locationLabelPublic) {
+    return values.locationLabelPublic;
+  }
+
+  const locationParts = [values.locality, values.region, values.countryName]
+    .filter(Boolean)
+    .join(", ");
+
+  return locationParts ? `${locationParts} area` : null;
+}

--- a/test/singer-profile-form.test.ts
+++ b/test/singer-profile-form.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPublicLocationLabel,
+  inferLocationPrecision,
+  parseSingerProfileFormData,
+} from "@/lib/profiles/singer-profile-form";
+
+function formData(entries: Array<[string, string]>) {
+  const data = new FormData();
+
+  for (const [key, value] of entries) {
+    data.append(key, value);
+  }
+
+  return data;
+}
+
+describe("singer profile form parsing", () => {
+  it("accepts globally tolerant location fields without US-only requirements", () => {
+    const values = parseSingerProfileFormData(
+      formData([
+        ["displayName", "Priya"],
+        ["countryCode", "gb"],
+        ["countryName", "United Kingdom"],
+        ["region", "Greater Manchester"],
+        ["locality", "Manchester"],
+        ["postalCodePrivate", "M1 1AE"],
+        ["parts", "lead"],
+        ["parts", "bass"],
+        ["goals", "pickup"],
+        ["travelRadiusKm", "40"],
+      ]),
+    );
+
+    expect(values.countryCode).toBe("GB");
+    expect(values.postalCodePrivate).toBe("M1 1AE");
+    expect(values.parts).toEqual(["lead", "bass"]);
+    expect(values.goals).toEqual(["pickup"]);
+    expect(values.travelRadiusKm).toBe(40);
+  });
+
+  it("filters unexpected parts and goals", () => {
+    const values = parseSingerProfileFormData(
+      formData([
+        ["displayName", "Jordan"],
+        ["parts", "lead"],
+        ["parts", "melody"],
+        ["goals", "contest"],
+        ["goals", "viral_video"],
+      ]),
+    );
+
+    expect(values.parts).toEqual(["lead"]);
+    expect(values.goals).toEqual(["contest"]);
+  });
+
+  it("builds an approximate public location without postal code", () => {
+    const values = parseSingerProfileFormData(
+      formData([
+        ["displayName", "Ari"],
+        ["countryName", "Canada"],
+        ["region", "Ontario"],
+        ["locality", "Toronto"],
+        ["postalCodePrivate", "M5V"],
+      ]),
+    );
+
+    expect(buildPublicLocationLabel(values)).toBe(
+      "Toronto, Ontario, Canada area",
+    );
+    expect(buildPublicLocationLabel(values)).not.toContain("M5V");
+    expect(inferLocationPrecision(values)).toBe("postal_code");
+  });
+
+  it("requires a display name", () => {
+    expect(() => parseSingerProfileFormData(formData([]))).toThrow(
+      "Display name is required.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the placeholder protected singer profile route with a create/edit form for MVP profile fields.
- Adds a server action that saves the signed-in user's singer profile through Supabase, upserts by `user_id`, replaces selected parts, and relies on RLS for ownership enforcement.
- Adds profile form parsing/privacy helpers for parts, goals, global location fields, private postal code, public location label, visibility, and travel radius.
- Updates privacy and Supabase docs for singer profile management behavior.
- Adds tests for globally tolerant location parsing, allowed parts/goals, approximate public labels, and required display names.

Closes #5.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --cached --check`
- Production server smoke test with `npm run start -- --hostname 127.0.0.1 --port 3000` returned HTTP 200 for `/` and `/app/profile`.

## Notes

- Full browser create/edit/save verification requires configured Supabase project environment values and an authenticated session. This local environment does not include those credentials.
- Postal code is stored as private profile data and is not used as the public location label.