### PR TITLE
[codex] Add approximate location helpers

### DIFF
--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import {
   approximateLocationLabel,
-  parseDiscoveryFilters,
+  toPublicLocationSummary,
   travelRadiusLabel,
-} from "@/lib/search/discovery-filters";
+} from "@/lib/location/approximate-location";
+import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type QuartetDiscoveryRow = {
@@ -254,7 +255,14 @@ export default async function QuartetSearchPage({
                   {quartet.name}
                 </h2>
                 <p className="mt-1 text-sm text-[#596466]">
-                  {approximateLocationLabel(quartet)}
+                  {approximateLocationLabel(
+                    toPublicLocationSummary({
+                      countryName: quartet.country_name,
+                      locality: quartet.locality,
+                      locationLabelPublic: quartet.location_label_public,
+                      region: quartet.region,
+                    }),
+                  )}
                 </p>
               </div>
               <p className="text-sm font-semibold text-[#2f6f73]">
@@ -291,10 +299,18 @@ export default async function QuartetSearchPage({
                   <dd>{quartet.availability}</dd>
                 </div>
               ) : null}
-              {travelRadiusLabel(quartet.travel_radius_km) ? (
+              {travelRadiusLabel(
+                quartet.travel_radius_km,
+                quartet.preferred_distance_unit,
+              ) ? (
                 <div>
                   <dt className="font-semibold text-[#172023]">Travel</dt>
-                  <dd>{travelRadiusLabel(quartet.travel_radius_km)}</dd>
+                  <dd>
+                    {travelRadiusLabel(
+                      quartet.travel_radius_km,
+                      quartet.preferred_distance_unit,
+                    )}
+                  </dd>
                 </div>
               ) : null}
             </dl>

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import {
   approximateLocationLabel,
-  parseDiscoveryFilters,
+  toPublicLocationSummary,
   travelRadiusLabel,
-} from "@/lib/search/discovery-filters";
+} from "@/lib/location/approximate-location";
+import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type SingerDiscoveryRow = {
@@ -252,7 +253,14 @@ export default async function SingerSearchPage({
                   {singer.display_name}
                 </h2>
                 <p className="mt-1 text-sm text-[#596466]">
-                  {approximateLocationLabel(singer)}
+                  {approximateLocationLabel(
+                    toPublicLocationSummary({
+                      countryName: singer.country_name,
+                      locality: singer.locality,
+                      locationLabelPublic: singer.location_label_public,
+                      region: singer.region,
+                    }),
+                  )}
                 </p>
               </div>
               <p className="text-sm font-semibold text-[#2f6f73]">
@@ -278,10 +286,18 @@ export default async function SingerSearchPage({
                   <dd>{singer.availability}</dd>
                 </div>
               ) : null}
-              {travelRadiusLabel(singer.travel_radius_km) ? (
+              {travelRadiusLabel(
+                singer.travel_radius_km,
+                singer.preferred_distance_unit,
+              ) ? (
                 <div>
                   <dt className="font-semibold text-[#172023]">Travel</dt>
-                  <dd>{travelRadiusLabel(singer.travel_radius_km)}</dd>
+                  <dd>
+                    {travelRadiusLabel(
+                      singer.travel_radius_km,
+                      singer.preferred_distance_unit,
+                    )}
+                  </dd>
                 </div>
               ) : null}
             </dl>

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -54,6 +54,19 @@ Users may enter a city, postal code, country, or approximate location.
 
 The app may store normalized location data to support distance search, but public UI should only expose approximate location.
 
+Private geocoded data should be transformed into a public location summary
+before display. Public summaries may contain only a user-provided public label,
+locality, region, and country. They must not contain exact latitude, longitude,
+private postal code, formatted private address, or other precise address
+components. If an explicit public label is present, use it as the display label;
+otherwise build an approximate label from locality, region, and country, such as
+“Dublin, Leinster, Ireland area.”
+
+Distance helpers may use exact coordinates internally for matching, but public
+distance display should be rounded and approximate, such as “about 15 mi / 24 km
+away.” Travel willingness and distance display should support both kilometers
+and miles without assuming a US-only default.
+
 Acceptable user-facing examples:
 
 - “Fort Collins, CO area”

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -130,6 +130,13 @@ Current pattern:
 - Return approximate distance/region rather than exact coordinates for public discovery.
 - Support both miles and kilometers in UI/helper logic where practical.
 
+Application location helpers should treat base-table coordinates and private
+postal/address fields as internal matching data. The reusable public
+transformation returns only `location_label_public`, `locality`, `region`, and
+`country_name` equivalents for display. Public distance strings are rounded and
+formatted in both kilometers and miles, ordered by the user/listing preferred
+distance unit where that field is available.
+
 Both singer profiles and quartet listings support these globally tolerant
 location fields:
 

--- a/lib/location/approximate-location.ts
+++ b/lib/location/approximate-location.ts
@@ -1,0 +1,135 @@
+export type DistanceUnit = "km" | "mi";
+
+export type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+export type PrivateLocationInput = {
+  countryName?: string | null;
+  locality?: string | null;
+  locationLabelPublic?: string | null;
+  region?: string | null;
+};
+
+export type PublicLocationSummary = {
+  countryName: string | null;
+  locality: string | null;
+  locationLabelPublic: string | null;
+  region: string | null;
+};
+
+const EARTH_RADIUS_KM = 6371.0088;
+const KM_PER_MILE = 1.609344;
+const MILES_PER_KM = 0.621371;
+
+function trimToNull(value: string | null | undefined) {
+  const trimmed = value?.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+function toRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}
+
+function isValidCoordinate({ latitude, longitude }: Coordinates) {
+  return (
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude) &&
+    latitude >= -90 &&
+    latitude <= 90 &&
+    longitude >= -180 &&
+    longitude <= 180
+  );
+}
+
+export function kilometersToMiles(kilometers: number) {
+  return kilometers * MILES_PER_KM;
+}
+
+export function milesToKilometers(miles: number) {
+  return miles * KM_PER_MILE;
+}
+
+export function distanceBetweenCoordinatesKm(
+  origin: Coordinates,
+  destination: Coordinates,
+) {
+  if (!isValidCoordinate(origin) || !isValidCoordinate(destination)) {
+    return null;
+  }
+
+  const latitudeDelta = toRadians(destination.latitude - origin.latitude);
+  const longitudeDelta = toRadians(destination.longitude - origin.longitude);
+  const originLatitude = toRadians(origin.latitude);
+  const destinationLatitude = toRadians(destination.latitude);
+
+  const haversine =
+    Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(originLatitude) *
+      Math.cos(destinationLatitude) *
+      Math.sin(longitudeDelta / 2) ** 2;
+
+  const centralAngle =
+    2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+
+  return EARTH_RADIUS_KM * centralAngle;
+}
+
+export function formatDistance(
+  distanceKm: number | null,
+  preferredUnit: DistanceUnit = "km",
+) {
+  if (distanceKm == null || !Number.isFinite(distanceKm) || distanceKm < 0) {
+    return null;
+  }
+
+  const roundedKm = Math.round(distanceKm);
+  const roundedMiles = Math.round(kilometersToMiles(distanceKm));
+
+  if (preferredUnit === "mi") {
+    return `${roundedMiles} mi / ${roundedKm} km`;
+  }
+
+  return `${roundedKm} km / ${roundedMiles} mi`;
+}
+
+export function formatApproximateDistance(
+  distanceKm: number | null,
+  preferredUnit: DistanceUnit = "km",
+) {
+  const formattedDistance = formatDistance(distanceKm, preferredUnit);
+
+  return formattedDistance ? `about ${formattedDistance} away` : null;
+}
+
+export function travelRadiusLabel(
+  radiusKm: number | null,
+  preferredUnit: DistanceUnit = "km",
+) {
+  return formatDistance(radiusKm, preferredUnit);
+}
+
+export function toPublicLocationSummary(
+  location: PrivateLocationInput,
+): PublicLocationSummary {
+  return {
+    countryName: trimToNull(location.countryName),
+    locality: trimToNull(location.locality),
+    locationLabelPublic: trimToNull(location.locationLabelPublic),
+    region: trimToNull(location.region),
+  };
+}
+
+export function approximateLocationLabel(location: PublicLocationSummary) {
+  if (location.locationLabelPublic) {
+    return location.locationLabelPublic;
+  }
+
+  const parts = [location.locality, location.region, location.countryName]
+    .filter(Boolean)
+    .join(", ");
+
+  return parts ? `${parts} area` : "Location not shared";
+}

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -16,13 +16,6 @@ export type DiscoveryFilters = {
   travelRadiusKm: number | null;
 };
 
-export type LocationSummary = {
-  country_name: string | null;
-  locality: string | null;
-  location_label_public: string | null;
-  region: string | null;
-};
-
 function normalizeSearchText(value: string | string[] | undefined) {
   const rawValue = Array.isArray(value) ? value[0] : value;
   const normalized = rawValue?.trim();
@@ -76,25 +69,4 @@ export function parseDiscoveryFilters(
 
 export function hasDiscoveryFilters(filters: DiscoveryFilters) {
   return Object.values(filters).some((value) => value !== null);
-}
-
-export function approximateLocationLabel(location: LocationSummary) {
-  if (location.location_label_public) {
-    return location.location_label_public;
-  }
-
-  const parts = [location.locality, location.region, location.country_name]
-    .filter(Boolean)
-    .join(", ");
-
-  return parts ? `${parts} area` : "Location not shared";
-}
-
-export function travelRadiusLabel(radiusKm: number | null) {
-  if (radiusKm == null) {
-    return null;
-  }
-
-  const miles = Math.round(radiusKm * 0.621371);
-  return `${radiusKm} km / ${miles} mi`;
 }

--- a/test/approximate-location.test.ts
+++ b/test/approximate-location.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  approximateLocationLabel,
+  distanceBetweenCoordinatesKm,
+  formatApproximateDistance,
+  formatDistance,
+  milesToKilometers,
+  toPublicLocationSummary,
+  travelRadiusLabel,
+} from "@/lib/location/approximate-location";
+
+describe("approximate location helpers", () => {
+  it("builds a US approximate label without exact private data", () => {
+    const publicLocation = toPublicLocationSummary({
+      countryName: "United States",
+      locality: "Fort Collins",
+      locationLabelPublic: null,
+      region: "CO",
+    });
+
+    expect(approximateLocationLabel(publicLocation)).toBe(
+      "Fort Collins, CO, United States area",
+    );
+    expect(Object.keys(publicLocation)).not.toContain("latitude");
+    expect(Object.keys(publicLocation)).not.toContain("longitude");
+    expect(Object.keys(publicLocation)).not.toContain("postalCode");
+  });
+
+  it("uses provided public labels for non-US locations", () => {
+    const publicLocation = toPublicLocationSummary({
+      countryName: "United Kingdom",
+      locality: "Manchester",
+      locationLabelPublic: "Manchester, UK area",
+      region: "England",
+    });
+
+    expect(approximateLocationLabel(publicLocation)).toBe(
+      "Manchester, UK area",
+    );
+  });
+
+  it("falls back to globally tolerant locality, region, and country labels", () => {
+    expect(
+      approximateLocationLabel(
+        toPublicLocationSummary({
+          countryName: "Ireland",
+          locality: "Dublin",
+          locationLabelPublic: null,
+          region: "Leinster",
+        }),
+      ),
+    ).toBe("Dublin, Leinster, Ireland area");
+  });
+
+  it("calculates global great-circle distance in kilometers", () => {
+    const distanceKm = distanceBetweenCoordinatesKm(
+      { latitude: 40.5853, longitude: -105.0844 },
+      { latitude: 51.5074, longitude: -0.1278 },
+    );
+
+    expect(distanceKm).not.toBeNull();
+    expect(Math.round(distanceKm ?? 0)).toBeGreaterThan(7400);
+    expect(Math.round(distanceKm ?? 0)).toBeLessThan(7600);
+  });
+
+  it("does not calculate distance for invalid exact coordinates", () => {
+    expect(
+      distanceBetweenCoordinatesKm(
+        { latitude: 120, longitude: -105 },
+        { latitude: 51.5074, longitude: -0.1278 },
+      ),
+    ).toBeNull();
+  });
+
+  it("formats distance and travel radius in miles and kilometers", () => {
+    expect(formatDistance(100)).toBe("100 km / 62 mi");
+    expect(formatDistance(100, "mi")).toBe("62 mi / 100 km");
+    expect(formatApproximateDistance(24, "mi")).toBe(
+      "about 15 mi / 24 km away",
+    );
+    expect(travelRadiusLabel(milesToKilometers(50), "mi")).toBe(
+      "50 mi / 80 km",
+    );
+    expect(travelRadiusLabel(null)).toBeNull();
+  });
+});

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-  approximateLocationLabel,
   hasDiscoveryFilters,
   parseDiscoveryFilters,
-  travelRadiusLabel,
 } from "@/lib/search/discovery-filters";
 
 describe("discovery filters", () => {
@@ -31,21 +29,5 @@ describe("discovery filters", () => {
     expect(filters.part).toBeNull();
     expect(filters.travelRadiusKm).toBeNull();
     expect(hasDiscoveryFilters(filters)).toBe(false);
-  });
-
-  it("builds an approximate location label without private fields", () => {
-    expect(
-      approximateLocationLabel({
-        country_name: "Ireland",
-        locality: "Dublin",
-        location_label_public: null,
-        region: "Leinster",
-      }),
-    ).toBe("Dublin, Leinster, Ireland area");
-  });
-
-  it("shows both kilometers and miles for travel willingness", () => {
-    expect(travelRadiusLabel(100)).toBe("100 km / 62 mi");
-    expect(travelRadiusLabel(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Adds reusable `lib/location` helpers for public location summaries, approximate labels, distance calculation, and miles/kilometers display.
- Updates singer and quartet discovery pages to use the location helpers and honor each row's preferred distance unit.
- Keeps search filter parsing separate from privacy-sensitive location display logic.
- Adds unit tests for US and non-US labels, invalid coordinate handling, great-circle distance calculation, and km/mi formatting.
- Updates privacy and Supabase docs for transforming private geocoded data into public approximate summaries.

Closes #8.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --check`