### PR TITLE
[codex] Implement Resend contact relay

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,8 +1,6 @@
 "use server";
 
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { getAppUrl } from "@/lib/supabase/env";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function redirectWithMessage(
@@ -10,7 +8,9 @@ function redirectWithMessage(
   key: "error" | "message",
   value: string,
 ): never {
-  redirect(`${path}?${key}=${encodeURIComponent(value)}`);
+  const separator = path.includes("?") ? "&" : "?";
+
+  redirect(`${path}${separator}${key}=${encodeURIComponent(value)}`);
 }
 
 export async function signInWithEmail(formData: FormData) {
@@ -18,6 +18,7 @@ export async function signInWithEmail(formData: FormData) {
     .trim()
     .toLowerCase();
   const next = String(formData.get("next") ?? "/app");
+  const safeNext = next.startsWith("/") ? next : "/app";
 
   if (!email) {
     redirectWithMessage("/sign-in", "error", "Enter an email address.");
@@ -33,28 +34,68 @@ export async function signInWithEmail(formData: FormData) {
     );
   }
 
-  const requestHeaders = await headers();
-  const origin = requestHeaders.get("origin") ?? getAppUrl();
-  const emailRedirectTo = `${origin}/auth/callback?next=${encodeURIComponent(
-    next.startsWith("/") ? next : "/app",
-  )}`;
-
   const { error } = await supabase.auth.signInWithOtp({
     email,
-    options: {
-      emailRedirectTo,
-    },
   });
 
   if (error) {
     redirectWithMessage("/sign-in", "error", error.message);
   }
 
-  redirectWithMessage(
-    "/sign-in",
-    "message",
-    "Check your email for a sign-in link.",
+  redirect(
+    `/sign-in?email=${encodeURIComponent(email)}&next=${encodeURIComponent(
+      safeNext,
+    )}&message=${encodeURIComponent("Check your email for the one-time code.")}`,
   );
+}
+
+export async function verifyEmailOtp(formData: FormData) {
+  const email = String(formData.get("email") ?? "")
+    .trim()
+    .toLowerCase();
+  const token = String(formData.get("token") ?? "")
+    .trim()
+    .replace(/\s+/g, "");
+  const next = String(formData.get("next") ?? "/app");
+  const safeNext = next.startsWith("/") ? next : "/app";
+
+  if (!email || !token) {
+    redirectWithMessage(
+      `/sign-in?email=${encodeURIComponent(email)}&next=${encodeURIComponent(
+        safeNext,
+      )}`,
+      "error",
+      "Enter the one-time code from your email.",
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithMessage(
+      "/sign-in",
+      "error",
+      "Supabase Auth is not configured for this environment.",
+    );
+  }
+
+  const { error } = await supabase.auth.verifyOtp({
+    email,
+    token,
+    type: "email",
+  });
+
+  if (error) {
+    redirectWithMessage(
+      `/sign-in?email=${encodeURIComponent(email)}&next=${encodeURIComponent(
+        safeNext,
+      )}`,
+      "error",
+      error.message,
+    );
+  }
+
+  redirect(safeNext);
 }
 
 export async function signOut() {

--- a/app/contact/actions.ts
+++ b/app/contact/actions.ts
@@ -1,0 +1,169 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  CONTACT_RATE_LIMIT_COUNT,
+  contactRateLimitWindowStart,
+  getContactRelayConfig,
+  parseContactRequestFormData,
+  sendContactNotification,
+  type ContactTarget,
+} from "@/lib/contact/contact-relay";
+import {
+  createSupabaseAdminClient,
+  createSupabaseServerClient,
+} from "@/lib/supabase/server";
+
+type ContactRequestRow = {
+  created_at: string;
+  id: string;
+  recipient_user_id: string;
+};
+
+function redirectWithContactStatus(
+  returnTo: string,
+  status: "auth" | "error" | "sent" | "stored",
+): never {
+  const separator = returnTo.includes("?") ? "&" : "?";
+
+  redirect(`${returnTo}${separator}contact=${status}`);
+}
+
+function senderDisplayName() {
+  return "A signed-in Quartet Member Finder user";
+}
+
+async function fetchContactTarget(
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  targetKind: "quartet" | "singer",
+  targetId: string,
+): Promise<ContactTarget | null> {
+  if (!supabase) {
+    return null;
+  }
+
+  if (targetKind === "singer") {
+    const { data } = await supabase
+      .from("singer_discovery_profiles")
+      .select("id, display_name")
+      .eq("id", targetId)
+      .single();
+
+    return data
+      ? { id: data.id, kind: "singer", name: data.display_name }
+      : null;
+  }
+
+  const { data } = await supabase
+    .from("quartet_discovery_listings")
+    .select("id, name")
+    .eq("id", targetId)
+    .single();
+
+  return data ? { id: data.id, kind: "quartet", name: data.name } : null;
+}
+
+export async function sendContactRequest(formData: FormData) {
+  let values;
+
+  try {
+    values = parseContactRequestFormData(formData);
+  } catch {
+    redirectWithContactStatus("/", "error");
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithContactStatus(values.returnTo, "error");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/sign-in?next=${encodeURIComponent(values.returnTo)}`);
+  }
+
+  const rateLimitWindowStart = contactRateLimitWindowStart();
+  const { count, error: rateLimitError } = await supabase
+    .from("contact_requests")
+    .select("id", { count: "exact", head: true })
+    .eq("sender_user_id", user.id)
+    .gte("created_at", rateLimitWindowStart);
+
+  if (rateLimitError || (count ?? 0) >= CONTACT_RATE_LIMIT_COUNT) {
+    redirectWithContactStatus(values.returnTo, "error");
+  }
+
+  const target = await fetchContactTarget(
+    supabase,
+    values.targetKind,
+    values.targetId,
+  );
+
+  if (!target) {
+    redirectWithContactStatus(values.returnTo, "error");
+  }
+
+  const payload =
+    values.targetKind === "singer"
+      ? {
+          message_body: values.message,
+          sender_user_id: user.id,
+          singer_profile_id: values.targetId,
+        }
+      : {
+          message_body: values.message,
+          quartet_listing_id: values.targetId,
+          sender_user_id: user.id,
+        };
+
+  const { data: contactRequest, error: insertError } = await supabase
+    .from("contact_requests")
+    .insert(payload)
+    .select("id, recipient_user_id, created_at")
+    .single<ContactRequestRow>();
+
+  if (insertError || !contactRequest) {
+    redirectWithContactStatus(values.returnTo, "error");
+  }
+
+  const admin = createSupabaseAdminClient();
+  const relayConfig = getContactRelayConfig();
+
+  if (!admin || !relayConfig) {
+    revalidatePath(values.returnTo);
+    redirectWithContactStatus(values.returnTo, "stored");
+  }
+
+  const { data: recipient, error: recipientError } =
+    await admin.auth.admin.getUserById(contactRequest.recipient_user_id);
+
+  if (recipientError || !recipient.user?.email) {
+    revalidatePath(values.returnTo);
+    redirectWithContactStatus(values.returnTo, "stored");
+  }
+
+  try {
+    await sendContactNotification(relayConfig, {
+      message: values.message,
+      recipientEmail: recipient.user.email,
+      requestId: contactRequest.id,
+      senderDisplayName: senderDisplayName(),
+      target,
+    });
+    await admin
+      .from("contact_requests")
+      .update({ status: "delivered" })
+      .eq("id", contactRequest.id);
+  } catch {
+    revalidatePath(values.returnTo);
+    redirectWithContactStatus(values.returnTo, "stored");
+  }
+
+  revalidatePath(values.returnTo);
+  redirectWithContactStatus(values.returnTo, "sent");
+}

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
   toPublicLocationSummary,
@@ -54,11 +56,45 @@ function tags(values: string[]) {
   return values.map((value) => value.replaceAll("_", " ")).join(", ");
 }
 
+function returnToPath(params: Record<string, string | string[] | undefined>) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (key === "contact") {
+      continue;
+    }
+
+    const normalized = Array.isArray(value) ? value[0] : value;
+
+    if (normalized) {
+      query.set(key, normalized);
+    }
+  }
+
+  const queryString = query.toString();
+
+  return queryString ? `/quartets?${queryString}` : "/quartets";
+}
+
+function contactBannerClass(tone: "error" | "notice" | "success") {
+  if (tone === "error") {
+    return "mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800";
+  }
+
+  if (tone === "success") {
+    return "mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]";
+  }
+
+  return "mt-6 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 text-sm text-[#394548]";
+}
+
 export default async function QuartetSearchPage({
   searchParams,
 }: SearchPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
+  const returnTo = returnToPath(params);
+  const contactStatus = contactStatusMessage(params.contact);
   const supabase = await createSupabaseServerClient();
 
   let quartets: QuartetDiscoveryRow[] = [];
@@ -236,6 +272,12 @@ export default async function QuartetSearchPage({
         </div>
       </form>
 
+      {contactStatus ? (
+        <p className={contactBannerClass(contactStatus.tone)}>
+          {contactStatus.text}
+        </p>
+      ) : null}
+
       {errorMessage ? (
         <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
           {errorMessage}
@@ -319,6 +361,12 @@ export default async function QuartetSearchPage({
                 </div>
               ) : null}
             </dl>
+            <ContactRequestForm
+              returnTo={returnTo}
+              targetId={quartet.id}
+              targetKind="quartet"
+              targetName={quartet.name}
+            />
           </article>
         ))}
       </section>

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
-import { signInWithEmail } from "@/app/auth/actions";
+import { signInWithEmail, verifyEmailOtp } from "@/app/auth/actions";
 
 type SignInPageProps = {
   searchParams: Promise<{
     error?: string;
+    email?: string;
     message?: string;
     next?: string;
   }>;
@@ -12,6 +13,7 @@ type SignInPageProps = {
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const params = await searchParams;
   const next = params.next?.startsWith("/") ? params.next : "/app";
+  const email = params.email ?? "";
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-16">
@@ -20,7 +22,7 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
       </Link>
       <h1 className="mt-6 text-3xl font-bold text-[#172023]">Sign in</h1>
       <p className="mt-3 text-base leading-7 text-[#394548]">
-        Enter your email address and Supabase will send a secure sign-in link.
+        Enter your email address and Supabase will send a one-time code.
       </p>
 
       {params.error ? (
@@ -42,6 +44,7 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
           <input
             autoComplete="email"
             className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            defaultValue={email}
             name="email"
             placeholder="singer@example.com"
             required
@@ -52,9 +55,38 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
           className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
           type="submit"
         >
-          Send sign-in link
+          Send one-time code
         </button>
       </form>
+
+      {email ? (
+        <form
+          action={verifyEmailOtp}
+          className="mt-6 space-y-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4"
+        >
+          <input name="email" type="hidden" value={email} />
+          <input name="next" type="hidden" value={next} />
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              One-time code
+            </span>
+            <input
+              autoComplete="one-time-code"
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              inputMode="numeric"
+              name="token"
+              placeholder="123456"
+              required
+            />
+          </label>
+          <button
+            className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            type="submit"
+          >
+            Verify code
+          </button>
+        </form>
+      ) : null}
     </main>
   );
 }

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
   toPublicLocationSummary,
@@ -52,11 +54,45 @@ function tags(values: string[]) {
   return values.map((value) => value.replaceAll("_", " ")).join(", ");
 }
 
+function returnToPath(params: Record<string, string | string[] | undefined>) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (key === "contact") {
+      continue;
+    }
+
+    const normalized = Array.isArray(value) ? value[0] : value;
+
+    if (normalized) {
+      query.set(key, normalized);
+    }
+  }
+
+  const queryString = query.toString();
+
+  return queryString ? `/singers?${queryString}` : "/singers";
+}
+
+function contactBannerClass(tone: "error" | "notice" | "success") {
+  if (tone === "error") {
+    return "mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800";
+  }
+
+  if (tone === "success") {
+    return "mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]";
+  }
+
+  return "mt-6 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 text-sm text-[#394548]";
+}
+
 export default async function SingerSearchPage({
   searchParams,
 }: SearchPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
+  const returnTo = returnToPath(params);
+  const contactStatus = contactStatusMessage(params.contact);
   const supabase = await createSupabaseServerClient();
 
   let singers: SingerDiscoveryRow[] = [];
@@ -234,6 +270,12 @@ export default async function SingerSearchPage({
         </div>
       </form>
 
+      {contactStatus ? (
+        <p className={contactBannerClass(contactStatus.tone)}>
+          {contactStatus.text}
+        </p>
+      ) : null}
+
       {errorMessage ? (
         <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
           {errorMessage}
@@ -306,6 +348,12 @@ export default async function SingerSearchPage({
                 </div>
               ) : null}
             </dl>
+            <ContactRequestForm
+              returnTo={returnTo}
+              targetId={singer.id}
+              targetKind="singer"
+              targetName={singer.display_name}
+            />
           </article>
         ))}
       </section>

--- a/components/contact/contact-request-form.tsx
+++ b/components/contact/contact-request-form.tsx
@@ -1,0 +1,45 @@
+import { sendContactRequest } from "@/app/contact/actions";
+import type { ContactTargetKind } from "@/lib/contact/contact-relay";
+
+type ContactRequestFormProps = {
+  returnTo: string;
+  targetId: string;
+  targetKind: ContactTargetKind;
+  targetName: string;
+};
+
+export function ContactRequestForm({
+  returnTo,
+  targetId,
+  targetKind,
+  targetName,
+}: ContactRequestFormProps) {
+  return (
+    <form
+      action={sendContactRequest}
+      className="mt-5 rounded-md border border-[#d7cec0] bg-white p-4"
+    >
+      <input name="returnTo" type="hidden" value={returnTo} />
+      <input name="targetId" type="hidden" value={targetId} />
+      <input name="targetKind" type="hidden" value={targetKind} />
+      <label className="block">
+        <span className="text-sm font-semibold text-[#172023]">
+          Contact {targetName}
+        </span>
+        <textarea
+          className="mt-2 min-h-24 w-full rounded-md border border-[#d7cec0] px-3 py-2 text-sm"
+          maxLength={2000}
+          name="message"
+          placeholder="Share a short, friendly note about the quartet opportunity."
+          required
+        />
+      </label>
+      <button
+        className="mt-3 rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+        type="submit"
+      >
+        Send contact request
+      </button>
+    </form>
+  );
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,6 +114,11 @@ The app's protected management routes use Supabase's anonymous public key on the
 server and in browser-safe helpers. Service-role keys must stay server-only and
 are not required for basic sign-in, sign-out, or protected route checks.
 
+Sign-in should use email one-time codes rather than magic links. Supabase email
+templates should include the OTP token so users can paste the code into the app
+sign-in form. The callback route can remain available for compatibility, but
+the app UI should not direct users to a magic-link flow.
+
 ## Resend
 
 Resend should be used for transactional email, including auth-related email where appropriate and the app-mediated contact relay.
@@ -123,6 +128,18 @@ Preferred sender addresses should use the domain once DNS is configured, such as
 - `no-reply@quartetmemberfinder.org`
 - `messages@quartetmemberfinder.org`
 - `support@quartetmemberfinder.org`
+
+The contact relay requires these server-side values in production:
+
+- `RESEND_API_KEY`
+- `RESEND_FROM_EMAIL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+`SUPABASE_SERVICE_ROLE_KEY` is used only in server code to look up the resolved
+recipient email after RLS and the contact-request trigger have accepted the
+request. It must not be exposed to browser code. If Resend or service-role
+configuration is missing, contact requests can still be stored, but notification
+delivery is deferred.
 
 ## Maps and geocoding
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -49,6 +49,23 @@ allow:
 For production, add the deployed app URL and `/auth/callback` URL in the
 Supabase dashboard before enabling sign-in links for users.
 
+Sign-in uses email one-time codes. Configure Supabase email templates to send
+the OTP token and avoid presenting the flow as a magic link in app copy.
+
+## Contact Relay
+
+The contact relay stores authenticated contact requests in Supabase and sends
+recipient notifications through Resend.
+
+Required server-only values for notification delivery:
+
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `RESEND_API_KEY`
+- `RESEND_FROM_EMAIL`
+
+The browser submits only target IDs and message text. Recipient email lookup
+must happen in server code after the database resolves the recipient.
+
 ## Maps
 
 The MVP discovery map does not require a map provider. Optional public map

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -152,6 +152,20 @@ The MVP contact flow should:
 
 Do not publicly display phone numbers or email addresses by default.
 
+Public singer and quartet cards may show app-mediated contact forms, but those
+forms must submit only the target type, target ID, return path, and message.
+They must not include recipient email addresses or phone numbers. The server
+inserts `contact_requests` as the authenticated sender, lets the database
+trigger resolve the private recipient from a visible target, and then uses
+server-only Supabase service-role access to find the recipient email for the
+Resend notification. If Resend or service-role configuration is missing, the
+request may be stored for audit but email delivery is deferred.
+
+Contact notifications should not reveal the sender’s direct email address by
+default. They should tell the recipient a signed-in user sent the request and
+allow the recipient to decide whether to respond or share direct contact
+information later.
+
 ## Abuse and safety considerations
 
 Future work may include:

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -109,6 +109,14 @@ from the visible target singer profile or quartet listing, overwriting
 client-provided recipient values and rejecting unavailable or self-contact
 targets.
 
+The contact relay server action should insert `contact_requests` with the
+authenticated sender ID and either `singer_profile_id` or `quartet_listing_id`.
+It should not accept recipient email or recipient user IDs from the browser.
+After the insert, server-only service-role access may read the resolved
+`recipient_user_id` and look up the recipient auth email for a Resend
+notification. Successful notification delivery may update the request status to
+`delivered`; requests remain auditable even if email configuration is missing.
+
 ## Location data expectations
 
 The database may store coordinates or geocoded data needed for search, but
@@ -175,6 +183,10 @@ The MVP contact flow should use app-mediated contact with Resend notifications.
 - message body
 - status
 - created and updated timestamps
+
+The app applies a basic sender-side rate limit before insert: five contact
+requests per authenticated sender per hour. Database-side rate limiting or abuse
+automation can be added later if the product needs stronger enforcement.
 
 Phone number handling, if added later, should not assume a US-only format.
 

--- a/lib/contact/contact-relay.ts
+++ b/lib/contact/contact-relay.ts
@@ -1,0 +1,149 @@
+import { getAppUrl } from "@/lib/supabase/env";
+
+export type ContactTargetKind = "quartet" | "singer";
+
+export type ContactTarget = {
+  id: string;
+  kind: ContactTargetKind;
+  name: string;
+};
+
+export type ContactRelayConfig = {
+  apiKey: string;
+  fromEmail: string;
+};
+
+export type ContactNotification = {
+  message: string;
+  recipientEmail: string;
+  requestId: string;
+  senderDisplayName: string;
+  target: ContactTarget;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const CONTACT_MESSAGE_MAX_LENGTH = 2000;
+export const CONTACT_RATE_LIMIT_COUNT = 5;
+export const CONTACT_RATE_LIMIT_WINDOW_MINUTES = 60;
+
+function trimToNull(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+export function parseContactRequestFormData(formData: FormData) {
+  const targetKind = trimToNull(formData.get("targetKind"));
+  const targetId = trimToNull(formData.get("targetId"));
+  const message = trimToNull(formData.get("message"));
+  const returnTo = normalizeReturnTo(trimToNull(formData.get("returnTo")));
+
+  if (targetKind !== "singer" && targetKind !== "quartet") {
+    throw new Error("Choose a valid contact target.");
+  }
+
+  const contactTargetKind: ContactTargetKind = targetKind;
+
+  if (!targetId || !UUID_PATTERN.test(targetId)) {
+    throw new Error("Choose a valid contact target.");
+  }
+
+  if (!message) {
+    throw new Error("Add a short message.");
+  }
+
+  if (message.length > CONTACT_MESSAGE_MAX_LENGTH) {
+    throw new Error(
+      `Keep contact messages under ${CONTACT_MESSAGE_MAX_LENGTH} characters.`,
+    );
+  }
+
+  return {
+    message,
+    returnTo,
+    targetId,
+    targetKind: contactTargetKind,
+  };
+}
+
+export function normalizeReturnTo(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/";
+  }
+
+  return value;
+}
+
+export function contactRateLimitWindowStart(now = new Date()) {
+  return new Date(
+    now.getTime() - CONTACT_RATE_LIMIT_WINDOW_MINUTES * 60 * 1000,
+  ).toISOString();
+}
+
+export function getContactRelayConfig(): ContactRelayConfig | null {
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.RESEND_FROM_EMAIL;
+
+  if (!apiKey || !fromEmail) {
+    return null;
+  }
+
+  return { apiKey, fromEmail };
+}
+
+export function buildContactNotificationEmail({
+  message,
+  requestId,
+  senderDisplayName,
+  target,
+}: Omit<ContactNotification, "recipientEmail">) {
+  const appUrl = getAppUrl();
+  const targetType =
+    target.kind === "singer" ? "singer profile" : "quartet listing";
+  const subject = `New Quartet Member Finder contact request for ${target.name}`;
+  const text = [
+    `You have a new contact request for your ${targetType}, "${target.name}".`,
+    "",
+    `From: ${senderDisplayName}`,
+    "",
+    "Message:",
+    message,
+    "",
+    `Request ID: ${requestId}`,
+    `Sign in to Quartet Member Finder to decide whether to respond: ${appUrl}/app`,
+    "",
+    "Your email address was not shown to the sender.",
+  ].join("\n");
+
+  return { subject, text };
+}
+
+export async function sendContactNotification(
+  config: ContactRelayConfig,
+  notification: ContactNotification,
+) {
+  const { subject, text } = buildContactNotificationEmail(notification);
+  const response = await fetch("https://api.resend.com/emails", {
+    body: JSON.stringify({
+      from: config.fromEmail,
+      subject,
+      text,
+      to: notification.recipientEmail,
+    }),
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Resend notification failed with ${response.status}.`);
+  }
+}

--- a/lib/contact/contact-status.ts
+++ b/lib/contact/contact-status.ts
@@ -1,0 +1,35 @@
+export type ContactStatus = "auth" | "error" | "sent" | "stored";
+
+export function contactStatusMessage(status: string | string[] | undefined) {
+  const value = Array.isArray(status) ? status[0] : status;
+
+  if (value === "sent") {
+    return {
+      tone: "success" as const,
+      text: "Contact request sent. The recipient can decide whether to respond or share direct contact information.",
+    };
+  }
+
+  if (value === "stored") {
+    return {
+      tone: "notice" as const,
+      text: "Contact request saved. Email notification is waiting on Resend or server email configuration.",
+    };
+  }
+
+  if (value === "auth") {
+    return {
+      tone: "notice" as const,
+      text: "Sign in with an email one-time code before sending a contact request.",
+    };
+  }
+
+  if (value === "error") {
+    return {
+      tone: "error" as const,
+      text: "Unable to send that contact request. Check the message and try again.",
+    };
+  }
+
+  return null;
+}

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -3,6 +3,10 @@ export type SupabasePublicConfig = {
   url: string;
 };
 
+export type SupabaseAdminConfig = SupabasePublicConfig & {
+  serviceRoleKey: string;
+};
+
 export function getSupabasePublicConfig(): SupabasePublicConfig | null {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -12,6 +16,17 @@ export function getSupabasePublicConfig(): SupabasePublicConfig | null {
   }
 
   return { anonKey, url };
+}
+
+export function getSupabaseAdminConfig(): SupabaseAdminConfig | null {
+  const publicConfig = getSupabasePublicConfig();
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!publicConfig || !serviceRoleKey) {
+    return null;
+  }
+
+  return { ...publicConfig, serviceRoleKey };
 }
 
 export function getAppUrl() {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,10 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
-import { getSupabasePublicConfig } from "@/lib/supabase/env";
+import {
+  getSupabaseAdminConfig,
+  getSupabasePublicConfig,
+} from "@/lib/supabase/env";
 
 export async function createSupabaseServerClient() {
   const config = getSupabasePublicConfig();
@@ -25,6 +29,21 @@ export async function createSupabaseServerClient() {
           // Server Components can read cookies but cannot always write them.
         }
       },
+    },
+  });
+}
+
+export function createSupabaseAdminClient() {
+  const config = getSupabaseAdminConfig();
+
+  if (!config) {
+    return null;
+  }
+
+  return createClient(config.url, config.serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
     },
   });
 }

--- a/test/contact-relay.test.ts
+++ b/test/contact-relay.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CONTACT_RATE_LIMIT_COUNT,
+  CONTACT_RATE_LIMIT_WINDOW_MINUTES,
+  buildContactNotificationEmail,
+  contactRateLimitWindowStart,
+  getContactRelayConfig,
+  normalizeReturnTo,
+  parseContactRequestFormData,
+} from "@/lib/contact/contact-relay";
+
+describe("contact relay helpers", () => {
+  it("parses a valid singer contact request without recipient email fields", () => {
+    const formData = new FormData();
+    formData.set("targetKind", "singer");
+    formData.set("targetId", "123e4567-e89b-12d3-a456-426614174000");
+    formData.set("message", "Would you be interested in a pickup quartet?");
+    formData.set("returnTo", "/singers?part=lead");
+
+    expect(parseContactRequestFormData(formData)).toEqual({
+      message: "Would you be interested in a pickup quartet?",
+      returnTo: "/singers?part=lead",
+      targetId: "123e4567-e89b-12d3-a456-426614174000",
+      targetKind: "singer",
+    });
+    expect(Array.from(formData.keys())).not.toContain("recipientEmail");
+  });
+
+  it("rejects invalid targets and unsafe return paths", () => {
+    const formData = new FormData();
+    formData.set("targetKind", "melody");
+    formData.set("targetId", "not-a-uuid");
+    formData.set("message", "Hello");
+
+    expect(() => parseContactRequestFormData(formData)).toThrow(
+      "Choose a valid contact target.",
+    );
+    expect(normalizeReturnTo("https://example.com")).toBe("/");
+    expect(normalizeReturnTo("//example.com")).toBe("/");
+  });
+
+  it("builds recipient notification without revealing direct sender contact", () => {
+    const { subject, text } = buildContactNotificationEmail({
+      message: "We are looking for a bass.",
+      requestId: "request-1",
+      senderDisplayName: "A signed-in Quartet Member Finder user",
+      target: {
+        id: "target-1",
+        kind: "quartet",
+        name: "Chord Harbor",
+      },
+    });
+
+    expect(subject).toContain("Chord Harbor");
+    expect(text).toContain("We are looking for a bass.");
+    expect(text).toContain("Your email address was not shown to the sender.");
+    expect(text).not.toContain("@example.com");
+  });
+
+  it("reads Resend configuration only from server environment", () => {
+    vi.stubEnv("RESEND_API_KEY", "resend-key");
+    vi.stubEnv("RESEND_FROM_EMAIL", "messages@example.com");
+
+    expect(getContactRelayConfig()).toEqual({
+      apiKey: "resend-key",
+      fromEmail: "messages@example.com",
+    });
+
+    vi.unstubAllEnvs();
+    expect(getContactRelayConfig()).toBeNull();
+  });
+
+  it("defines a basic sender rate-limit window", () => {
+    expect(CONTACT_RATE_LIMIT_COUNT).toBe(5);
+    expect(CONTACT_RATE_LIMIT_WINDOW_MINUTES).toBe(60);
+    expect(contactRateLimitWindowStart(new Date("2026-04-30T12:00:00Z"))).toBe(
+      "2026-04-30T11:00:00.000Z",
+    );
+  });
+});

--- a/test/contact-status.test.ts
+++ b/test/contact-status.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { contactStatusMessage } from "@/lib/contact/contact-status";
+
+describe("contact status messages", () => {
+  it("describes the contact relay outcomes", () => {
+    expect(contactStatusMessage("sent")).toMatchObject({ tone: "success" });
+    expect(contactStatusMessage("stored")).toMatchObject({ tone: "notice" });
+    expect(contactStatusMessage("error")).toMatchObject({ tone: "error" });
+    expect(contactStatusMessage(undefined)).toBeNull();
+  });
+
+  it("uses OTP wording for authentication", () => {
+    expect(contactStatusMessage("auth")?.text).toContain("one-time code");
+    expect(contactStatusMessage("auth")?.text).not.toContain("magic link");
+  });
+});

--- a/test/supabase-auth.test.ts
+++ b/test/supabase-auth.test.ts
@@ -9,9 +9,11 @@ describe("Supabase public env helpers", () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
 
-    const { getSupabasePublicConfig } = await import("@/lib/supabase/env");
+    const { getSupabaseAdminConfig, getSupabasePublicConfig } =
+      await import("@/lib/supabase/env");
 
     expect(getSupabasePublicConfig()).toBeNull();
+    expect(getSupabaseAdminConfig()).toBeNull();
   });
 
   it("uses only public Supabase values for client configuration", async () => {
@@ -19,10 +21,16 @@ describe("Supabase public env helpers", () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key");
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
 
-    const { getSupabasePublicConfig } = await import("@/lib/supabase/env");
+    const { getSupabaseAdminConfig, getSupabasePublicConfig } =
+      await import("@/lib/supabase/env");
 
     expect(getSupabasePublicConfig()).toEqual({
       anonKey: "anon-key",
+      url: "https://example.supabase.co",
+    });
+    expect(getSupabaseAdminConfig()).toEqual({
+      anonKey: "anon-key",
+      serviceRoleKey: "service-role-key",
       url: "https://example.supabase.co",
     });
   });


### PR DESCRIPTION
## Summary
- Adds app-mediated contact request forms to singer and quartet discovery results without exposing recipient contact information.
- Adds a server action that requires an authenticated sender, applies a basic five-per-hour sender rate limit, inserts `contact_requests`, lets the database resolve the recipient, and sends a server-only Resend notification when configured.
- Adds server-only Supabase service-role client support for recipient email lookup after RLS/trigger acceptance.
- Updates sign-in to use email one-time code verification rather than magic-link copy or flow.
- Adds contact relay/status helpers and tests for request parsing, safe return paths, Resend config, no direct sender email disclosure, OTP wording, and admin config.
- Updates privacy, Supabase, deployment, and environment docs for relay behavior, server-only secrets, Resend setup, rate-limit notes, and OTP sign-in.

Closes #10.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --check`
- Production server smoke test returned HTTP 200 for `/sign-in`, `/singers?contact=auth`, and `/quartets?contact=stored`.

## Notes
- Full live delivery verification requires configured Supabase auth, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, and visible discovery rows. This local environment does not include those credentials/data.