### PR TITLE
Add first-run onboarding around Singer and Quartet modes

### DIFF
--- a/app/(protected)/app/onboarding/actions.ts
+++ b/app/(protected)/app/onboarding/actions.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import {
+  destinationForOnboardingChoice,
+  isValidOnboardingChoice,
+  normalizePostOnboardingPath,
+} from "@/lib/onboarding/app-onboarding";
+import {
+  ensureAccountProfileForOnboarding,
+  type AuthUserForOnboarding,
+} from "@/lib/onboarding/account-onboarding";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+async function authenticatedOnboardingUser() {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirect("/sign-in?next=/app/onboarding");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app/onboarding");
+  }
+
+  return { supabase, user };
+}
+
+export async function completeOnboarding(formData: FormData) {
+  const choiceId = String(formData.get("choice") ?? "");
+
+  if (!isValidOnboardingChoice(choiceId)) {
+    redirect("/app/onboarding?error=Choose%20a%20first%20step.");
+  }
+
+  const { supabase, user } = await authenticatedOnboardingUser();
+  const now = new Date().toISOString();
+  const typedUser: AuthUserForOnboarding = {
+    email: user.email,
+    id: user.id,
+  };
+
+  await ensureAccountProfileForOnboarding(supabase, typedUser);
+
+  const { error } = await supabase
+    .from("account_profiles")
+    .update({
+      onboarding_completed_at: now,
+      onboarding_last_choice: choiceId,
+      onboarding_skipped_at: null,
+    })
+    .eq("user_id", user.id);
+
+  if (error) {
+    redirect("/app/onboarding?error=Unable%20to%20save%20onboarding.");
+  }
+
+  redirect(destinationForOnboardingChoice(choiceId));
+}
+
+export async function skipOnboarding(formData: FormData) {
+  const next = normalizePostOnboardingPath(String(formData.get("next") ?? ""));
+  const { supabase, user } = await authenticatedOnboardingUser();
+  const typedUser: AuthUserForOnboarding = {
+    email: user.email,
+    id: user.id,
+  };
+
+  await ensureAccountProfileForOnboarding(supabase, typedUser);
+
+  const { error } = await supabase
+    .from("account_profiles")
+    .update({
+      onboarding_last_choice: "skipped",
+      onboarding_skipped_at: new Date().toISOString(),
+    })
+    .eq("user_id", user.id);
+
+  if (error) {
+    redirect("/app/onboarding?error=Unable%20to%20skip%20onboarding.");
+  }
+
+  redirect(next);
+}

