### PR TITLE
[codex] Build quartet listing create/edit flow

### DIFF
--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -1,0 +1,124 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  buildQuartetPublicLocationLabel,
+  inferQuartetLocationPrecision,
+  parseQuartetListingFormData,
+} from "@/lib/quartets/quartet-listing-form";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function redirectWithListingMessage(
+  key: "error" | "message",
+  value: string,
+): never {
+  redirect(`/app/listings?${key}=${encodeURIComponent(value)}`);
+}
+
+export async function saveQuartetListing(formData: FormData) {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithListingMessage(
+      "error",
+      "Supabase is not configured for this environment.",
+    );
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app/listings");
+  }
+
+  let values;
+
+  try {
+    values = parseQuartetListingFormData(formData);
+  } catch (error) {
+    redirectWithListingMessage(
+      "error",
+      error instanceof Error ? error.message : "Listing data is invalid.",
+    );
+  }
+
+  const listingPayload = {
+    availability: values.availability,
+    country_code: values.countryCode,
+    country_name: values.countryName,
+    description: values.description,
+    experience_level: values.experienceLevel,
+    goals: values.goals,
+    is_active: true,
+    is_visible: values.isVisible,
+    locality: values.locality,
+    location_label_public: buildQuartetPublicLocationLabel(values),
+    location_precision: inferQuartetLocationPrecision(values),
+    name: values.name,
+    owner_user_id: user.id,
+    postal_code_private: values.postalCodePrivate,
+    preferred_distance_unit: "km",
+    region: values.region,
+    travel_radius_km: values.travelRadiusKm,
+  };
+
+  const listingResult = values.listingId
+    ? await supabase
+        .from("quartet_listings")
+        .update(listingPayload)
+        .eq("id", values.listingId)
+        .eq("owner_user_id", user.id)
+        .select("id")
+        .single()
+    : await supabase
+        .from("quartet_listings")
+        .insert(listingPayload)
+        .select("id")
+        .single();
+
+  if (listingResult.error || !listingResult.data) {
+    redirectWithListingMessage(
+      "error",
+      listingResult.error?.message ?? "Unable to save quartet listing.",
+    );
+  }
+
+  const listingId = listingResult.data.id;
+  const { error: deletePartsError } = await supabase
+    .from("quartet_listing_parts")
+    .delete()
+    .eq("quartet_listing_id", listingId);
+
+  if (deletePartsError) {
+    redirectWithListingMessage("error", deletePartsError.message);
+  }
+
+  const partRows = [
+    ...values.partsCovered.map((part) => ({
+      part,
+      quartet_listing_id: listingId,
+      status: "covered",
+    })),
+    ...values.partsNeeded.map((part) => ({
+      part,
+      quartet_listing_id: listingId,
+      status: "needed",
+    })),
+  ];
+
+  if (partRows.length > 0) {
+    const { error: partsError } = await supabase
+      .from("quartet_listing_parts")
+      .insert(partRows);
+
+    if (partsError) {
+      redirectWithListingMessage("error", partsError.message);
+    }
+  }
+
+  revalidatePath("/app/listings");
+  redirectWithListingMessage("message", "Quartet listing saved.");
+}

