### PR TITLE
Add authenticated feedback form on help page

### DIFF
--- a/app/help/actions.ts
+++ b/app/help/actions.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  FEEDBACK_RATE_LIMIT_COUNT,
+  feedbackRateLimitWindowStart,
+  parseFeedbackFormData,
+} from "@/lib/feedback/feedback-form";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function redirectWithFeedbackStatus(
+  status: "auth" | "error" | "sent" | "limited",
+): never {
+  redirect(`/help?feedback=${status}`);
+}
+
+export async function submitHelpFeedback(formData: FormData) {
+  let values;
+
+  try {
+    values = parseFeedbackFormData(formData);
+  } catch {
+    redirectWithFeedbackStatus("error");
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithFeedbackStatus("error");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/sign-in?next=${encodeURIComponent("/help")}`);
+  }
+
+  const rateLimitWindowStart = feedbackRateLimitWindowStart();
+  const headerStore = await headers();
+  const userAgent = headerStore.get("user-agent");
+  const { count, error: rateLimitError } = await supabase
+    .from("feedback_submissions")
+    .select("id", { count: "exact", head: true })
+    .eq("submitter_user_id", user.id)
+    .gte("created_at", rateLimitWindowStart);
+
+  if (rateLimitError) {
+    redirectWithFeedbackStatus("error");
+  }
+
+  if ((count ?? 0) >= FEEDBACK_RATE_LIMIT_COUNT) {
+    redirectWithFeedbackStatus("limited");
+  }
+
+  const { error: insertError } = await supabase
+    .from("feedback_submissions")
+    .insert({
+      context_path: values.contextPath,
+      feedback_type: values.feedbackType,
+      message_body: values.message,
+      submitter_email_private: user.email ?? null,
+      submitter_user_id: user.id,
+      user_agent: userAgent ? userAgent.slice(0, 500) : null,
+    });
+
+  if (insertError) {
+    redirectWithFeedbackStatus("error");
+  }
+
+  revalidatePath("/help");
+  redirectWithFeedbackStatus("sent");
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,7 +1,21 @@
 import Link from "next/link";
+import { HelpFeedbackForm } from "@/components/feedback/help-feedback-form";
 import { publicHelpSections } from "@/lib/content/public-pages";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
-export default function HelpPage() {
+type HelpPageProps = {
+  searchParams: Promise<{
+    feedback?: string;
+  }>;
+};
+
+export default async function HelpPage({ searchParams }: HelpPageProps) {
+  const params = await searchParams;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
   return (
     <main className="mx-auto min-h-screen w-full max-w-4xl px-6 py-12">
       <nav aria-label="Public navigation" className="flex flex-wrap gap-4">
@@ -50,13 +64,38 @@ export default function HelpPage() {
         ))}
       </section>
 
+      {user ? (
+        <HelpFeedbackForm status={params.feedback} />
+      ) : (
+        <section className="mt-10 border-t border-[#d7cec0] pt-8">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            Feedback
+          </p>
+          <h2 className="mt-3 text-2xl font-bold text-[#172023]">
+            Send feedback after signing in
+          </h2>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
+            Signed-in users can send private feedback, bug reports, and
+            suggestions from this page.
+          </p>
+          <Link
+            className="mt-4 inline-flex rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            href="/sign-in?next=%2Fhelp"
+          >
+            Sign in to send feedback
+          </Link>
+        </section>
+      )}
+
       <footer className="mt-10 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
         <Link className="font-semibold text-[#2f6f73]" href="/privacy">
           Read the privacy overview
         </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/sign-in">
-          Sign in
-        </Link>
+        {user ? null : (
+          <Link className="font-semibold text-[#2f6f73]" href="/sign-in">
+            Sign in
+          </Link>
+        )}
       </footer>
     </main>
   );

--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -1,0 +1,101 @@
+import { submitHelpFeedback } from "@/app/help/actions";
+import { FEEDBACK_MESSAGE_MAX_LENGTH } from "@/lib/feedback/feedback-form";
+
+type HelpFeedbackFormProps = {
+  status?: string;
+};
+
+function feedbackStatusMessage(status?: string) {
+  if (status === "sent") {
+    return "Thanks for the note. Your feedback was sent.";
+  }
+
+  if (status === "limited") {
+    return "You have sent several notes recently. Please try again later.";
+  }
+
+  if (status === "error") {
+    return "Feedback could not be submitted. Please try again.";
+  }
+
+  return null;
+}
+
+export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
+  const statusMessage = feedbackStatusMessage(status);
+  const isSuccess = status === "sent";
+
+  return (
+    <section className="mt-10 border-t border-[#d7cec0] pt-8">
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Feedback
+        </p>
+        <h2 className="mt-3 text-2xl font-bold text-[#172023]">
+          Send a note to the project team
+        </h2>
+        <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
+          Share feedback, bug reports, or suggestions. Your note is private and
+          is tied to your signed-in account for follow-up and abuse prevention.
+        </p>
+      </div>
+
+      {statusMessage ? (
+        <p
+          className={`mt-5 rounded-md border p-4 text-sm ${
+            isSuccess
+              ? "border-[#b7d7ce] bg-[#eef8f4] text-[#174b4f]"
+              : "border-red-200 bg-red-50 text-red-800"
+          }`}
+        >
+          {statusMessage}
+        </p>
+      ) : null}
+
+      <form action={submitHelpFeedback} className="mt-5 grid gap-4">
+        <input name="contextPath" type="hidden" value="/help" />
+        <label className="hidden">
+          Website
+          <input
+            autoComplete="off"
+            name="website"
+            tabIndex={-1}
+            type="text"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-semibold text-[#172023]">Type</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            defaultValue="feedback"
+            name="feedbackType"
+            required
+          >
+            <option value="feedback">General feedback</option>
+            <option value="bug">Bug report</option>
+            <option value="suggestion">Suggestion</option>
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-semibold text-[#172023]">Message</span>
+          <textarea
+            className="mt-2 min-h-36 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            maxLength={FEEDBACK_MESSAGE_MAX_LENGTH}
+            name="message"
+            placeholder="What should we know?"
+            required
+          />
+        </label>
+
+        <button
+          className="w-fit rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          type="submit"
+        >
+          Send feedback
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -141,6 +141,11 @@ request. It must not be exposed to browser code. If Resend or service-role
 configuration is missing, contact requests can still be stored, but notification
 delivery is deferred.
 
+Help-page feedback currently stores authenticated submissions in Supabase rather
+than sending transactional email. Admin review should use service-role/server
+access or a future protected admin surface; feedback must not be exposed through
+public routes or browser-side service-role code.
+
 ## Maps and geocoding
 
 The current public discovery map does not require a third-party map or geocoder

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -166,6 +166,21 @@ default. They should tell the recipient a signed-in user sent the request and
 allow the recipient to decide whether to respond or share direct contact
 information later.
 
+## Feedback model
+
+The public help page stays readable before login. Signed-out visitors are
+invited to sign in before sending feedback.
+
+Signed-in users can submit private feedback, bug reports, or suggestions from
+the help page. The browser sends only the feedback type, message, current route
+context, and a spam honeypot field. The server action attaches the authenticated
+user ID and auth email when available, then stores the submission in Supabase.
+
+Feedback submissions are not public content and are not included in discovery
+views, search results, maps, or public profile/listing UI. Regular authenticated
+users cannot read other users' feedback. Admin/service-role access is required
+for cross-user review or triage.
+
 ## Abuse and safety considerations
 
 Future work may include:
@@ -173,7 +188,10 @@ Future work may include:
 - reporting inappropriate profiles/messages
 - blocking users
 - rate limits on contact messages
+- admin feedback triage tools
 - audit logs for contact attempts
 - admin tools for handling abuse reports
 
-The MVP should at least avoid public exposure of private location/contact data and should avoid unauthenticated contact spam.
+The MVP should at least avoid public exposure of private location/contact data,
+avoid unauthenticated contact spam, and rate-limit authenticated feedback
+submissions.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -17,6 +17,7 @@ It includes these data areas:
 - `quartet_listings`: incomplete quartet listings owned by one authenticated user.
 - `quartet_listing_parts`: parts currently covered or needed by a quartet.
 - `contact_requests`: app-mediated first-contact messages.
+- `feedback_submissions`: private authenticated-user feedback from the help page.
 - `singer_discovery_profiles`: privacy-safe singer discovery view.
 - `quartet_discovery_listings`: privacy-safe quartet discovery view.
 
@@ -82,6 +83,8 @@ RLS should enforce:
 - private fields are not exposed in public discovery views
 - contact requests require an authenticated sender
 - recipients can read contact requests addressed to them or to listings they own
+- feedback submissions require an authenticated submitter and are not readable by
+  other regular users
 
 Do not rely only on client-side filtering for visibility, privacy, or ownership checks.
 
@@ -116,6 +119,17 @@ After the insert, server-only service-role access may read the resolved
 `recipient_user_id` and look up the recipient auth email for a Resend
 notification. Successful notification delivery may update the request status to
 `delivered`; requests remain auditable even if email configuration is missing.
+
+Help-page feedback inserts are authenticated-only. The server action writes
+`feedback_submissions` with the authenticated user ID and, when available, the
+signed-in auth email from the server session. Browser submissions may provide
+only the feedback type, message, and current route/context. They must not provide
+the submitter user ID, submitter email, status, or other ownership fields.
+
+The feedback table is private. Anonymous users have no direct table grants.
+Authenticated users may insert their own feedback and read only their own
+feedback rows so the server action can apply a basic sender-side rate limit.
+Service-role/admin access is required for cross-user review, triage, or export.
 
 ## Location data expectations
 
@@ -187,6 +201,22 @@ The MVP contact flow should use app-mediated contact with Resend notifications.
 The app applies a basic sender-side rate limit before insert: five contact
 requests per authenticated sender per hour. Database-side rate limiting or abuse
 automation can be added later if the product needs stronger enforcement.
+
+`feedback_submissions` supports private product feedback:
+
+- submitter user
+- server-captured submitter email when available
+- feedback type: feedback, bug, or suggestion
+- message body
+- current route/context when available
+- user agent when available
+- status
+- created and updated timestamps
+
+The help-page feedback action applies authenticated-only spam protection:
+three feedback submissions per authenticated submitter per hour, message length
+limits, type validation, route/context normalization, and a hidden honeypot
+field. Feedback is not exposed in public discovery views or public pages.
 
 Phone number handling, if added later, should not assume a US-only format.
 

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -63,7 +63,7 @@ export const publicHelpSections = [
   },
   {
     body: [
-      "Once the feedback form exists, signed-in users should find it at /app/feedback. Until then, use the project issue tracker or contact the project owner directly.",
+      "Signed-in users can send private feedback, bug reports, and suggestions from this help page. Feedback is tied to the signed-in account server-side and is not shown publicly.",
     ],
     heading: "Feedback",
   },

--- a/lib/feedback/feedback-form.ts
+++ b/lib/feedback/feedback-form.ts
@@ -1,0 +1,75 @@
+export const FEEDBACK_MESSAGE_MAX_LENGTH = 3000;
+export const FEEDBACK_CONTEXT_MAX_LENGTH = 500;
+export const FEEDBACK_RATE_LIMIT_COUNT = 3;
+export const FEEDBACK_RATE_LIMIT_WINDOW_MINUTES = 60;
+
+export const feedbackTypes = ["feedback", "bug", "suggestion"] as const;
+
+export type FeedbackType = (typeof feedbackTypes)[number];
+
+export type FeedbackFormValues = {
+  contextPath: string | null;
+  feedbackType: FeedbackType;
+  message: string;
+};
+
+function trimToNull(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+export function normalizeFeedbackContext(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return null;
+  }
+
+  return value.slice(0, FEEDBACK_CONTEXT_MAX_LENGTH);
+}
+
+export function parseFeedbackFormData(formData: FormData): FeedbackFormValues {
+  const feedbackType = trimToNull(formData.get("feedbackType"));
+  const message = trimToNull(formData.get("message"));
+  const contextPath = normalizeFeedbackContext(
+    trimToNull(formData.get("contextPath")),
+  );
+  const website = trimToNull(formData.get("website"));
+
+  if (website) {
+    throw new Error("Feedback could not be submitted.");
+  }
+
+  if (
+    feedbackType !== "feedback" &&
+    feedbackType !== "bug" &&
+    feedbackType !== "suggestion"
+  ) {
+    throw new Error("Choose a feedback type.");
+  }
+
+  if (!message) {
+    throw new Error("Add a short message.");
+  }
+
+  if (message.length > FEEDBACK_MESSAGE_MAX_LENGTH) {
+    throw new Error(
+      `Keep feedback under ${FEEDBACK_MESSAGE_MAX_LENGTH} characters.`,
+    );
+  }
+
+  return {
+    contextPath,
+    feedbackType,
+    message,
+  };
+}
+
+export function feedbackRateLimitWindowStart(now = new Date()) {
+  return new Date(
+    now.getTime() - FEEDBACK_RATE_LIMIT_WINDOW_MINUTES * 60 * 1000,
+  ).toISOString();
+}

--- a/supabase/migrations/20260430170000_feedback_submissions.sql
+++ b/supabase/migrations/20260430170000_feedback_submissions.sql
@@ -1,0 +1,50 @@
+create table public.feedback_submissions (
+  id uuid primary key default gen_random_uuid(),
+  submitter_user_id uuid not null references auth.users (id) on delete cascade,
+  submitter_email_private text check (
+    submitter_email_private is null
+    or char_length(submitter_email_private) <= 320
+  ),
+  feedback_type text not null check (
+    feedback_type in ('feedback', 'bug', 'suggestion')
+  ),
+  message_body text not null check (char_length(message_body) between 1 and 3000),
+  context_path text check (
+    context_path is null
+    or char_length(context_path) <= 500
+  ),
+  user_agent text check (
+    user_agent is null
+    or char_length(user_agent) <= 500
+  ),
+  status text not null default 'new' check (
+    status in ('new', 'reviewed', 'closed')
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index feedback_submissions_submitter_idx
+  on public.feedback_submissions (submitter_user_id, created_at desc);
+
+create index feedback_submissions_status_idx
+  on public.feedback_submissions (status, created_at desc);
+
+create trigger feedback_submissions_set_updated_at
+before update on public.feedback_submissions
+for each row execute function public.set_updated_at();
+
+alter table public.feedback_submissions enable row level security;
+
+create policy "Authenticated users can create their own feedback"
+on public.feedback_submissions
+for insert
+with check (auth.uid() = submitter_user_id);
+
+create policy "Authenticated users can rate limit their own feedback"
+on public.feedback_submissions
+for select
+using (auth.uid() = submitter_user_id);
+
+revoke all on table public.feedback_submissions from anon, authenticated;
+grant select, insert on table public.feedback_submissions to authenticated;

--- a/test/feedback-form.test.ts
+++ b/test/feedback-form.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEEDBACK_RATE_LIMIT_COUNT,
+  FEEDBACK_RATE_LIMIT_WINDOW_MINUTES,
+  feedbackRateLimitWindowStart,
+  normalizeFeedbackContext,
+  parseFeedbackFormData,
+} from "@/lib/feedback/feedback-form";
+
+describe("feedback form helpers", () => {
+  it("parses authenticated help feedback without client-owned identity fields", () => {
+    const formData = new FormData();
+    formData.set("feedbackType", "bug");
+    formData.set("message", "The quartet search filter reset unexpectedly.");
+    formData.set("contextPath", "/help");
+
+    expect(parseFeedbackFormData(formData)).toEqual({
+      contextPath: "/help",
+      feedbackType: "bug",
+      message: "The quartet search filter reset unexpectedly.",
+    });
+    expect(Array.from(formData.keys())).not.toContain("submitterUserId");
+    expect(Array.from(formData.keys())).not.toContain("submitterEmail");
+  });
+
+  it("rejects unsafe values and spam honeypot submissions", () => {
+    const formData = new FormData();
+    formData.set("feedbackType", "other");
+    formData.set("message", "Hello");
+
+    expect(() => parseFeedbackFormData(formData)).toThrow(
+      "Choose a feedback type.",
+    );
+
+    formData.set("feedbackType", "feedback");
+    formData.set("website", "https://spam.example");
+
+    expect(() => parseFeedbackFormData(formData)).toThrow(
+      "Feedback could not be submitted.",
+    );
+    expect(normalizeFeedbackContext("https://example.com/help")).toBeNull();
+    expect(normalizeFeedbackContext("//example.com/help")).toBeNull();
+  });
+
+  it("defines an authenticated feedback rate-limit window", () => {
+    expect(FEEDBACK_RATE_LIMIT_COUNT).toBe(3);
+    expect(FEEDBACK_RATE_LIMIT_WINDOW_MINUTES).toBe(60);
+    expect(feedbackRateLimitWindowStart(new Date("2026-04-30T12:00:00Z"))).toBe(
+      "2026-04-30T11:00:00.000Z",
+    );
+  });
+});

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -19,7 +19,7 @@ describe("public help and privacy content", () => {
     expect(helpText).toContain("Search");
     expect(helpText).toContain("Location And Privacy");
     expect(helpText).toContain("Contact");
-    expect(helpText).toContain("/app/feedback");
+    expect(helpText).toContain("Signed-in users can send private feedback");
     expect(helpText).toContain("does not replace personal judgment");
     expect(helpText).not.toMatch(/24\/7 moderation|background checks/i);
   });

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -1,10 +1,13 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const migration = readFileSync(
-  "supabase/migrations/20260430023000_initial_schema_and_rls.sql",
-  "utf8",
-);
+const migration = readdirSync("supabase/migrations")
+  .filter((fileName) => fileName.endsWith(".sql"))
+  .sort()
+  .map((fileName) =>
+    readFileSync(`supabase/migrations/${fileName}`, "utf8"),
+  )
+  .join("\n\n");
 
 const appTables = [
   "account_profiles",
@@ -13,6 +16,7 @@ const appTables = [
   "quartet_listings",
   "quartet_listing_parts",
   "contact_requests",
+  "feedback_submissions",
 ];
 
 function viewDefinition(viewName: string) {


### PR DESCRIPTION
## Summary

- Adds a signed-in feedback form to `/help` while keeping the help page public for signed-out visitors.
- Stores private feedback submissions in Supabase with authenticated insert/RLS and server-captured user identity.
- Adds authenticated spam protection, tests, and docs for the new feedback storage/privacy contract.

Closes #29.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- Local `/help` request returned `200 OK` and rendered the signed-out feedback prompt.