### PR TITLE
[codex] Add privacy-safe discovery map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
+
+# Optional future map provider configuration. The current MVP map does not
+# require these values and must not expose private exact coordinates.
+NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE=
+NEXT_PUBLIC_MAP_ATTRIBUTION=
+NEXT_PUBLIC_MAP_STYLE_URL=

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,0 +1,381 @@
+import Link from "next/link";
+import {
+  buildDiscoveryMapMarkers,
+  type DiscoveryMapItem,
+} from "@/lib/location/map-markers";
+import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type SingerMapRow = {
+  country_code: string | null;
+  country_name: string | null;
+  display_name: string;
+  goals: string[];
+  id: string;
+  locality: string | null;
+  location_label_public: string | null;
+  parts: string[];
+  region: string | null;
+};
+
+type QuartetMapRow = {
+  country_code: string | null;
+  country_name: string | null;
+  goals: string[];
+  id: string;
+  locality: string | null;
+  location_label_public: string | null;
+  name: string;
+  parts_needed: string[];
+  region: string | null;
+};
+
+type MapPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const kindOptions = [
+  ["both", "Singers and quartets"],
+  ["singers", "Singers"],
+  ["quartets", "Quartets"],
+];
+
+const partOptions = [
+  ["", "Any part"],
+  ["tenor", "Tenor"],
+  ["lead", "Lead"],
+  ["baritone", "Baritone"],
+  ["bass", "Bass"],
+];
+
+const goalOptions = [
+  ["", "Any goal"],
+  ["casual", "Casual/social"],
+  ["pickup", "Pickup singing"],
+  ["regular_rehearsal", "Regular rehearsing"],
+  ["contest", "Contest"],
+  ["paid_gigs", "Paid gigs"],
+  ["learning", "Learning"],
+];
+
+function textValue(value: string | null) {
+  return value ?? "";
+}
+
+function selectedKind(value: string | string[] | undefined) {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+
+  return rawValue === "singers" || rawValue === "quartets" ? rawValue : "both";
+}
+
+function tags(values: string[]) {
+  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+function markerSummary(marker: { names: string[] }) {
+  const previewNames = marker.names.slice(0, 3).join(", ");
+  const remainingCount = marker.names.length - 3;
+
+  return remainingCount > 0
+    ? `${previewNames}, +${remainingCount} more`
+    : previewNames;
+}
+
+function markerKindLabel(marker: { count: number; kinds: string[] }) {
+  if (marker.kinds.includes("quartet") && marker.kinds.includes("singer")) {
+    return "listings";
+  }
+
+  if (marker.kinds[0] === "quartet") {
+    return marker.count === 1 ? "quartet listing" : "quartet listings";
+  }
+
+  return marker.count === 1 ? "singer profile" : "singer profiles";
+}
+
+export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
+  const params = await searchParams;
+  const filters = parseDiscoveryFilters(params);
+  const kind = selectedKind(params.kind);
+  const supabase = await createSupabaseServerClient();
+
+  let mapItems: DiscoveryMapItem[] = [];
+  let errorMessage: string | null = null;
+
+  if (!supabase) {
+    errorMessage = "Supabase is not configured for discovery map search yet.";
+  } else {
+    if (kind === "both" || kind === "singers") {
+      let query = supabase
+        .from("singer_discovery_profiles")
+        .select(
+          "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public",
+        )
+        .order("updated_at", { ascending: false });
+
+      if (filters.country) {
+        query = query.ilike("country_name", `%${filters.country}%`);
+      }
+
+      if (filters.region) {
+        query = query.ilike("region", `%${filters.region}%`);
+      }
+
+      if (filters.locality) {
+        query = query.ilike("locality", `%${filters.locality}%`);
+      }
+
+      if (filters.part) {
+        query = query.contains("parts", [filters.part]);
+      }
+
+      if (filters.goal) {
+        query = query.contains("goals", [filters.goal]);
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        errorMessage = error.message;
+      } else {
+        mapItems = [
+          ...mapItems,
+          ...((data ?? []) as SingerMapRow[]).map((singer) => ({
+            countryCode: singer.country_code,
+            countryName: singer.country_name,
+            id: singer.id,
+            kind: "singer" as const,
+            locality: singer.locality,
+            locationLabelPublic: singer.location_label_public,
+            name: singer.display_name,
+            parts: singer.parts,
+            region: singer.region,
+          })),
+        ];
+      }
+    }
+
+    if (!errorMessage && (kind === "both" || kind === "quartets")) {
+      let query = supabase
+        .from("quartet_discovery_listings")
+        .select(
+          "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public",
+        )
+        .order("updated_at", { ascending: false });
+
+      if (filters.country) {
+        query = query.ilike("country_name", `%${filters.country}%`);
+      }
+
+      if (filters.region) {
+        query = query.ilike("region", `%${filters.region}%`);
+      }
+
+      if (filters.locality) {
+        query = query.ilike("locality", `%${filters.locality}%`);
+      }
+
+      if (filters.part) {
+        query = query.contains("parts_needed", [filters.part]);
+      }
+
+      if (filters.goal) {
+        query = query.contains("goals", [filters.goal]);
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        errorMessage = error.message;
+      } else {
+        mapItems = [
+          ...mapItems,
+          ...((data ?? []) as QuartetMapRow[]).map((quartet) => ({
+            countryCode: quartet.country_code,
+            countryName: quartet.country_name,
+            id: quartet.id,
+            kind: "quartet" as const,
+            locality: quartet.locality,
+            locationLabelPublic: quartet.location_label_public,
+            name: quartet.name,
+            parts: quartet.parts_needed,
+            region: quartet.region,
+          })),
+        ];
+      }
+    }
+  }
+
+  const markers = buildDiscoveryMapMarkers(mapItems);
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-6xl px-6 py-12">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
+            Quartet Member Finder
+          </Link>
+          <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+            Discovery map
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
+            Explore visible singer and quartet availability by approximate
+            public region.
+          </p>
+        </div>
+        <div className="flex gap-4">
+          <Link className="font-semibold text-[#2f6f73]" href="/singers">
+            Find singers
+          </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+            Find quartets
+          </Link>
+        </div>
+      </div>
+
+      <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5">
+        <label className="block">
+          <span className="text-sm font-semibold">Show</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={kind}
+            name="kind"
+          >
+            {kindOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Country</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.country)}
+            name="country"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Region</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.region)}
+            name="region"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Locality</span>
+          <input
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.locality)}
+            name="locality"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Part</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.part)}
+            name="part"
+          >
+            {partOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-semibold">Goal</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+            defaultValue={textValue(filters.goal)}
+            name="goal"
+          >
+            {goalOptions.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-5">
+          <button
+            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+            type="submit"
+          >
+            Search
+          </button>
+          <Link className="font-semibold text-[#2f6f73]" href="/map">
+            Clear
+          </Link>
+        </div>
+      </form>
+
+      {errorMessage ? (
+        <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <section className="mt-8 overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]">
+        <div
+          aria-label="Privacy-safe discovery map"
+          className="relative min-h-[420px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)]"
+          role="img"
+        >
+          <div className="absolute inset-x-0 top-0 flex items-center justify-between bg-white/80 px-4 py-3 text-sm text-[#394548] backdrop-blur">
+            <span>{markers.length} approximate regions</span>
+            <span>{mapItems.length} visible listings with public location</span>
+          </div>
+
+          {markers.map((marker) => (
+            <div
+              className="absolute max-w-48 -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm"
+              key={marker.id}
+              style={{
+                left: `${marker.xPercent}%`,
+                top: `${marker.yPercent}%`,
+              }}
+            >
+              <p className="font-bold text-[#172023]">{marker.label}</p>
+              <p className="mt-1 text-[#394548]">
+                {marker.count} {markerKindLabel(marker)}
+              </p>
+              {marker.parts.length > 0 ? (
+                <p className="mt-1 text-[#596466]">{tags(marker.parts)}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-8 grid gap-4 md:grid-cols-2">
+        {markers.length === 0 && !errorMessage ? (
+          <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548] md:col-span-2">
+            No visible public locations match these filters yet.
+          </p>
+        ) : null}
+
+        {markers.map((marker) => (
+          <article
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+            key={marker.id}
+          >
+            <h2 className="text-xl font-bold text-[#172023]">{marker.label}</h2>
+            <p className="mt-2 text-sm text-[#394548]">
+              {marker.count} visible result{marker.count === 1 ? "" : "s"}:
+              {" " + markerSummary(marker)}
+            </p>
+            {marker.parts.length > 0 ? (
+              <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
+                {tags(marker.parts)}
+              </p>
+            ) : null}
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,6 +35,12 @@ export default function Home() {
           </Link>
           <Link
             className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+            href="/map"
+          >
+            View map
+          </Link>
+          <Link
+            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
             href="/sign-in"
           >
             Sign in

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -130,9 +130,14 @@ export default async function QuartetSearchPage({
             Results show approximate location only.
           </p>
         </div>
-        <Link className="font-semibold text-[#2f6f73]" href="/singers">
-          Find singers
-        </Link>
+        <div className="flex gap-4">
+          <Link className="font-semibold text-[#2f6f73]" href="/singers">
+            Find singers
+          </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/map">
+            View map
+          </Link>
+        </div>
       </div>
 
       <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -128,9 +128,14 @@ export default async function SingerSearchPage({
             Results show approximate location only.
           </p>
         </div>
-        <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-          Find quartets
-        </Link>
+        <div className="flex gap-4">
+          <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+            Find quartets
+          </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/map">
+            View map
+          </Link>
+        </div>
       </div>
 
       <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,6 +26,9 @@ Codex/local development path:
 - Vercel: web hosting, preview deployments, production deployment
 - Supabase: auth, database, Row Level Security
 - Resend: transactional email and contact relay notifications
+- Map provider: provider-agnostic MVP map now; MapLibre with
+  OpenStreetMap-compatible raster or vector tiles is the preferred future
+  provider approach when richer panning/zooming is needed
 - Namecheap: domain registrar for `quartetmemberfinder.org`
 
 ## Global location expectations
@@ -120,6 +123,26 @@ Preferred sender addresses should use the domain once DNS is configured, such as
 - `no-reply@quartetmemberfinder.org`
 - `messages@quartetmemberfinder.org`
 - `support@quartetmemberfinder.org`
+
+## Maps and geocoding
+
+The current public discovery map does not require a third-party map or geocoder
+environment variable. It uses public discovery-view location summaries and
+country/region anchors to render approximate regional markers.
+
+When interactive tiles or geocoding are added, use a provider-compatible
+MapLibre setup rather than sending exact home coordinates to the browser.
+Provider configuration should be optional and documented in `.env.example`.
+Expected future public configuration values are:
+
+- `NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE`
+- `NEXT_PUBLIC_MAP_ATTRIBUTION`
+- `NEXT_PUBLIC_MAP_STYLE_URL` when using a hosted vector style
+
+Geocoding provider secrets, if any, must be server-only. Browser-rendered map
+props should contain approximate public labels, regional anchors, rounded
+distances, or jittered/blurred marker positions, never exact private
+latitude/longitude or private address fields.
 
 ## Production readiness checklist
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -20,6 +20,9 @@ The current scaffold includes `.env.example` with safe placeholder keys:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
+- `NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE` optional future map tile template
+- `NEXT_PUBLIC_MAP_ATTRIBUTION` optional future map attribution
+- `NEXT_PUBLIC_MAP_STYLE_URL` optional future hosted map style
 
 Do not expose server-only values in browser code.
 
@@ -45,3 +48,10 @@ allow:
 
 For production, add the deployed app URL and `/auth/callback` URL in the
 Supabase dashboard before enabling sign-in links for users.
+
+## Maps
+
+The MVP discovery map does not require a map provider. Optional public map
+values are reserved for a future MapLibre/OpenStreetMap-compatible tile setup.
+Geocoding secrets, if later needed, should be server-only and must not use the
+`NEXT_PUBLIC_` prefix.

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -82,6 +82,13 @@ Avoid exact map pins. Map interfaces should use one of the following:
 - region/city-level markers
 - search-result areas rather than exact addresses
 
+The MVP discovery map uses region-level markers derived from public discovery
+view fields only: public location label, locality, region, country, and country
+code. It must not receive base-table coordinates, private postal codes, or
+formatted private addresses in browser-rendered props. Marker placement may use
+country/region anchors and deterministic offsets so nearby results can cluster
+without implying a home address or exact rehearsal location.
+
 ## Visibility controls
 
 Users must be able to control whether their singer profile appears in search.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -64,6 +64,7 @@ The public discovery routes are:
 
 - `/singers`, backed by `singer_discovery_profiles`
 - `/quartets`, backed by `quartet_discovery_listings`
+- `/map`, backed by both discovery views
 
 These routes may filter on public location fields, part, goals,
 experience/commitment, availability, and travel willingness. They should not
@@ -155,6 +156,10 @@ location fields:
 The public discovery views expose country, region, locality, public location
 label, and preferred distance unit. They do not expose private postal codes,
 formatted addresses, or exact coordinates.
+
+The public map route must continue to use those discovery views rather than base
+tables. Map markers are built from public location summaries and country/region
+anchors; no latitude/longitude columns should be selected for browser display.
 
 ## Contact data expectations
 

--- a/lib/location/map-markers.ts
+++ b/lib/location/map-markers.ts
@@ -1,0 +1,166 @@
+import {
+  approximateLocationLabel,
+  toPublicLocationSummary,
+} from "@/lib/location/approximate-location";
+
+export type DiscoveryMapKind = "quartet" | "singer";
+
+export type DiscoveryMapItem = {
+  countryCode: string | null;
+  countryName: string | null;
+  id: string;
+  kind: DiscoveryMapKind;
+  locality: string | null;
+  locationLabelPublic: string | null;
+  name: string;
+  parts: string[];
+  region: string | null;
+};
+
+export type DiscoveryMapMarker = {
+  id: string;
+  count: number;
+  kinds: DiscoveryMapKind[];
+  label: string;
+  names: string[];
+  parts: string[];
+  xPercent: number;
+  yPercent: number;
+};
+
+type MapAnchor = {
+  xPercent: number;
+  yPercent: number;
+};
+
+const COUNTRY_ANCHORS: Record<string, MapAnchor> = {
+  australia: { xPercent: 80, yPercent: 72 },
+  au: { xPercent: 80, yPercent: 72 },
+  canada: { xPercent: 22, yPercent: 24 },
+  ca: { xPercent: 22, yPercent: 24 },
+  france: { xPercent: 49, yPercent: 39 },
+  fr: { xPercent: 49, yPercent: 39 },
+  germany: { xPercent: 51, yPercent: 37 },
+  de: { xPercent: 51, yPercent: 37 },
+  ireland: { xPercent: 46, yPercent: 35 },
+  ie: { xPercent: 46, yPercent: 35 },
+  netherlands: { xPercent: 49, yPercent: 35 },
+  nl: { xPercent: 49, yPercent: 35 },
+  "new zealand": { xPercent: 86, yPercent: 78 },
+  nz: { xPercent: 86, yPercent: 78 },
+  "united kingdom": { xPercent: 47, yPercent: 34 },
+  uk: { xPercent: 47, yPercent: 34 },
+  gb: { xPercent: 47, yPercent: 34 },
+  "united states": { xPercent: 24, yPercent: 43 },
+  "united states of america": { xPercent: 24, yPercent: 43 },
+  us: { xPercent: 24, yPercent: 43 },
+  usa: { xPercent: 24, yPercent: 43 },
+};
+
+function stableHash(value: string) {
+  let hash = 0;
+
+  for (const character of value) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return hash;
+}
+
+function normalizeKey(value: string | null) {
+  return value?.trim().toLowerCase() || null;
+}
+
+function anchorForItem(item: DiscoveryMapItem): MapAnchor {
+  const countryCode = normalizeKey(item.countryCode);
+  const countryName = normalizeKey(item.countryName);
+  const anchor =
+    (countryCode ? COUNTRY_ANCHORS[countryCode] : undefined) ??
+    (countryName ? COUNTRY_ANCHORS[countryName] : undefined);
+
+  if (anchor) {
+    return anchor;
+  }
+
+  const hash = stableHash(
+    [item.countryName, item.region, item.locality, item.locationLabelPublic]
+      .filter(Boolean)
+      .join("|"),
+  );
+
+  return {
+    xPercent: 12 + (hash % 76),
+    yPercent: 24 + ((hash >>> 8) % 50),
+  };
+}
+
+function approximateMarkerPosition(item: DiscoveryMapItem): MapAnchor {
+  const anchor = anchorForItem(item);
+  const offsetHash = stableHash(
+    [item.countryName, item.region, item.locality, item.kind].join("|"),
+  );
+  const xOffset = (offsetHash % 13) - 6;
+  const yOffset = ((offsetHash >>> 4) % 11) - 5;
+
+  return {
+    xPercent: Math.min(92, Math.max(8, anchor.xPercent + xOffset)),
+    yPercent: Math.min(82, Math.max(16, anchor.yPercent + yOffset)),
+  };
+}
+
+export function buildDiscoveryMapMarkers(
+  items: DiscoveryMapItem[],
+): DiscoveryMapMarker[] {
+  const markerGroups = new Map<string, DiscoveryMapMarker>();
+
+  for (const item of items) {
+    const publicLocation = toPublicLocationSummary({
+      countryName: item.countryName,
+      locality: item.locality,
+      locationLabelPublic: item.locationLabelPublic,
+      region: item.region,
+    });
+    const label = approximateLocationLabel(publicLocation);
+
+    if (label === "Location not shared") {
+      continue;
+    }
+
+    const groupKey = [
+      normalizeKey(item.countryName),
+      normalizeKey(item.region),
+      normalizeKey(item.locality),
+      normalizeKey(item.locationLabelPublic),
+    ].join("|");
+    const existingMarker = markerGroups.get(groupKey);
+
+    if (existingMarker) {
+      existingMarker.count += 1;
+      existingMarker.kinds = Array.from(
+        new Set([...existingMarker.kinds, item.kind]),
+      ).sort();
+      existingMarker.names.push(item.name);
+      existingMarker.parts = Array.from(
+        new Set([...existingMarker.parts, ...item.parts]),
+      ).sort();
+      continue;
+    }
+
+    const { xPercent, yPercent } = approximateMarkerPosition(item);
+
+    markerGroups.set(groupKey, {
+      count: 1,
+      id: groupKey,
+      kinds: [item.kind],
+      label,
+      names: [item.name],
+      parts: [...item.parts].sort(),
+      xPercent,
+      yPercent,
+    });
+  }
+
+  return Array.from(markerGroups.values()).sort((first, second) =>
+    first.label.localeCompare(second.label),
+  );
+}

--- a/test/map-markers.test.ts
+++ b/test/map-markers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildDiscoveryMapMarkers } from "@/lib/location/map-markers";
+
+describe("privacy-safe discovery map markers", () => {
+  it("builds approximate markers from public US and non-US locations", () => {
+    const markers = buildDiscoveryMapMarkers([
+      {
+        countryCode: "US",
+        countryName: "United States",
+        id: "singer-1",
+        kind: "singer",
+        locality: "Fort Collins",
+        locationLabelPublic: null,
+        name: "Avery",
+        parts: ["lead"],
+        region: "CO",
+      },
+      {
+        countryCode: "GB",
+        countryName: "United Kingdom",
+        id: "quartet-1",
+        kind: "quartet",
+        locality: "Manchester",
+        locationLabelPublic: "Manchester, UK area",
+        name: "Northern Ring",
+        parts: ["bass"],
+        region: "England",
+      },
+    ]);
+
+    expect(markers).toHaveLength(2);
+    expect(markers.map((marker) => marker.label)).toEqual([
+      "Fort Collins, CO, United States area",
+      "Manchester, UK area",
+    ]);
+
+    for (const marker of markers) {
+      expect(marker.xPercent).toBeGreaterThanOrEqual(8);
+      expect(marker.xPercent).toBeLessThanOrEqual(92);
+      expect(marker.yPercent).toBeGreaterThanOrEqual(16);
+      expect(marker.yPercent).toBeLessThanOrEqual(82);
+      expect(Object.keys(marker)).not.toContain("latitude");
+      expect(Object.keys(marker)).not.toContain("longitude");
+    }
+  });
+
+  it("clusters repeated public locations without exposing private fields", () => {
+    const markers = buildDiscoveryMapMarkers([
+      {
+        countryCode: "IE",
+        countryName: "Ireland",
+        id: "singer-1",
+        kind: "singer",
+        locality: "Dublin",
+        locationLabelPublic: null,
+        name: "Casey",
+        parts: ["tenor"],
+        region: "Leinster",
+      },
+      {
+        countryCode: "IE",
+        countryName: "Ireland",
+        id: "quartet-1",
+        kind: "quartet",
+        locality: "Dublin",
+        locationLabelPublic: null,
+        name: "River City Four",
+        parts: ["lead"],
+        region: "Leinster",
+      },
+    ]);
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      count: 2,
+      kinds: ["quartet", "singer"],
+      label: "Dublin, Leinster, Ireland area",
+      names: ["Casey", "River City Four"],
+      parts: ["lead", "tenor"],
+    });
+  });
+
+  it("skips entries with no public location", () => {
+    expect(
+      buildDiscoveryMapMarkers([
+        {
+          countryCode: null,
+          countryName: null,
+          id: "singer-1",
+          kind: "singer",
+          locality: null,
+          locationLabelPublic: null,
+          name: "Hidden Location",
+          parts: ["bass"],
+          region: null,
+        },
+      ]),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a public `/map` discovery route that queries only the privacy-safe singer and quartet discovery views.
- Builds approximate regional markers from public location summaries and country/region anchors, without selecting or rendering exact coordinates.
- Adds map marker helpers and tests covering US and non-US examples, clustering, and omission of entries without public location.
- Links the map from the home, singer search, and quartet search pages.
- Documents the provider approach: no third-party map keys required for the MVP, with optional future MapLibre/OpenStreetMap-compatible configuration documented in `.env.example`, deployment, environment, privacy, and Supabase docs.

Closes #9.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --check`
- Production server smoke test returned HTTP 200 for `/map` and `/map?kind=quartets&country=Ireland&part=lead`.

## Notes
- Full live map-result verification requires configured Supabase project env values and visible discovery rows. This local environment does not include those credentials/data.
- A local production server process remained listening on `127.0.0.1:3000` after smoke testing; the sandbox denied terminating PID 71357 with a signal.