--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -1,16 +1,359 @@
-export default function ManageListingsPage() {
+import {
+  BARBERSHOP_PARTS,
+  PROFILE_GOALS,
+  type BarbershopPart,
+  type ProfileGoal,
+} from "@/lib/profiles/singer-profile-form";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { saveQuartetListing } from "./actions";
+
+type QuartetListingRow = {
+  availability: string | null;
+  country_code: string | null;
+  country_name: string | null;
+  description: string | null;
+  experience_level: string | null;
+  goals: ProfileGoal[];
+  id: string;
+  is_visible: boolean;
+  locality: string | null;
+  location_label_public: string | null;
+  name: string;
+  postal_code_private: string | null;
+  region: string | null;
+  travel_radius_km: number | null;
+};
+
+type ManageListingsPageProps = {
+  searchParams: Promise<{
+    error?: string;
+    message?: string;
+  }>;
+};
+
+const partLabels: Record<BarbershopPart, string> = {
+  baritone: "Baritone",
+  bass: "Bass",
+  lead: "Lead",
+  tenor: "Tenor",
+};
+
+const goalLabels: Record<ProfileGoal, string> = {
+  casual: "Casual/social singing",
+  contest: "Contest quartet",
+  learning: "Learning/development",
+  paid_gigs: "Paid gigs",
+  pickup: "Pickup singing",
+  regular_rehearsal: "Regular rehearsing quartet",
+};
+
+function checked(value: string, values: readonly string[] | null | undefined) {
+  return values?.includes(value) ?? false;
+}
+
+function fieldValue(value: string | number | null | undefined) {
+  return value == null ? "" : String(value);
+}
+
+export default async function ManageListingsPage({
+  searchParams,
+}: ManageListingsPageProps) {
+  const params = await searchParams;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  const { data: listing } =
+    supabase && user
+      ? await supabase
+          .from("quartet_listings")
+          .select(
+            "id, availability, country_code, country_name, description, experience_level, goals, is_visible, locality, location_label_public, name, postal_code_private, region, travel_radius_km",
+          )
+          .eq("owner_user_id", user.id)
+          .order("created_at", { ascending: true })
+          .limit(1)
+          .maybeSingle<QuartetListingRow>()
+      : { data: null };
+
+  const { data: parts } =
+    supabase && listing
+      ? await supabase
+          .from("quartet_listing_parts")
+          .select("part, status")
+          .eq("quartet_listing_id", listing.id)
+      : { data: [] };
+
+  const partsCovered =
+    parts
+      ?.filter((partRow) => partRow.status === "covered")
+      .map((partRow) => partRow.part as BarbershopPart) ?? [];
+  const partsNeeded =
+    parts
+      ?.filter((partRow) => partRow.status === "needed")
+      .map((partRow) => partRow.part as BarbershopPart) ?? [];
+
   return (
     <div>
-      <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-        Quartet listings
-      </p>
-      <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-        Manage quartet listings
-      </h1>
-      <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
-        Quartet listing management will live here. Listings can stay private
-        until their owner makes them visible for discovery.
-      </p>
+      <div className="max-w-3xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Quartet listings
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          Manage quartet listing
+        </h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          Create the listing that tells singers which parts are covered, which
+          parts are needed, and what kind of quartet you are building. Keep the
+          public location approximate.
+        </p>
+      </div>
+
+      {params.error ? (
+        <p className="mt-8 max-w-3xl rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {params.error}
+        </p>
+      ) : null}
+
+      {params.message ? (
+        <p className="mt-8 max-w-3xl rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+          {params.message}
+        </p>
+      ) : null}
+
+      <form action={saveQuartetListing} className="mt-8 max-w-3xl space-y-8">
+        <input name="listingId" type="hidden" value={fieldValue(listing?.id)} />
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Basics</h2>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Listing or quartet name
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(listing?.name)}
+              maxLength={160}
+              name="name"
+              required
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Short description
+            </span>
+            <textarea
+              className="mt-2 min-h-28 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(listing?.description)}
+              maxLength={2400}
+              name="description"
+            />
+          </label>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Parts</h2>
+          <div className="grid gap-6 sm:grid-cols-2">
+            <fieldset className="space-y-3">
+              <legend className="text-sm font-semibold text-[#172023]">
+                Currently covered
+              </legend>
+              {BARBERSHOP_PARTS.map((part) => (
+                <label
+                  className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                  key={part}
+                >
+                  <input
+                    defaultChecked={checked(part, partsCovered)}
+                    name="partsCovered"
+                    type="checkbox"
+                    value={part}
+                  />
+                  <span className="font-semibold">{partLabels[part]}</span>
+                </label>
+              ))}
+            </fieldset>
+            <fieldset className="space-y-3">
+              <legend className="text-sm font-semibold text-[#172023]">
+                Needed
+              </legend>
+              {BARBERSHOP_PARTS.map((part) => (
+                <label
+                  className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                  key={part}
+                >
+                  <input
+                    defaultChecked={checked(part, partsNeeded)}
+                    name="partsNeeded"
+                    type="checkbox"
+                    value={part}
+                  />
+                  <span className="font-semibold">{partLabels[part]}</span>
+                </label>
+              ))}
+            </fieldset>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Location</h2>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Public approximate location
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(listing?.location_label_public)}
+              maxLength={160}
+              name="locationLabelPublic"
+              placeholder="Toronto, ON area"
+            />
+          </label>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Locality/city
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.locality)}
+                maxLength={120}
+                name="locality"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Region/admin area
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.region)}
+                maxLength={120}
+                name="region"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Country name
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.country_name)}
+                maxLength={120}
+                name="countryName"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Country code
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base uppercase text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.country_code)}
+                maxLength={2}
+                name="countryCode"
+                placeholder="CA"
+              />
+            </label>
+          </div>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Postal code
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(listing?.postal_code_private)}
+              maxLength={40}
+              name="postalCodePrivate"
+            />
+          </label>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Quartet Fit</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {PROFILE_GOALS.map((goal) => (
+              <label
+                className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                key={goal}
+              >
+                <input
+                  defaultChecked={checked(goal, listing?.goals)}
+                  name="goals"
+                  type="checkbox"
+                  value={goal}
+                />
+                <span className="font-semibold">{goalLabels[goal]}</span>
+              </label>
+            ))}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Experience or commitment level
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.experience_level)}
+                maxLength={120}
+                name="experienceLevel"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Travel willingness in km
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.travel_radius_km)}
+                min={0}
+                name="travelRadiusKm"
+                type="number"
+              />
+            </label>
+          </div>
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Rehearsal expectations
+            </span>
+            <textarea
+              className="mt-2 min-h-24 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={fieldValue(listing?.availability)}
+              maxLength={500}
+              name="availability"
+            />
+          </label>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-[#172023]">Visibility</h2>
+          <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
+            <input
+              className="mt-1"
+              defaultChecked={listing?.is_visible ?? false}
+              name="isVisible"
+              type="checkbox"
+            />
+            <span>
+              <span className="block font-semibold text-[#172023]">
+                Show this quartet listing in discovery
+              </span>
+              <span className="mt-1 block text-sm leading-6 text-[#596466]">
+                Discovery views include the name, parts covered and needed,
+                goals, and approximate location only.
+              </span>
+            </span>
+          </label>
+        </section>
+
+        <button
+          className="rounded-md bg-[#174b4f] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          type="submit"
+        >
+          Save quartet listing
+        </button>
+      </form>
     </div>
   );
 }

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -91,6 +91,27 @@ be shown in public discovery results. The public discovery label should stay
 approximate, such as a city/region/country area. Location inputs remain globally
 tolerant and do not require US state, ZIP code, address, or phone formats.
 
