### PR TITLE
Reorganize signed-in navigation around singer tasks

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { signOut } from "@/app/auth/actions";
+import { signedInNavigationLinks } from "@/lib/navigation/signed-in-nav";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -40,44 +41,34 @@ export default async function ProtectedAppLayout({
   return (
     <div className="min-h-screen">
       <header className="border-b border-[#d7cec0] bg-[#fffaf2]/90">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <Link className="text-lg font-bold text-[#172023]" href="/app">
-            Quartet Member Finder
-          </Link>
-          <nav aria-label="App navigation" className="flex flex-wrap gap-3">
-            <Link className="text-sm font-semibold text-[#394548]" href="/app">
-              Home
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Link className="text-lg font-bold text-[#172023]" href="/app">
+              Quartet Member Finder
             </Link>
-            <Link
-              className="text-sm font-semibold text-[#394548]"
-              href="/app/profile"
-            >
-              Singer profile
-            </Link>
-            <Link
-              className="text-sm font-semibold text-[#394548]"
-              href="/app/listings"
-            >
-              Quartet listings
-            </Link>
-            <Link className="text-sm font-semibold text-[#394548]" href="/help">
-              Help
-            </Link>
-            <Link
-              className="text-sm font-semibold text-[#394548]"
-              href="/privacy"
-            >
-              Privacy
-            </Link>
+            <form action={signOut}>
+              <button
+                className="w-fit rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
+                type="submit"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+          <nav
+            aria-label="App navigation"
+            className="flex flex-wrap gap-x-4 gap-y-2"
+          >
+            {signedInNavigationLinks.map((link) => (
+              <Link
+                className="text-sm font-semibold text-[#394548] hover:text-[#174b4f]"
+                href={link.href}
+                key={link.href}
+              >
+                {link.label}
+              </Link>
+            ))}
           </nav>
-          <form action={signOut}>
-            <button
-              className="rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
-              type="submit"
-            >
-              Sign out
-            </button>
-          </form>
         </div>
       </header>
       <main className="mx-auto w-full max-w-6xl px-6 py-10">{children}</main>

--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -56,12 +56,7 @@ export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
         <input name="contextPath" type="hidden" value="/help" />
         <label className="hidden">
           Website
-          <input
-            autoComplete="off"
-            name="website"
-            tabIndex={-1}
-            type="text"
-          />
+          <input autoComplete="off" name="website" tabIndex={-1} type="text" />
         </label>
 
         <label className="block">

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -1,0 +1,34 @@
+export const signedInNavigationLinks = [
+  {
+    href: "/app",
+    label: "Home",
+  },
+  {
+    href: "/app/profile",
+    label: "My Singer Profile",
+  },
+  {
+    href: "/quartets",
+    label: "Find Quartet Openings",
+  },
+  {
+    href: "/singers",
+    label: "Find Singers",
+  },
+  {
+    href: "/map",
+    label: "Map",
+  },
+  {
+    href: "/app/listings",
+    label: "Quartet Mode",
+  },
+  {
+    href: "/help",
+    label: "Help",
+  },
+  {
+    href: "/privacy",
+    label: "Privacy",
+  },
+] as const;

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { signedInNavigationLinks } from "@/lib/navigation/signed-in-nav";
+
+describe("signed-in navigation", () => {
+  it("foregrounds singer-first tasks before quartet mode", () => {
+    expect(signedInNavigationLinks.map((link) => link.label)).toEqual([
+      "Home",
+      "My Singer Profile",
+      "Find Quartet Openings",
+      "Find Singers",
+      "Map",
+      "Quartet Mode",
+      "Help",
+      "Privacy",
+    ]);
+  });
+
+  it("keeps existing route targets for the reorganized labels", () => {
+    expect(signedInNavigationLinks).toEqual([
+      { href: "/app", label: "Home" },
+      { href: "/app/profile", label: "My Singer Profile" },
+      { href: "/quartets", label: "Find Quartet Openings" },
+      { href: "/singers", label: "Find Singers" },
+      { href: "/map", label: "Map" },
+      { href: "/app/listings", label: "Quartet Mode" },
+      { href: "/help", label: "Help" },
+      { href: "/privacy", label: "Privacy" },
+    ]);
+  });
+});

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -4,9 +4,7 @@ import { describe, expect, it } from "vitest";
 const migration = readdirSync("supabase/migrations")
   .filter((fileName) => fileName.endsWith(".sql"))
   .sort()
-  .map((fileName) =>
-    readFileSync(`supabase/migrations/${fileName}`, "utf8"),
-  )
+  .map((fileName) => readFileSync(`supabase/migrations/${fileName}`, "utf8"))
   .join("\n\n");
 
 const appTables = [


### PR DESCRIPTION
## Summary

- Reorders signed-in navigation around the singer-first workflow requested in #32.
- Adds discovery links for quartet openings, singers, and map from the signed-in app nav.
- Labels quartet listing management as Quartet Mode and keeps all existing route targets.
- Adds a small nav config test covering labels, order, and routes.
- Applies formatter cleanup needed for `npm run format:check`.

Closes #32.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`