### PR TITLE
[codex] Add public help and privacy pages

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -60,6 +60,15 @@ export default async function ProtectedAppLayout({
             >
               Quartet listings
             </Link>
+            <Link className="text-sm font-semibold text-[#394548]" href="/help">
+              Help
+            </Link>
+            <Link
+              className="text-sm font-semibold text-[#394548]"
+              href="/privacy"
+            >
+              Privacy
+            </Link>
           </nav>
           <form action={signOut}>
             <button

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { publicHelpSections } from "@/lib/content/public-pages";
+
+export default function HelpPage() {
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-4xl px-6 py-12">
+      <nav aria-label="Public navigation" className="flex flex-wrap gap-4">
+        <Link className="font-semibold text-[#2f6f73]" href="/">
+          Home
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/singers">
+          Singers
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+          Quartets
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
+          Privacy
+        </Link>
+      </nav>
+
+      <header className="mt-10">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Help
+        </p>
+        <h1 className="mt-4 text-4xl font-bold text-[#172023]">
+          How Quartet Member Finder Works
+        </h1>
+        <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
+          A practical guide for singers and quartets using the app before,
+          during, and after first contact.
+        </p>
+      </header>
+
+      <section className="mt-10 grid gap-5">
+        {publicHelpSections.map((section) => (
+          <article
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+            key={section.heading}
+          >
+            <h2 className="text-xl font-bold text-[#172023]">
+              {section.heading}
+            </h2>
+            <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <footer className="mt-10 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
+        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
+          Read the privacy overview
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/sign-in">
+          Sign in
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -230,6 +230,9 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           <Link className="font-semibold text-[#2f6f73]" href="/quartets">
             Find quartets
           </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/help">
+            Help
+          </Link>
         </div>
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,6 +45,12 @@ export default function Home() {
           >
             Sign in
           </Link>
+          <Link
+            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+            href="/help"
+          >
+            Help
+          </Link>
         </div>
       </section>
 
@@ -61,6 +67,15 @@ export default function Home() {
           </div>
         ))}
       </section>
+
+      <footer className="mt-12 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
+        <Link className="font-semibold text-[#2f6f73]" href="/help">
+          Help
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
+          Privacy
+        </Link>
+      </footer>
     </main>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { publicPrivacySections } from "@/lib/content/public-pages";
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-4xl px-6 py-12">
+      <nav aria-label="Public navigation" className="flex flex-wrap gap-4">
+        <Link className="font-semibold text-[#2f6f73]" href="/">
+          Home
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/help">
+          Help
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/singers">
+          Singers
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+          Quartets
+        </Link>
+      </nav>
+
+      <header className="mt-10">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Privacy
+        </p>
+        <h1 className="mt-4 text-4xl font-bold text-[#172023]">
+          Privacy Overview
+        </h1>
+        <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
+          How Quartet Member Finder keeps public discovery useful without
+          exposing private contact details or exact home-location information.
+        </p>
+      </header>
+
+      <section className="mt-10 grid gap-5">
+        {publicPrivacySections.map((section) => (
+          <article
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+            key={section.heading}
+          >
+            <h2 className="text-xl font-bold text-[#172023]">
+              {section.heading}
+            </h2>
+            <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <footer className="mt-10 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
+        <Link className="font-semibold text-[#2f6f73]" href="/help">
+          Read the help page
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/sign-in">
+          Sign in
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -173,6 +173,9 @@ export default async function QuartetSearchPage({
           <Link className="font-semibold text-[#2f6f73]" href="/map">
             View map
           </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/help">
+            Help
+          </Link>
         </div>
       </div>
 

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -20,6 +20,14 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
       <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
         Quartet Member Finder
       </Link>
+      <div className="mt-4 flex gap-4 text-sm">
+        <Link className="font-semibold text-[#2f6f73]" href="/help">
+          Help
+        </Link>
+        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
+          Privacy
+        </Link>
+      </div>
       <h1 className="mt-6 text-3xl font-bold text-[#172023]">Sign in</h1>
       <p className="mt-3 text-base leading-7 text-[#394548]">
         Enter your email address and Supabase will send a one-time code.

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -171,6 +171,9 @@ export default async function SingerSearchPage({
           <Link className="font-semibold text-[#2f6f73]" href="/map">
             View map
           </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/help">
+            Help
+          </Link>
         </div>
       </div>
 

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -1,0 +1,114 @@
+export const publicHelpSections = [
+  {
+    body: [
+      "Quartet Member Finder helps barbershop singers and incomplete quartets find each other. It is for practical discovery and safer introductions, not for building a public social network.",
+      "You can use it to create a singer profile, list an incomplete quartet, search for nearby possibilities, and send an app-mediated first contact request.",
+    ],
+    heading: "What It Is For",
+  },
+  {
+    body: [
+      "A singer profile describes who you are as a singer: your name, parts, goals, experience, availability, travel willingness, and approximate location.",
+      "You choose whether the profile appears in public discovery. Hidden profiles stay out of singer search and the map.",
+    ],
+    heading: "Singer Profiles",
+  },
+  {
+    body: [
+      "A quartet listing is for a quartet or prospective quartet that has some parts covered and is looking for one or more singers.",
+      "Listings keep covered parts and needed parts separate so searchers can quickly understand what the group needs.",
+    ],
+    heading: "Quartet Listings",
+  },
+  {
+    body: [
+      "Search can show visible singers, visible quartet listings, and approximate regional map markers. Filters can use public fields like part, goal, country, region, locality, availability, and travel willingness where that data exists.",
+      "Search results are useful even when a profile is incomplete, but more complete profiles are easier for others to evaluate.",
+    ],
+    heading: "Search",
+  },
+  {
+    body: [
+      "Public results show approximate places, such as a city or regional area. They do not show exact home addresses, exact coordinates, private postal codes, email addresses, or phone numbers.",
+      "Location fields are designed for a global barbershop community, so they are not limited to US ZIP codes or US states.",
+    ],
+    heading: "Location And Privacy",
+  },
+  {
+    body: [
+      "First contact happens through the app. A signed-in user can send a short message, and the recipient can decide whether to respond or share direct contact information.",
+      "The app does not show the recipient's private email address or phone number in public search results.",
+    ],
+    heading: "Contact",
+  },
+  {
+    body: [
+      "You can hide a singer profile or quartet listing by turning off its search visibility and saving. Hidden items should disappear from public search and the map.",
+      "If you no longer want a profile or listing to be active, keep it hidden until deletion or stronger deactivation controls are added.",
+    ],
+    heading: "Visibility Controls",
+  },
+  {
+    body: [
+      "Use the same judgment you would use when meeting someone through a singing community. Start with app-mediated messages, meet in public or group settings when possible, and do not share private contact details until you are comfortable.",
+      "The app helps reduce public exposure of personal data, but it does not replace personal judgment or formal moderation.",
+    ],
+    heading: "First Contact Safety",
+  },
+  {
+    body: [
+      "The public privacy overview explains what is shown, what is kept private, and how approximate location and contact relay behavior work.",
+    ],
+    heading: "Privacy Page",
+  },
+  {
+    body: [
+      "Once the feedback form exists, signed-in users should find it at /app/feedback. Until then, use the project issue tracker or contact the project owner directly.",
+    ],
+    heading: "Feedback",
+  },
+];
+
+export const publicPrivacySections = [
+  {
+    body: [
+      "You choose what to put in a singer profile or quartet listing. That can include names, parts, goals, experience, availability, travel willingness, a short description, and approximate location fields.",
+      "Do not put private contact details or exact home-location details into public text fields if you do not want other people to see them.",
+    ],
+    heading: "Information You Add",
+  },
+  {
+    body: [
+      "Approximate location helps singers and quartets judge whether an introduction might be practical without exposing exact home-location details.",
+      "Public discovery uses city, region, country, or a public location label. It should not show exact coordinates, private postal codes, or private addresses.",
+    ],
+    heading: "Approximate Location",
+  },
+  {
+    body: [
+      "Singer profiles and quartet listings have visibility controls. Visible and active items can appear in public search and the map. Hidden items should stay out of those public discovery views.",
+      "The database uses privacy-safe discovery views for public search rather than exposing private base tables directly.",
+    ],
+    heading: "Visibility",
+  },
+  {
+    body: [
+      "Public search results should not show personal email addresses or phone numbers by default.",
+      "When someone sends a contact request, the app stores the request, resolves the recipient on the server/database side, and sends a notification without revealing the recipient's email address to the sender.",
+    ],
+    heading: "Contact Relay",
+  },
+  {
+    body: [
+      "Barbershop is global, and the app should be useful outside the United States and Canada. Location handling is approximate and globally tolerant by design.",
+      "The app should not require US-only fields like ZIP code or state to make basic discovery useful.",
+    ],
+    heading: "Global Use",
+  },
+  {
+    body: [
+      "This page is a plain-language product overview, not a formal legal privacy policy. A formal policy can be added later when the app is closer to public launch.",
+    ],
+    heading: "Not A Legal Policy",
+  },
+];

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  publicHelpSections,
+  publicPrivacySections,
+} from "@/lib/content/public-pages";
+
+function pageText(sections: Array<{ body: string[]; heading: string }>) {
+  return sections
+    .flatMap((section) => [section.heading, ...section.body])
+    .join("\n");
+}
+
+describe("public help and privacy content", () => {
+  it("covers practical help topics without overpromising moderation", () => {
+    const helpText = pageText(publicHelpSections);
+
+    expect(helpText).toContain("Singer Profiles");
+    expect(helpText).toContain("Quartet Listings");
+    expect(helpText).toContain("Search");
+    expect(helpText).toContain("Location And Privacy");
+    expect(helpText).toContain("Contact");
+    expect(helpText).toContain("/app/feedback");
+    expect(helpText).toContain("does not replace personal judgment");
+    expect(helpText).not.toMatch(/24\/7 moderation|background checks/i);
+  });
+
+  it("keeps privacy overview plainspoken and aligned with app behavior", () => {
+    const privacyText = pageText(publicPrivacySections);
+
+    expect(privacyText).toContain("Approximate Location");
+    expect(privacyText).toContain("Public search results should not show");
+    expect(privacyText).toContain("email addresses or phone numbers");
+    expect(privacyText).toContain("global");
+    expect(privacyText).toContain("not a formal legal privacy policy");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds public `/help` and `/privacy` pages available before login.
- Explains singer profiles, quartet listings, search, approximate/global location behavior, visibility controls, app-mediated contact, and first-contact safety in plain user-facing language.
- Links help/privacy from the home page, discovery pages, sign-in page, and signed-in app navigation.
- Defines the future feedback location as `/app/feedback` without adding a form before issue #29.
- Adds content tests to keep the required help/privacy topics and non-overpromising safety language in place.

Closes #26.
Closes #28.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run format:check`
- `git diff --check`
- Production server smoke test returned HTTP 200 for `/help` and `/privacy`, and confirmed help content includes privacy, first-contact safety, and `/app/feedback` references.

## Notes
- `.env.local` remained ignored and was not inspected or committed.
- Local smoke testing left a server process listening on port 3000 as PID 10877; the sandbox denied terminating it with a signal.