+## Quartet listing management
+
+Signed-in users can manage a quartet listing from the protected app area. The
+MVP listing form stores:
+
+- listing or quartet name
+- parts currently covered
+- parts needed
+- goals
+- experience or commitment level
+- rehearsal expectations
+- travel willingness in kilometers
+- short description
+- public approximate location label
+- country, region, locality, and private postal code when provided
+- search visibility
+
+The listing form keeps covered and needed parts distinct so public discovery can
+clearly show what the quartet has and what it is seeking. Postal code remains
+private listing data and should not be shown in public listing discovery.
+
 ## Contact model
 
 Initial contact should be mediated by the app.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -51,6 +51,11 @@ A `quartet_listings` row belongs to the authenticated user identified by
 `owner_user_id`. Multi-owner quartet management is not part of the initial
 schema.
 
+Quartet listing edits are saved through the protected app route at
+`/app/listings`. The server action writes `owner_user_id = auth.uid()` and
+filters updates by both listing ID and owner ID, with RLS enforcing the same
+ownership boundary in the database.
+
 Users can read and update their own private base-table rows.
 
 Public discovery should use the discovery views, not the base tables.

--- a/lib/quartets/quartet-listing-form.ts
+++ b/lib/quartets/quartet-listing-form.ts
@@ -1,0 +1,130 @@
+import {
+  BARBERSHOP_PARTS,
+  PROFILE_GOALS,
+  normalizeCountryCode,
+  normalizeOptionalText,
+  parseTravelRadiusKm,
+  type BarbershopPart,
+  type ProfileGoal,
+} from "@/lib/profiles/singer-profile-form";
+
+export type QuartetListingFormValues = {
+  availability: string | null;
+  countryCode: string | null;
+  countryName: string | null;
+  description: string | null;
+  experienceLevel: string | null;
+  goals: ProfileGoal[];
+  isVisible: boolean;
+  listingId: string | null;
+  locality: string | null;
+  locationLabelPublic: string | null;
+  name: string;
+  partsCovered: BarbershopPart[];
+  partsNeeded: BarbershopPart[];
+  postalCodePrivate: string | null;
+  region: string | null;
+  travelRadiusKm: number | null;
+};
+
+function parseAllowedList<T extends string>(
+  values: FormDataEntryValue[],
+  allowedValues: readonly T[],
+) {
+  const allowed = new Set<string>(allowedValues);
+
+  return values
+    .filter((value): value is string => typeof value === "string")
+    .filter((value): value is T => allowed.has(value));
+}
+
+function removePartsAlreadyNeeded(
+  covered: BarbershopPart[],
+  needed: BarbershopPart[],
+) {
+  const neededParts = new Set(needed);
+
+  return covered.filter((part) => !neededParts.has(part));
+}
+
+export function parseQuartetListingFormData(
+  formData: FormData,
+): QuartetListingFormValues {
+  const name = normalizeOptionalText(formData.get("name"));
+
+  if (!name) {
+    throw new Error("Listing name is required.");
+  }
+
+  const partsNeeded = parseAllowedList(
+    formData.getAll("partsNeeded"),
+    BARBERSHOP_PARTS,
+  );
+  const partsCovered = removePartsAlreadyNeeded(
+    parseAllowedList(formData.getAll("partsCovered"), BARBERSHOP_PARTS),
+    partsNeeded,
+  );
+
+  return {
+    availability: normalizeOptionalText(formData.get("availability")),
+    countryCode: normalizeCountryCode(formData.get("countryCode")),
+    countryName: normalizeOptionalText(formData.get("countryName")),
+    description: normalizeOptionalText(formData.get("description")),
+    experienceLevel: normalizeOptionalText(formData.get("experienceLevel")),
+    goals: parseAllowedList(formData.getAll("goals"), PROFILE_GOALS),
+    isVisible: formData.get("isVisible") === "on",
+    listingId: normalizeOptionalText(formData.get("listingId")),
+    locality: normalizeOptionalText(formData.get("locality")),
+    locationLabelPublic: normalizeOptionalText(
+      formData.get("locationLabelPublic"),
+    ),
+    name,
+    partsCovered,
+    partsNeeded,
+    postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
+    region: normalizeOptionalText(formData.get("region")),
+    travelRadiusKm: parseTravelRadiusKm(formData.get("travelRadiusKm")),
+  };
+}
+
+export function inferQuartetLocationPrecision(
+  values: Pick<
+    QuartetListingFormValues,
+    "countryCode" | "countryName" | "locality" | "postalCodePrivate" | "region"
+  >,
+) {
+  if (values.postalCodePrivate) {
+    return "postal_code";
+  }
+
+  if (values.locality) {
+    return "locality";
+  }
+
+  if (values.region) {
+    return "region";
+  }
+
+  if (values.countryCode || values.countryName) {
+    return "country";
+  }
+
+  return "unknown";
+}
+
+export function buildQuartetPublicLocationLabel(
+  values: Pick<
+    QuartetListingFormValues,
+    "countryName" | "locality" | "locationLabelPublic" | "region"
+  >,
+) {
+  if (values.locationLabelPublic) {
+    return values.locationLabelPublic;
+  }
+
+  const locationParts = [values.locality, values.region, values.countryName]
+    .filter(Boolean)
+    .join(", ");
+
+  return locationParts ? `${locationParts} area` : null;
+}