--- a/app/(protected)/app/onboarding/page.tsx
+++ b/app/(protected)/app/onboarding/page.tsx
@@ -1,0 +1,135 @@
+import { redirect } from "next/navigation";
+import {
+  completeOnboarding,
+  skipOnboarding,
+} from "@/app/(protected)/app/onboarding/actions";
+import { onboardingSections } from "@/lib/onboarding/app-onboarding";
+import {
+  ensureAccountProfileForOnboarding,
+  getOnboardingStatus,
+  onboardingIsDone,
+} from "@/lib/onboarding/account-onboarding";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type OnboardingPageProps = {
+  searchParams: Promise<{
+    error?: string;
+    next?: string;
+  }>;
+};
+
+export default async function OnboardingPage({
+  searchParams,
+}: OnboardingPageProps) {
+  const params = await searchParams;
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirect("/sign-in?next=/app/onboarding");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app/onboarding");
+  }
+
+  await ensureAccountProfileForOnboarding(supabase, {
+    email: user.email,
+    id: user.id,
+  });
+
+  const onboardingStatus = await getOnboardingStatus(supabase, user.id);
+
+  if (onboardingIsDone(onboardingStatus)) {
+    redirect("/app");
+  }
+
+  const next = params.next?.startsWith("/") ? params.next : "/app";
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          First steps
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          What would you like to do first?
+        </h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-[#394548]">
+          You can use Quartet Member Finder as a singer, in Quartet Mode, or
+          both. This only chooses a first step, not a permanent role.
+        </p>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-[#394548]">
+          Exact locations are not shown publicly, location fields are meant for
+          singers outside the United States too, and first contact starts
+          through the app.
+        </p>
+      </header>
+
+      {params.error ? (
+        <p className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {params.error}
+        </p>
+      ) : null}
+
+      <form action={completeOnboarding} className="space-y-8">
+        {onboardingSections.map((section) => (
+          <section
+            className="border-t border-[#d7cec0] pt-6 first:border-t-0 first:pt-0"
+            key={section.heading}
+          >
+            <div className="max-w-3xl">
+              <h2 className="text-2xl font-bold text-[#172023]">
+                {section.heading}
+              </h2>
+              <p className="mt-2 text-base leading-7 text-[#394548]">
+                {section.summary}
+              </p>
+            </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {section.choices.map((choice) => (
+                <label
+                  className="block cursor-pointer rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm has-[:checked]:border-[#2f6f73] has-[:checked]:ring-2 has-[:checked]:ring-[#2f6f73]/20"
+                  key={choice.id}
+                >
+                  <input
+                    className="sr-only"
+                    name="choice"
+                    required
+                    type="radio"
+                    value={choice.id}
+                  />
+                  <span className="text-base font-bold text-[#172023]">
+                    {choice.label}
+                  </span>
+                  <span className="mt-2 block text-sm leading-6 text-[#394548]">
+                    {choice.description}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <div className="flex flex-wrap gap-3 border-t border-[#d7cec0] pt-6">
+          <button
+            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            type="submit"
+          >
+            Continue
+          </button>
+        </div>
+      </form>
+
+      <form action={skipOnboarding}>
+        <input name="next" type="hidden" value={next} />
+        <button className="font-semibold text-[#2f6f73]" type="submit">
+          Skip for now
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { firstSignInDestination } from "@/lib/onboarding/account-onboarding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function redirectWithMessage(
@@ -95,7 +96,15 @@ export async function verifyEmailOtp(formData: FormData) {
     );
   }
 
-  redirect(safeNext);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(safeNext);
+  }
+
+  redirect(await firstSignInDestination(supabase, user, safeNext));
 }
 
 export async function signOut() {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { firstSignInDestination } from "@/lib/onboarding/account-onboarding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export async function GET(request: NextRequest) {
@@ -13,8 +14,15 @@ export async function GET(request: NextRequest) {
       ? await supabase.auth.exchangeCodeForSession(code)
       : { error: new Error("Supabase Auth is not configured.") };
 
-    if (!error) {
-      return NextResponse.redirect(new URL(safeNext, requestUrl.origin));
+    if (!error && supabase) {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      const destination = user
+        ? await firstSignInDestination(supabase, user, safeNext)
+        : safeNext;
+
+      return NextResponse.redirect(new URL(destination, requestUrl.origin));
     }
   }
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -181,6 +181,21 @@ views, search results, maps, or public profile/listing UI. Regular authenticated
 users cannot read other users' feedback. Admin/service-role access is required
 for cross-user review or triage.
 
+## Onboarding model
+
+First-run onboarding asks signed-in users what they want to do first, not what
+role they permanently are. A user may use the app as a singer and in Quartet
+Mode.
+
+Onboarding state is stored on the user's private `account_profiles` row. The app
+records whether onboarding was completed or skipped and, when completed, the
+selected first action. This state is used only to avoid showing first-run
+onboarding repeatedly and to route the user to a useful next step.
+
+The onboarding copy reminds users that exact locations are not shown publicly,
+location fields should work outside the United States, and first contact starts
+through the app.
+
 ## Abuse and safety considerations
 
 Future work may include:

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -40,6 +40,8 @@ Baritone, and Bass unless the product explicitly adds alternate naming later.
 ## Ownership model
 
 An `account_profiles` row belongs to one authenticated user by `user_id`.
+It also stores first-run onboarding completion/skipped state so new users can be
+guided to a first action after sign-in without choosing a permanent role.
 
 A `singer_profiles` row belongs to one authenticated user by `user_id`. The
 initial schema enforces one singer profile per user.
@@ -60,6 +62,16 @@ ownership boundary in the database.
 Users can read and update their own private base-table rows.
 
 Public discovery should use the discovery views, not the base tables.
+
+First-run onboarding writes these `account_profiles` fields:
+
+- `onboarding_completed_at`
+- `onboarding_skipped_at`
+- `onboarding_last_choice`
+
+The server creates the account profile row after sign-in when needed. If neither
+completion nor skipped state is present, sign-in routes the user through
+`/app/onboarding` before continuing to the requested app destination.
 
 The public discovery routes are:
 

--- a/lib/onboarding/account-onboarding.ts
+++ b/lib/onboarding/account-onboarding.ts
@@ -1,0 +1,85 @@
+import { normalizePostOnboardingPath } from "@/lib/onboarding/app-onboarding";
+
+type SupabaseLike = {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (
+        column: string,
+        value: string,
+      ) => {
+        maybeSingle: () => PromiseLike<{
+          data: AccountProfileOnboardingRow | null;
+          error: unknown;
+        }>;
+      };
+    };
+    upsert: (
+      values: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => PromiseLike<{ error: unknown }>;
+  };
+};
+
+export type AuthUserForOnboarding = {
+  email?: string | null;
+  id: string;
+};
+
+export type AccountProfileOnboardingRow = {
+  onboarding_completed_at: string | null;
+  onboarding_skipped_at: string | null;
+};
+
+export function displayNameFromUser(user: AuthUserForOnboarding) {
+  const emailName = user.email?.split("@")[0]?.trim();
+
+  return (emailName || "Quartet Member Finder user").slice(0, 120);
+}
+
+export function onboardingIsDone(row: AccountProfileOnboardingRow | null) {
+  return Boolean(row?.onboarding_completed_at || row?.onboarding_skipped_at);
+}
+
+export async function ensureAccountProfileForOnboarding(
+  supabase: unknown,
+  user: AuthUserForOnboarding,
+) {
+  const client = supabase as SupabaseLike;
+
+  await client.from("account_profiles").upsert(
+    {
+      display_name: displayNameFromUser(user),
+      user_id: user.id,
+    },
+    { ignoreDuplicates: true, onConflict: "user_id" },
+  );
+}
+
+export async function getOnboardingStatus(supabase: unknown, userId: string) {
+  const client = supabase as SupabaseLike;
+  const { data } = await client
+    .from("account_profiles")
+    .select("onboarding_completed_at, onboarding_skipped_at")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  return data;
+}
+
+export async function firstSignInDestination(
+  supabase: unknown,
+  user: AuthUserForOnboarding,
+  requestedNext: string,
+) {
+  const safeNext = normalizePostOnboardingPath(requestedNext);
+
+  await ensureAccountProfileForOnboarding(supabase, user);
+
+  const onboardingStatus = await getOnboardingStatus(supabase, user.id);
+
+  if (onboardingIsDone(onboardingStatus)) {
+    return safeNext;
+  }
+
+  return `/app/onboarding?next=${encodeURIComponent(safeNext)}`;
+}

--- a/lib/onboarding/app-onboarding.ts
+++ b/lib/onboarding/app-onboarding.ts
@@ -1,0 +1,111 @@
+export type OnboardingChoice = {
+  description: string;
+  href: string;
+  id: string;
+  label: string;
+};
+
+export type OnboardingSection = {
+  choices: OnboardingChoice[];
+  heading: string;
+  summary: string;
+};
+
+export const onboardingSections: OnboardingSection[] = [
+  {
+    choices: [
+      {
+        description:
+          "Set up the profile that helps others discover your parts, goals, availability, and approximate area.",
+        href: "/app/profile",
+        id: "my-singer-profile",
+        label: "My Singer Profile",
+      },
+      {
+        description:
+          "Browse quartet openings from groups looking for one or more missing parts.",
+        href: "/quartets",
+        id: "find-quartet-openings",
+        label: "Find Quartet Openings",
+      },
+      {
+        description:
+          "Look for singers nearby or in another region where you are willing to sing.",
+        href: "/singers",
+        id: "find-singers-as-singer",
+        label: "Find Singers",
+      },
+    ],
+    heading: "As a singer",
+    summary:
+      "Start with your own singer profile, or look for quartet openings and other singers.",
+  },
+  {
+    choices: [
+      {
+        description:
+          "Create or update a quartet listing with covered parts, missing parts, goals, and approximate area.",
+        href: "/app/listings",
+        id: "quartet-mode-listing",
+        label: "Create or edit a quartet listing",
+      },
+      {
+        description:
+          "Search singer profiles when your quartet is ready to contact someone about a missing part.",
+        href: "/singers",
+        id: "quartet-mode-find-singers",
+        label: "Find singers for a quartet",
+      },
+    ],
+    heading: "Quartet Mode",
+    summary:
+      "Use Quartet Mode when you are representing an incomplete quartet looking for singers.",
+  },
+  {
+    choices: [
+      {
+        description:
+          "Go to the signed-in dashboard and browse the main actions from there.",
+        href: "/app",
+        id: "browse-for-now",
+        label: "Just browse/search for now",
+      },
+      {
+        description:
+          "Read the plain-language help and privacy pages before adding profile or listing details.",
+        href: "/help",
+        id: "read-help-privacy",
+        label: "Read Help / Privacy",
+      },
+    ],
+    heading: "Other",
+    summary:
+      "You can skip setup decisions for now, read how privacy works, and come back later. Location fields are meant to work outside the United States too.",
+  },
+];
+
+export const onboardingChoices = onboardingSections.flatMap(
+  (section) => section.choices,
+);
+
+export function destinationForOnboardingChoice(choiceId: string | null) {
+  return (
+    onboardingChoices.find((choice) => choice.id === choiceId)?.href ?? "/app"
+  );
+}
+
+export function isValidOnboardingChoice(choiceId: string | null) {
+  return onboardingChoices.some((choice) => choice.id === choiceId);
+}
+
+export function normalizePostOnboardingPath(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/app";
+  }
+
+  if (value === "/app/onboarding") {
+    return "/app";
+  }
+
+  return value;
+}

--- a/supabase/migrations/20260430190000_account_onboarding.sql
+++ b/supabase/migrations/20260430190000_account_onboarding.sql
@@ -1,0 +1,16 @@
+alter table public.account_profiles
+add column onboarding_completed_at timestamptz,
+add column onboarding_skipped_at timestamptz,
+add column onboarding_last_choice text check (
+  onboarding_last_choice is null
+  or onboarding_last_choice in (
+    'my-singer-profile',
+    'find-quartet-openings',
+    'find-singers-as-singer',
+    'quartet-mode-listing',
+    'quartet-mode-find-singers',
+    'browse-for-now',
+    'read-help-privacy',
+    'skipped'
+  )
+);

--- a/test/app-onboarding.test.ts
+++ b/test/app-onboarding.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  destinationForOnboardingChoice,
+  isValidOnboardingChoice,
+  normalizePostOnboardingPath,
+  onboardingChoices,
+  onboardingSections,
+} from "@/lib/onboarding/app-onboarding";
+import {
+  displayNameFromUser,
+  onboardingIsDone,
+} from "@/lib/onboarding/account-onboarding";
+
+describe("first-run onboarding", () => {
+  it("uses the requested Singer and Quartet Mode language", () => {
+    const text = JSON.stringify(onboardingSections);
+
+    expect(text).toContain("My Singer Profile");
+    expect(text).toContain("Find Quartet Openings");
+    expect(text).toContain("Find Singers");
+    expect(text).toContain("Quartet Mode");
+    expect(text).toContain("outside the United States");
+  });
+
+  it("routes each first action to the expected destination", () => {
+    expect(destinationForOnboardingChoice("my-singer-profile")).toBe(
+      "/app/profile",
+    );
+    expect(destinationForOnboardingChoice("find-quartet-openings")).toBe(
+      "/quartets",
+    );
+    expect(destinationForOnboardingChoice("quartet-mode-listing")).toBe(
+      "/app/listings",
+    );
+    expect(destinationForOnboardingChoice("read-help-privacy")).toBe("/help");
+    expect(destinationForOnboardingChoice("unknown")).toBe("/app");
+  });
+
+  it("validates choices and post-onboarding paths", () => {
+    expect(onboardingChoices.length).toBe(7);
+    expect(isValidOnboardingChoice("find-singers-as-singer")).toBe(true);
+    expect(isValidOnboardingChoice("skipped")).toBe(false);
+    expect(normalizePostOnboardingPath("/app/profile")).toBe("/app/profile");
+    expect(normalizePostOnboardingPath("/app/onboarding")).toBe("/app");
+    expect(normalizePostOnboardingPath("https://example.com")).toBe("/app");
+    expect(normalizePostOnboardingPath("//example.com")).toBe("/app");
+  });
+
+  it("normalizes account profile display and done state", () => {
+    expect(
+      displayNameFromUser({
+        email: "lead@example.com",
+        id: "user-1",
+      }),
+    ).toBe("lead");
+    expect(displayNameFromUser({ id: "user-1" })).toBe(
+      "Quartet Member Finder user",
+    );
+    expect(
+      displayNameFromUser({
+        email: `${"a".repeat(140)}@example.com`,
+        id: "user-1",
+      }),
+    ).toHaveLength(120);
+    expect(onboardingIsDone(null)).toBe(false);
+    expect(
+      onboardingIsDone({
+        onboarding_completed_at: "2026-04-30T12:00:00.000Z",
+        onboarding_skipped_at: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -49,6 +49,14 @@ describe("initial Supabase schema migration", () => {
     }
   });
 
+  it("stores first-run onboarding state on private account profiles", () => {
+    expect(migration).toContain("add column onboarding_completed_at");
+    expect(migration).toContain("add column onboarding_skipped_at");
+    expect(migration).toContain("add column onboarding_last_choice");
+    expect(migration).toContain("'find-quartet-openings'");
+    expect(migration).toContain("'quartet-mode-listing'");
+  });
+
   it("keeps private fields out of discovery views", () => {
     const privateFieldPattern =
       /user_id|owner_user_id|recipient_user_id|postal_code_private|formatted_address_private|latitude_private|longitude_private/i;


### PR DESCRIPTION
## Summary

- Adds `/app/onboarding` as a first-run flow after successful sign-in for users who have not completed or skipped onboarding.
- Lets users choose a first action across As a singer, Quartet Mode, and Other without forcing a permanent role.
- Persists completed/skipped onboarding state on the private `account_profiles` row.
- Routes selected first actions to My Singer Profile, Find Quartet Openings, Find Singers, Quartet Mode listing management, dashboard, or Help.
- Updates Supabase/privacy docs and tests for onboarding state and copy.

Closes #27.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`