### PR TITLE
[codex] Build privacy-safe discovery search views

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,15 +23,21 @@ export default function Home() {
         <div className="mt-8 flex flex-wrap gap-3">
           <Link
             className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
-            href="/sign-in"
+            href="/singers"
           >
-            Sign in
+            Find singers
           </Link>
           <Link
             className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/app"
+            href="/quartets"
           >
-            Manage profile
+            Find quartets
+          </Link>
+          <Link
+            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+            href="/sign-in"
+          >
+            Sign in
           </Link>
         </div>
       </section>

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,0 +1,306 @@
+import Link from "next/link";
+import {
+  approximateLocationLabel,
+  parseDiscoveryFilters,
+  travelRadiusLabel,
+} from "@/lib/search/discovery-filters";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type QuartetDiscoveryRow = {
+  availability: string | null;
+  country_name: string | null;
+  description: string | null;
+  experience_level: string | null;
+  goals: string[];
+  id: string;
+  locality: string | null;
+  location_label_public: string | null;
+  name: string;
+  parts_covered: string[];
+  parts_needed: string[];
+  preferred_distance_unit: "km" | "mi";
+  region: string | null;
+  travel_radius_km: number | null;
+};
+
+type SearchPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const partOptions = [
+  ["", "Any needed part"],
+  ["tenor", "Tenor"],
+  ["lead", "Lead"],
+  ["baritone", "Baritone"],
+  ["bass", "Bass"],
+];
+
+const goalOptions = [
+  ["", "Any goal"],
+  ["casual", "Casual/social"],
+  ["pickup", "Pickup singing"],
+  ["regular_rehearsal", "Regular rehearsing"],
+  ["contest", "Contest"],
+  ["paid_gigs", "Paid gigs"],
+  ["learning", "Learning"],
+];
+
+function textValue(value: string | null) {
+  return value ?? "";
+}
+
+function tags(values: string[]) {
+  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+export default async function QuartetSearchPage({
+  searchParams,
+}: SearchPageProps) {
+  const params = await searchParams;
+  const filters = parseDiscoveryFilters(params);
+  const supabase = await createSupabaseServerClient();
+
+  let quartets: QuartetDiscoveryRow[] = [];
+  let errorMessage: string | null = null;
+
+  if (!supabase) {
+    errorMessage = "Supabase is not configured for discovery search yet.";
+  } else {
+    let query = supabase
+      .from("quartet_discovery_listings")
+      .select(
+        "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, preferred_distance_unit, country_name, region, locality, location_label_public",
+      )
+      .order("updated_at", { ascending: false });
+
+    if (filters.country) {
+      query = query.ilike("country_name", `%${filters.country}%`);
+    }
+
+    if (filters.region) {
+      query = query.ilike("region", `%${filters.region}%`);
+    }
+
+    if (filters.locality) {
+      query = query.ilike("locality", `%${filters.locality}%`);
+    }
+
+    if (filters.part) {
+      query = query.contains("parts_needed", [filters.part]);
+    }
+
+    if (filters.goal) {
+      query = query.contains("goals", [filters.goal]);
+    }
+
+    if (filters.experience) {
+      query = query.ilike("experience_level", `%${filters.experience}%`);
+    }
+
+    if (filters.availability) {
+      query = query.ilike("availability", `%${filters.availability}%`);
+    }
+
+    if (filters.travelRadiusKm != null) {
+      query = query.gte("travel_radius_km", filters.travelRadiusKm);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      errorMessage = error.message;
+    } else {
+      quartets = (data ?? []) as QuartetDiscoveryRow[];
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-6xl px-6 py-12">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
+            Quartet Member Finder
+          </Link>
+          <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+            Find quartets
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
+            Search visible quartet listings using privacy-safe discovery data.
+            Results show approximate location only.
+          </p>
+        </div>
+        <Link className="font-semibold text-[#2f6f73]" href="/singers">
+          Find singers
+        </Link>
+      </div>
+
+      <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
+        <label className="block">
+          <span className="text-sm font-semibold">Country</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.country)}
+            name="country"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Region</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.region)}
+            name="region"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Locality</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.locality)}
+            name="locality"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Needed part</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.part)}
+            name="part"
+          >
+            {partOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Goal</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.goal)}
+            name="goal"
+          >
+            {goalOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Commitment</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.experience)}
+            name="experience"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Rehearsal</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.availability)}
+            name="availability"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Travel km</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(
+              filters.travelRadiusKm == null
+                ? null
+                : String(filters.travelRadiusKm),
+            )}
+            min={0}
+            name="travelRadiusKm"
+            type="number"
+          />
+        </label>
+        <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
+          <button
+            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+            type="submit"
+          >
+            Search
+          </button>
+          <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+            Clear
+          </Link>
+        </div>
+      </form>
+
+      {errorMessage ? (
+        <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <section className="mt-8 grid gap-4">
+        {quartets.length === 0 && !errorMessage ? (
+          <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+            No visible quartet listings match these filters yet.
+          </p>
+        ) : null}
+
+        {quartets.map((quartet) => (
+          <article
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+            key={quartet.id}
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-xl font-bold text-[#172023]">
+                  {quartet.name}
+                </h2>
+                <p className="mt-1 text-sm text-[#596466]">
+                  {approximateLocationLabel(quartet)}
+                </p>
+              </div>
+              <p className="text-sm font-semibold text-[#2f6f73]">
+                Seeking {tags(quartet.parts_needed)}
+              </p>
+            </div>
+            {quartet.description ? (
+              <p className="mt-4 text-sm leading-6 text-[#394548]">
+                {quartet.description}
+              </p>
+            ) : null}
+            <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">
+              {quartet.parts_covered.length > 0 ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Covered</dt>
+                  <dd>{tags(quartet.parts_covered)}</dd>
+                </div>
+              ) : null}
+              {quartet.goals.length > 0 ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Goals</dt>
+                  <dd>{tags(quartet.goals)}</dd>
+                </div>
+              ) : null}
+              {quartet.experience_level ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Commitment</dt>
+                  <dd>{quartet.experience_level}</dd>
+                </div>
+              ) : null}
+              {quartet.availability ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Rehearsal</dt>
+                  <dd>{quartet.availability}</dd>
+                </div>
+              ) : null}
+              {travelRadiusLabel(quartet.travel_radius_km) ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Travel</dt>
+                  <dd>{travelRadiusLabel(quartet.travel_radius_km)}</dd>
+                </div>
+              ) : null}
+            </dl>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,0 +1,293 @@
+import Link from "next/link";
+import {
+  approximateLocationLabel,
+  parseDiscoveryFilters,
+  travelRadiusLabel,
+} from "@/lib/search/discovery-filters";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type SingerDiscoveryRow = {
+  availability: string | null;
+  country_name: string | null;
+  display_name: string;
+  experience_level: string | null;
+  goals: string[];
+  id: string;
+  locality: string | null;
+  location_label_public: string | null;
+  parts: string[];
+  preferred_distance_unit: "km" | "mi";
+  region: string | null;
+  travel_radius_km: number | null;
+};
+
+type SearchPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const partOptions = [
+  ["", "Any part"],
+  ["tenor", "Tenor"],
+  ["lead", "Lead"],
+  ["baritone", "Baritone"],
+  ["bass", "Bass"],
+];
+
+const goalOptions = [
+  ["", "Any goal"],
+  ["casual", "Casual/social"],
+  ["pickup", "Pickup singing"],
+  ["regular_rehearsal", "Regular rehearsing"],
+  ["contest", "Contest"],
+  ["paid_gigs", "Paid gigs"],
+  ["learning", "Learning"],
+];
+
+function textValue(value: string | null) {
+  return value ?? "";
+}
+
+function tags(values: string[]) {
+  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+export default async function SingerSearchPage({
+  searchParams,
+}: SearchPageProps) {
+  const params = await searchParams;
+  const filters = parseDiscoveryFilters(params);
+  const supabase = await createSupabaseServerClient();
+
+  let singers: SingerDiscoveryRow[] = [];
+  let errorMessage: string | null = null;
+
+  if (!supabase) {
+    errorMessage = "Supabase is not configured for discovery search yet.";
+  } else {
+    let query = supabase
+      .from("singer_discovery_profiles")
+      .select(
+        "id, display_name, parts, goals, experience_level, availability, travel_radius_km, preferred_distance_unit, country_name, region, locality, location_label_public",
+      )
+      .order("updated_at", { ascending: false });
+
+    if (filters.country) {
+      query = query.ilike("country_name", `%${filters.country}%`);
+    }
+
+    if (filters.region) {
+      query = query.ilike("region", `%${filters.region}%`);
+    }
+
+    if (filters.locality) {
+      query = query.ilike("locality", `%${filters.locality}%`);
+    }
+
+    if (filters.part) {
+      query = query.contains("parts", [filters.part]);
+    }
+
+    if (filters.goal) {
+      query = query.contains("goals", [filters.goal]);
+    }
+
+    if (filters.experience) {
+      query = query.ilike("experience_level", `%${filters.experience}%`);
+    }
+
+    if (filters.availability) {
+      query = query.ilike("availability", `%${filters.availability}%`);
+    }
+
+    if (filters.travelRadiusKm != null) {
+      query = query.gte("travel_radius_km", filters.travelRadiusKm);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      errorMessage = error.message;
+    } else {
+      singers = (data ?? []) as SingerDiscoveryRow[];
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-6xl px-6 py-12">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
+            Quartet Member Finder
+          </Link>
+          <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+            Find singers
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
+            Search visible singer profiles using privacy-safe discovery data.
+            Results show approximate location only.
+          </p>
+        </div>
+        <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+          Find quartets
+        </Link>
+      </div>
+
+      <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
+        <label className="block">
+          <span className="text-sm font-semibold">Country</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.country)}
+            name="country"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Region</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.region)}
+            name="region"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Locality</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.locality)}
+            name="locality"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Part</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.part)}
+            name="part"
+          >
+            {partOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Goal</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.goal)}
+            name="goal"
+          >
+            {goalOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Experience</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.experience)}
+            name="experience"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Availability</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.availability)}
+            name="availability"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Travel km</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(
+              filters.travelRadiusKm == null
+                ? null
+                : String(filters.travelRadiusKm),
+            )}
+            min={0}
+            name="travelRadiusKm"
+            type="number"
+          />
+        </label>
+        <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
+          <button
+            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+            type="submit"
+          >
+            Search
+          </button>
+          <Link className="font-semibold text-[#2f6f73]" href="/singers">
+            Clear
+          </Link>
+        </div>
+      </form>
+
+      {errorMessage ? (
+        <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <section className="mt-8 grid gap-4">
+        {singers.length === 0 && !errorMessage ? (
+          <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+            No visible singer profiles match these filters yet.
+          </p>
+        ) : null}
+
+        {singers.map((singer) => (
+          <article
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+            key={singer.id}
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-xl font-bold text-[#172023]">
+                  {singer.display_name}
+                </h2>
+                <p className="mt-1 text-sm text-[#596466]">
+                  {approximateLocationLabel(singer)}
+                </p>
+              </div>
+              <p className="text-sm font-semibold text-[#2f6f73]">
+                {tags(singer.parts)}
+              </p>
+            </div>
+            <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">
+              {singer.goals.length > 0 ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Goals</dt>
+                  <dd>{tags(singer.goals)}</dd>
+                </div>
+              ) : null}
+              {singer.experience_level ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Experience</dt>
+                  <dd>{singer.experience_level}</dd>
+                </div>
+              ) : null}
+              {singer.availability ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Availability</dt>
+                  <dd>{singer.availability}</dd>
+                </div>
+              ) : null}
+              {travelRadiusLabel(singer.travel_radius_km) ? (
+                <div>
+                  <dt className="font-semibold text-[#172023]">Travel</dt>
+                  <dd>{travelRadiusLabel(singer.travel_radius_km)}</dd>
+                </div>
+              ) : null}
+            </dl>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -24,6 +24,13 @@ Public search results must not show:
 - unlisted profile/listing data
 - inactive or hidden profiles/listings
 
+Public singer and quartet discovery pages must query privacy-safe discovery
+views rather than private base tables. Filters may use public country, region,
+locality, part, goal, experience/commitment, availability, and travel
+willingness fields where data exists. Exact coordinates, private postal codes,
+formatted private addresses, email addresses, and phone numbers are not part of
+the public result shape.
+
 ## Global location expectations
 
 Barbershop is global. The app should not assume that all users are in the United States.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -60,6 +60,15 @@ Users can read and update their own private base-table rows.
 
 Public discovery should use the discovery views, not the base tables.
 
+The public discovery routes are:
+
+- `/singers`, backed by `singer_discovery_profiles`
+- `/quartets`, backed by `quartet_discovery_listings`
+
+These routes may filter on public location fields, part, goals,
+experience/commitment, availability, and travel willingness. They should not
+read private base-table location or contact fields.
+
 ## Row Level Security expectations
 
 RLS should enforce:

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -1,0 +1,100 @@
+import {
+  BARBERSHOP_PARTS,
+  PROFILE_GOALS,
+  type BarbershopPart,
+  type ProfileGoal,
+} from "@/lib/profiles/singer-profile-form";
+
+export type DiscoveryFilters = {
+  availability: string | null;
+  country: string | null;
+  experience: string | null;
+  goal: ProfileGoal | null;
+  locality: string | null;
+  part: BarbershopPart | null;
+  region: string | null;
+  travelRadiusKm: number | null;
+};
+
+export type LocationSummary = {
+  country_name: string | null;
+  locality: string | null;
+  location_label_public: string | null;
+  region: string | null;
+};
+
+function normalizeSearchText(value: string | string[] | undefined) {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+  const normalized = rawValue?.trim();
+
+  return normalized ? normalized : null;
+}
+
+function parseAllowedValue<T extends string>(
+  value: string | string[] | undefined,
+  allowedValues: readonly T[],
+) {
+  const normalized = normalizeSearchText(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  return allowedValues.includes(normalized as T) ? (normalized as T) : null;
+}
+
+function parseTravelRadiusKm(value: string | string[] | undefined) {
+  const normalized = normalizeSearchText(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const radius = Number(normalized);
+
+  if (!Number.isInteger(radius) || radius < 0 || radius > 10000) {
+    return null;
+  }
+
+  return radius;
+}
+
+export function parseDiscoveryFilters(
+  searchParams: Record<string, string | string[] | undefined>,
+): DiscoveryFilters {
+  return {
+    availability: normalizeSearchText(searchParams.availability),
+    country: normalizeSearchText(searchParams.country),
+    experience: normalizeSearchText(searchParams.experience),
+    goal: parseAllowedValue(searchParams.goal, PROFILE_GOALS),
+    locality: normalizeSearchText(searchParams.locality),
+    part: parseAllowedValue(searchParams.part, BARBERSHOP_PARTS),
+    region: normalizeSearchText(searchParams.region),
+    travelRadiusKm: parseTravelRadiusKm(searchParams.travelRadiusKm),
+  };
+}
+
+export function hasDiscoveryFilters(filters: DiscoveryFilters) {
+  return Object.values(filters).some((value) => value !== null);
+}
+
+export function approximateLocationLabel(location: LocationSummary) {
+  if (location.location_label_public) {
+    return location.location_label_public;
+  }
+
+  const parts = [location.locality, location.region, location.country_name]
+    .filter(Boolean)
+    .join(", ");
+
+  return parts ? `${parts} area` : "Location not shared";
+}
+
+export function travelRadiusLabel(radiusKm: number | null) {
+  if (radiusKm == null) {
+    return null;
+  }
+
+  const miles = Math.round(radiusKm * 0.621371);
+  return `${radiusKm} km / ${miles} mi`;
+}

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  approximateLocationLabel,
+  hasDiscoveryFilters,
+  parseDiscoveryFilters,
+  travelRadiusLabel,
+} from "@/lib/search/discovery-filters";
+
+describe("discovery filters", () => {
+  it("parses allowed part and goal filters", () => {
+    const filters = parseDiscoveryFilters({
+      goal: "contest",
+      part: "lead",
+      travelRadiusKm: "50",
+    });
+
+    expect(filters.goal).toBe("contest");
+    expect(filters.part).toBe("lead");
+    expect(filters.travelRadiusKm).toBe(50);
+    expect(hasDiscoveryFilters(filters)).toBe(true);
+  });
+
+  it("ignores unexpected enum filters and invalid travel radius", () => {
+    const filters = parseDiscoveryFilters({
+      goal: "viral",
+      part: "melody",
+      travelRadiusKm: "-10",
+    });
+
+    expect(filters.goal).toBeNull();
+    expect(filters.part).toBeNull();
+    expect(filters.travelRadiusKm).toBeNull();
+    expect(hasDiscoveryFilters(filters)).toBe(false);
+  });
+
+  it("builds an approximate location label without private fields", () => {
+    expect(
+      approximateLocationLabel({
+        country_name: "Ireland",
+        locality: "Dublin",
+        location_label_public: null,
+        region: "Leinster",
+      }),
+    ).toBe("Dublin, Leinster, Ireland area");
+  });
+
+  it("shows both kilometers and miles for travel willingness", () => {
+    expect(travelRadiusLabel(100)).toBe("100 km / 62 mi");
+    expect(travelRadiusLabel(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds public `/singers` and `/quartets` discovery pages backed by Supabase privacy-safe discovery views.
- Adds filters for public country/region/locality, part sung or needed, goals, experience/commitment, availability/rehearsal, and travel willingness.
- Keeps public results limited to approximate location and other discovery-safe fields; no base tables or private fields are queried.
- Adds shared discovery filter helpers and tests for allowed filters, invalid filter handling, approximate location labels, and km/mi travel display.
- Updates privacy and Supabase docs for search behavior and discovery-view usage.

Closes #7.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --cached --check`
- Production server smoke test returned HTTP 200 for `/`, `/singers`, and `/quartets?part=lead&country=Canada`.

## Notes
- Full data-result verification requires configured Supabase project env values and visible discovery rows. This local environment does not include those credentials/data.