### PR TITLE
Clarify public discovery language and CTAs

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -23,10 +23,10 @@ export default async function HelpPage({ searchParams }: HelpPageProps) {
           Home
         </Link>
         <Link className="font-semibold text-[#2f6f73]" href="/singers">
-          Singers
+          Find Singers
         </Link>
         <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-          Quartets
+          Find Quartet Openings
         </Link>
         <Link className="font-semibold text-[#2f6f73]" href="/privacy">
           Privacy

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -35,9 +35,9 @@ type MapPageProps = {
 };
 
 const kindOptions = [
-  ["both", "Singers and quartets"],
+  ["both", "Singers and quartet openings"],
   ["singers", "Singers"],
-  ["quartets", "Quartets"],
+  ["quartets", "Quartet openings"],
 ];
 
 const partOptions = [
@@ -216,19 +216,19 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
             Quartet Member Finder
           </Link>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-            Discovery map
+            Discovery Map
           </h1>
           <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Explore visible singer and quartet availability by approximate
-            public region.
+            Explore visible singers and quartet openings by approximate public
+            region.
           </p>
         </div>
         <div className="flex gap-4">
           <Link className="font-semibold text-[#2f6f73]" href="/singers">
-            Find singers
+            Find Singers
           </Link>
           <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-            Find quartets
+            Find Quartet Openings
           </Link>
           <Link className="font-semibold text-[#2f6f73]" href="/help">
             Help

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,9 @@ import { PRODUCT_NAME, PRODUCT_PROMISE } from "@/lib/app-metadata";
 import Link from "next/link";
 
 const discoveryPaths = [
-  "Singer profiles for quartet opportunities",
-  "Quartet listings for missing parts",
-  "App-mediated introductions before direct contact",
+  "Find Quartet Openings from groups looking for missing parts",
+  "Find Singers for a quartet, pickup group, or local singing circle",
+  "Start with app-mediated contact before sharing direct details",
 ];
 
 export default function Home() {
@@ -20,30 +20,40 @@ export default function Home() {
         <p className="mt-6 max-w-2xl text-lg leading-8 text-[#394548]">
           {PRODUCT_PROMISE}
         </p>
+        <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
+          Start as a singer looking for quartet openings, or use Find Singers
+          when you are helping an incomplete quartet fill a part.
+        </p>
         <div className="mt-8 flex flex-wrap gap-3">
           <Link
             className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
-            href="/singers"
+            href="/quartets"
           >
-            Find singers
+            Find Quartet Openings
           </Link>
           <Link
             className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/quartets"
+            href="/singers"
           >
-            Find quartets
+            Find Singers
           </Link>
           <Link
             className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
             href="/map"
           >
-            View map
+            View Map
           </Link>
           <Link
             className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/sign-in"
+            href="/sign-in?next=%2Fapp%2Fprofile"
           >
-            Sign in
+            My Singer Profile
+          </Link>
+          <Link
+            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+            href="/sign-in?next=%2Fapp%2Flistings"
+          >
+            Quartet Mode
           </Link>
           <Link
             className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -12,10 +12,10 @@ export default function PrivacyPage() {
           Help
         </Link>
         <Link className="font-semibold text-[#2f6f73]" href="/singers">
-          Singers
+          Find Singers
         </Link>
         <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-          Quartets
+          Find Quartet Openings
         </Link>
       </nav>
 

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -159,19 +159,19 @@ export default async function QuartetSearchPage({
             Quartet Member Finder
           </Link>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-            Find quartets
+            Find Quartet Openings
           </h1>
           <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Search visible quartet listings using privacy-safe discovery data.
-            Results show approximate location only.
+            Search visible quartet listings from groups looking for one or more
+            missing parts. Results show approximate location only.
           </p>
         </div>
         <div className="flex gap-4">
           <Link className="font-semibold text-[#2f6f73]" href="/singers">
-            Find singers
+            Find Singers
           </Link>
           <Link className="font-semibold text-[#2f6f73]" href="/map">
-            View map
+            View Map
           </Link>
           <Link className="font-semibold text-[#2f6f73]" href="/help">
             Help
@@ -290,7 +290,7 @@ export default async function QuartetSearchPage({
       <section className="mt-8 grid gap-4">
         {quartets.length === 0 && !errorMessage ? (
           <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
-            No visible quartet listings match these filters yet.
+            No visible quartet openings match these filters yet.
           </p>
         ) : null}
 

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -157,19 +157,20 @@ export default async function SingerSearchPage({
             Quartet Member Finder
           </Link>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-            Find singers
+            Find Singers
           </h1>
           <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Search visible singer profiles using privacy-safe discovery data.
-            Results show approximate location only.
+            Search visible singer profiles for singers who may be open to
+            quartet opportunities, pickup singing, or local connections. Results
+            show approximate location only.
           </p>
         </div>
         <div className="flex gap-4">
           <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-            Find quartets
+            Find Quartet Openings
           </Link>
           <Link className="font-semibold text-[#2f6f73]" href="/map">
-            View map
+            View Map
           </Link>
           <Link className="font-semibold text-[#2f6f73]" href="/help">
             Help

--- a/lib/app-metadata.ts
+++ b/lib/app-metadata.ts
@@ -1,4 +1,4 @@
 export const PRODUCT_NAME = "Quartet Member Finder";
 
 export const PRODUCT_PROMISE =
-  "Find nearby singers and incomplete quartets while keeping personal contact details and exact locations private.";
+  "Find quartet openings and available singers while keeping personal contact details and exact locations private.";

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -22,7 +22,8 @@ export const publicHelpSections = [
   },
   {
     body: [
-      "Search can show visible singers, visible quartet listings, and approximate regional map markers. Filters can use public fields like part, goal, country, region, locality, availability, and travel willingness where that data exists.",
+      "Find Quartet Openings shows visible quartet listings from groups looking for missing parts. Find Singers shows visible singer profiles for both individual singers and quartet representatives.",
+      "Search and map filters can use public fields like part, goal, country, region, locality, availability, and travel willingness where that data exists.",
       "Search results are useful even when a profile is incomplete, but more complete profiles are easier for others to evaluate.",
     ],
     heading: "Search",

--- a/test/app-metadata.test.ts
+++ b/test/app-metadata.test.ts
@@ -8,5 +8,7 @@ describe("app metadata", () => {
 
   it("keeps privacy in the core promise", () => {
     expect(PRODUCT_PROMISE).toContain("private");
+    expect(PRODUCT_PROMISE).toContain("Find quartet openings");
+    expect(PRODUCT_PROMISE).toContain("available singers");
   });
 });

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("public discovery copy", () => {
+  it("makes the singer-first path obvious on the public home page", () => {
+    const homePage = source("app/page.tsx");
+
+    expect(homePage).toContain("Find Quartet Openings");
+    expect(homePage).toContain("Find Singers");
+    expect(homePage).toContain("My Singer Profile");
+    expect(homePage).toContain("Quartet Mode");
+    expect(homePage).toContain("Start as a singer");
+  });
+
+  it("frames quartet discovery as openings for missing parts", () => {
+    const quartetPage = source("app/quartets/page.tsx");
+
+    expect(quartetPage).toContain("Find Quartet Openings");
+    expect(quartetPage).toContain("groups looking for one or more");
+    expect(quartetPage).toContain("No visible quartet openings");
+    expect(quartetPage).not.toContain("Find quartets");
+  });
+
+  it("frames singer discovery as available singer profiles", () => {
+    const singerPage = source("app/singers/page.tsx");
+
+    expect(singerPage).toContain("Find Singers");
+    expect(singerPage).toContain("singers who may be open");
+    expect(singerPage).not.toContain("Find singers");
+  });
+});

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -17,6 +17,8 @@ describe("public help and privacy content", () => {
     expect(helpText).toContain("Singer Profiles");
     expect(helpText).toContain("Quartet Listings");
     expect(helpText).toContain("Search");
+    expect(helpText).toContain("Find Quartet Openings");
+    expect(helpText).toContain("Find Singers");
     expect(helpText).toContain("Location And Privacy");
     expect(helpText).toContain("Contact");
     expect(helpText).toContain("Signed-in users can send private feedback");


### PR DESCRIPTION
## Summary

- Updates public home CTAs and framing around the singer-first path, Find Quartet Openings, Find Singers, My Singer Profile, and Quartet Mode.
- Reframes `/quartets` as quartet openings from groups looking for missing parts.
- Clarifies `/singers` as available singer profile discovery for singers and quartet representatives.
- Updates map/help/privacy public link labels and discovery descriptions to match the new language.
- Adds tests pinning the public discovery copy.

Closes #34.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`