--- a/test/quartet-listing-form.test.ts
+++ b/test/quartet-listing-form.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildQuartetPublicLocationLabel,
+  inferQuartetLocationPrecision,
+  parseQuartetListingFormData,
+} from "@/lib/quartets/quartet-listing-form";
+
+function formData(entries: Array<[string, string]>) {
+  const data = new FormData();
+
+  for (const [key, value] of entries) {
+    data.append(key, value);
+  }
+
+  return data;
+}
+
+describe("quartet listing form parsing", () => {
+  it("accepts globally tolerant location fields without US-only requirements", () => {
+    const values = parseQuartetListingFormData(
+      formData([
+        ["name", "Harbour Lights"],
+        ["countryCode", "ca"],
+        ["countryName", "Canada"],
+        ["region", "Ontario"],
+        ["locality", "Toronto"],
+        ["postalCodePrivate", "M5V"],
+        ["partsCovered", "lead"],
+        ["partsCovered", "bass"],
+        ["partsNeeded", "tenor"],
+        ["goals", "regular_rehearsal"],
+        ["travelRadiusKm", "75"],
+      ]),
+    );
+
+    expect(values.countryCode).toBe("CA");
+    expect(values.postalCodePrivate).toBe("M5V");
+    expect(values.partsCovered).toEqual(["lead", "bass"]);
+    expect(values.partsNeeded).toEqual(["tenor"]);
+    expect(values.goals).toEqual(["regular_rehearsal"]);
+    expect(values.travelRadiusKm).toBe(75);
+  });
+
+  it("keeps needed parts distinct from covered parts", () => {
+    const values = parseQuartetListingFormData(
+      formData([
+        ["name", "Chord Project"],
+        ["partsCovered", "lead"],
+        ["partsCovered", "bass"],
+        ["partsNeeded", "lead"],
+        ["partsNeeded", "baritone"],
+      ]),
+    );
+
+    expect(values.partsCovered).toEqual(["bass"]);
+    expect(values.partsNeeded).toEqual(["lead", "baritone"]);
+  });
+
+  it("builds an approximate public location without postal code", () => {
+    const values = parseQuartetListingFormData(
+      formData([
+        ["name", "Afterglow Four"],
+        ["countryName", "Australia"],
+        ["region", "Victoria"],
+        ["locality", "Melbourne"],
+        ["postalCodePrivate", "3000"],
+      ]),
+    );
+
+    expect(buildQuartetPublicLocationLabel(values)).toBe(
+      "Melbourne, Victoria, Australia area",
+    );
+    expect(buildQuartetPublicLocationLabel(values)).not.toContain("3000");
+    expect(inferQuartetLocationPrecision(values)).toBe("postal_code");
+  });
+
+  it("requires a listing name", () => {
+    expect(() => parseQuartetListingFormData(formData([]))).toThrow(
+      "Listing name is required.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the quartet listing placeholder with a protected create/edit form for MVP listing fields.
- Adds a server action that creates or updates the signed-in user's listing, filters updates by owner, replaces covered/needed parts, and relies on Supabase RLS for ownership enforcement.
- Adds quartet listing form helpers for global location fields, private postal code, visibility, goals, travel radius, and distinct covered vs needed parts.
- Updates privacy and Supabase docs for quartet listing management behavior.
- Adds tests for non-US location parsing, covered/needed part separation, approximate public labels, and required listing names.

Closes #6.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --cached --check`

## Notes

- Full browser create/edit/save verification requires configured Supabase project environment values and an authenticated session. This local environment does not include those credentials.
- I started a production server for a smoke test, but the local permission reviewer timed out on the curl requests. The server was stopped and port 3000 is clear.