### PR TITLE
Redesign signed-in home as task dashboard

### DIFF
--- a/app/(protected)/app/page.tsx
+++ b/app/(protected)/app/page.tsx
@@ -1,4 +1,32 @@
+import Link from "next/link";
+import {
+  quartetModeDashboardActions,
+  singerDashboardActions,
+  supportDashboardActions,
+  type DashboardAction,
+} from "@/lib/dashboard/app-dashboard";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function DashboardActionList({ actions }: { actions: DashboardAction[] }) {
+  return (
+    <div className="mt-5 grid gap-4 md:grid-cols-2">
+      {actions.map((action) => (
+        <Link
+          className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm hover:border-[#2f6f73]"
+          href={action.href}
+          key={`${action.label}-${action.href}`}
+        >
+          <span className="text-base font-bold text-[#172023]">
+            {action.label}
+          </span>
+          <span className="mt-2 block text-sm leading-6 text-[#394548]">
+            {action.description}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}
 
 export default async function AppHomePage() {
   const supabase = await createSupabaseServerClient();
@@ -7,17 +35,87 @@ export default async function AppHomePage() {
   } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
 
   return (
-    <div>
-      <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-        Signed-in workspace
-      </p>
-      <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-        Welcome{user?.email ? `, ${user.email}` : ""}
-      </h1>
-      <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
-        Manage your singer profile and quartet listings here. Public discovery
-        stays separate from this signed-in management area.
-      </p>
+    <div className="space-y-10">
+      <header>
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Signed-in dashboard
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          What would you like to do
+          {user?.email ? `, ${user.email}` : ""}?
+        </h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-[#394548]">
+          Use the app as a singer, as someone helping an incomplete quartet, or
+          both. Singer profiles help others find you, quartet openings help you
+          find groups looking for missing parts, and first contact starts
+          through the app.
+        </p>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-[#394548]">
+          Discovery uses approximate locations so singers and quartets can judge
+          practical distance without exposing exact home-location details.
+        </p>
+      </header>
+
+      <section aria-labelledby="singer-dashboard-heading">
+        <div className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            As a singer
+          </p>
+          <h2
+            className="mt-3 text-2xl font-bold text-[#172023]"
+            id="singer-dashboard-heading"
+          >
+            Start with your singer workflow
+          </h2>
+          <p className="mt-3 text-base leading-7 text-[#394548]">
+            Build a useful profile, look for quartet openings, connect with
+            other singers, and use the map for privacy-minded regional
+            discovery.
+          </p>
+        </div>
+        <DashboardActionList actions={singerDashboardActions} />
+      </section>
+
+      <section
+        aria-labelledby="quartet-mode-dashboard-heading"
+        className="border-t border-[#d7cec0] pt-8"
+      >
+        <div className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            Quartet Mode
+          </p>
+          <h2
+            className="mt-3 text-2xl font-bold text-[#172023]"
+            id="quartet-mode-dashboard-heading"
+          >
+            Represent an incomplete quartet
+          </h2>
+          <p className="mt-3 text-base leading-7 text-[#394548]">
+            Quartet Mode is for managing a quartet listing and finding singers
+            who may fit the missing part. You can use it alongside your own
+            singer profile.
+          </p>
+        </div>
+        <DashboardActionList actions={quartetModeDashboardActions} />
+      </section>
+
+      <section
+        aria-labelledby="support-dashboard-heading"
+        className="border-t border-[#d7cec0] pt-8"
+      >
+        <div className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            Support
+          </p>
+          <h2
+            className="mt-3 text-2xl font-bold text-[#172023]"
+            id="support-dashboard-heading"
+          >
+            Help and privacy
+          </h2>
+        </div>
+        <DashboardActionList actions={supportDashboardActions} />
+      </section>
     </div>
   );
 }

--- a/lib/dashboard/app-dashboard.ts
+++ b/lib/dashboard/app-dashboard.ts
@@ -1,0 +1,62 @@
+export type DashboardAction = {
+  description: string;
+  href: string;
+  label: string;
+};
+
+export const singerDashboardActions: DashboardAction[] = [
+  {
+    description:
+      "Create or update the profile that helps other singers and quartets understand your parts, goals, availability, and approximate area.",
+    href: "/app/profile",
+    label: "My Singer Profile",
+  },
+  {
+    description:
+      "Browse quartet openings from groups looking for one or more missing parts.",
+    href: "/quartets",
+    label: "Find Quartet Openings",
+  },
+  {
+    description:
+      "Look for other singers nearby or in a region where you are willing to sing.",
+    href: "/singers",
+    label: "Find Singers",
+  },
+  {
+    description:
+      "Scan approximate discovery locations without exposing exact home addresses or private coordinates.",
+    href: "/map",
+    label: "View Map",
+  },
+];
+
+export const quartetModeDashboardActions: DashboardAction[] = [
+  {
+    description:
+      "Create or update the listing for an incomplete quartet, including covered parts, needed parts, goals, and approximate area.",
+    href: "/app/listings",
+    label: "Manage Quartet Listing",
+  },
+  {
+    description:
+      "Search singer profiles when your quartet is ready to contact someone about a missing part.",
+    href: "/singers",
+    label: "Find Singers",
+  },
+];
+
+export const supportDashboardActions: DashboardAction[] = [
+  {
+    description:
+      "Review how profiles, listings, discovery, visibility, and app-mediated contact work.",
+    href: "/help",
+    label: "Help",
+  },
+  {
+    description:
+      "See how approximate location, visibility, and contact privacy are handled.",
+    href: "/privacy",
+    label: "Privacy",
+  },
+];

--- a/test/app-dashboard.test.ts
+++ b/test/app-dashboard.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  quartetModeDashboardActions,
+  singerDashboardActions,
+  supportDashboardActions,
+} from "@/lib/dashboard/app-dashboard";
+
+describe("signed-in app dashboard", () => {
+  it("foregrounds the singer workflow with all primary next actions", () => {
+    expect(singerDashboardActions.map((action) => action.label)).toEqual([
+      "My Singer Profile",
+      "Find Quartet Openings",
+      "Find Singers",
+      "View Map",
+    ]);
+  });
+
+  it("keeps quartet mode separate from the primary singer workflow", () => {
+    expect(quartetModeDashboardActions.map((action) => action.label)).toEqual([
+      "Manage Quartet Listing",
+      "Find Singers",
+    ]);
+  });
+
+  it("links every dashboard action to an existing route", () => {
+    expect([
+      ...singerDashboardActions,
+      ...quartetModeDashboardActions,
+      ...supportDashboardActions,
+    ]).toEqual([
+      expect.objectContaining({ href: "/app/profile" }),
+      expect.objectContaining({ href: "/quartets" }),
+      expect.objectContaining({ href: "/singers" }),
+      expect.objectContaining({ href: "/map" }),
+      expect.objectContaining({ href: "/app/listings" }),
+      expect.objectContaining({ href: "/singers" }),
+      expect.objectContaining({ href: "/help" }),
+      expect.objectContaining({ href: "/privacy" }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the generic signed-in `/app` welcome with a task-oriented dashboard.
- Foregrounds the primary singer workflow with My Singer Profile, Find Quartet Openings, Find Singers, and View Map actions.
- Separates Quartet Mode as a secondary workflow for managing listings and finding singers.
- Adds support links and explanatory copy for approximate locations and app-mediated contact.
- Adds dashboard action tests for labels, structure, and routes.

Closes #33.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`