### PR TITLE
Improve empty states and first-time guidance

### DIFF
--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   BARBERSHOP_PARTS,
   PROFILE_GOALS,
@@ -121,6 +122,36 @@ export default async function ManageListingsPage({
           {params.message}
         </p>
       ) : null}
+
+      {!listing ? (
+        <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">
+            Start Quartet Mode
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Quartet Mode is for a quartet or prospective quartet looking for
+            singers. Create a listing with covered parts, missing parts, and an
+            approximate location so singers can judge whether it might fit.
+          </p>
+          <Link
+            className="mt-4 inline-flex font-semibold text-[#2f6f73]"
+            href="/singers"
+          >
+            Browse Find Singers first
+          </Link>
+        </section>
+      ) : listing.is_visible ? null : (
+        <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">
+            This quartet listing is hidden
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Hidden listings do not appear in Find Quartet Openings or on the
+            map, so singers cannot discover them yet. Turn on visibility below
+            when the listing is ready.
+          </p>
+        </section>
+      )}
 
       <form action={saveQuartetListing} className="mt-8 max-w-3xl space-y-8">
         <input name="listingId" type="hidden" value={fieldValue(listing?.id)} />

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   BARBERSHOP_PARTS,
   PROFILE_GOALS,
@@ -113,6 +114,36 @@ export default async function ManageProfilePage({
           {params.message}
         </p>
       ) : null}
+
+      {!profile ? (
+        <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">
+            Create My Singer Profile
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            A singer profile helps quartet openings and other singers find you.
+            Start with your parts, goals, and approximate location; you can keep
+            it hidden until you are ready.
+          </p>
+          <Link
+            className="mt-4 inline-flex font-semibold text-[#2f6f73]"
+            href="/quartets"
+          >
+            Browse Find Quartet Openings first
+          </Link>
+        </section>
+      ) : profile.is_visible ? null : (
+        <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">
+            Your profile is hidden
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Hidden profiles do not appear in Find Singers or on the map. Turn on
+            the visibility checkbox below when you want discovery to show your
+            public singer details.
+          </p>
+        </section>
+      )}
 
       <form action={saveSingerProfile} className="mt-8 max-w-3xl space-y-8">
         <section className="space-y-4">

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -75,8 +75,9 @@ export default async function HelpPage({ searchParams }: HelpPageProps) {
             Send feedback after signing in
           </h2>
           <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Signed-in users can send private feedback, bug reports, and
-            suggestions from this page.
+            Sign in if you want to send private feedback, bug reports, or
+            suggestions. Keeping feedback tied to an account helps prevent spam
+            and gives the project team a way to follow up.
           </p>
           <Link
             className="mt-4 inline-flex rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -356,9 +356,27 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
 
       <section className="mt-8 grid gap-4 md:grid-cols-2">
         {markers.length === 0 && !errorMessage ? (
-          <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548] md:col-span-2">
-            No visible public locations match these filters yet.
-          </p>
+          <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548] md:col-span-2">
+            <h2 className="text-xl font-bold text-[#172023]">
+              No approximate map regions match these filters yet
+            </h2>
+            <p className="mt-3 text-sm leading-6">
+              The map only shows visible singer profiles and quartet openings
+              with approximate public location data. Try clearing filters or
+              searching Find Singers and Find Quartet Openings directly.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-4">
+              <Link className="font-semibold text-[#2f6f73]" href="/map">
+                Clear filters
+              </Link>
+              <Link className="font-semibold text-[#2f6f73]" href="/singers">
+                Find Singers
+              </Link>
+              <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+                Find Quartet Openings
+              </Link>
+            </div>
+          </section>
         ) : null}
 
         {markers.map((marker) => (

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -289,9 +289,27 @@ export default async function QuartetSearchPage({
 
       <section className="mt-8 grid gap-4">
         {quartets.length === 0 && !errorMessage ? (
-          <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
-            No visible quartet openings match these filters yet.
-          </p>
+          <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+            <h2 className="text-xl font-bold text-[#172023]">
+              No visible quartet openings match these filters yet
+            </h2>
+            <p className="mt-3 text-sm leading-6">
+              Try clearing filters, widening the country/region/locality, or
+              checking the map. Some quartets may not have turned on discovery
+              for their Quartet Mode listing yet.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-4">
+              <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+                Clear filters
+              </Link>
+              <Link className="font-semibold text-[#2f6f73]" href="/map">
+                View Map
+              </Link>
+              <Link className="font-semibold text-[#2f6f73]" href="/singers">
+                Find Singers
+              </Link>
+            </div>
+          </section>
         ) : null}
 
         {quartets.map((quartet) => (

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -288,9 +288,27 @@ export default async function SingerSearchPage({
 
       <section className="mt-8 grid gap-4">
         {singers.length === 0 && !errorMessage ? (
-          <p className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
-            No visible singer profiles match these filters yet.
-          </p>
+          <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+            <h2 className="text-xl font-bold text-[#172023]">
+              No visible singer profiles match these filters yet
+            </h2>
+            <p className="mt-3 text-sm leading-6">
+              Try clearing filters, widening the country/region/locality, or
+              checking the map. Early on, some singers may still be creating My
+              Singer Profile or keeping it hidden.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-4">
+              <Link className="font-semibold text-[#2f6f73]" href="/singers">
+                Clear filters
+              </Link>
+              <Link className="font-semibold text-[#2f6f73]" href="/map">
+                View Map
+              </Link>
+              <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+                Find Quartet Openings
+              </Link>
+            </div>
+          </section>
         ) : null}
 
         {singers.map((singer) => (

--- a/components/contact/contact-request-form.tsx
+++ b/components/contact/contact-request-form.tsx
@@ -22,6 +22,11 @@ export function ContactRequestForm({
       <input name="returnTo" type="hidden" value={returnTo} />
       <input name="targetId" type="hidden" value={targetId} />
       <input name="targetKind" type="hidden" value={targetKind} />
+      <p className="mb-3 text-sm leading-6 text-[#394548]">
+        Contact starts through the app so personal email addresses and phone
+        numbers stay private until both people choose to share them. You will be
+        asked to sign in if you are not already signed in.
+      </p>
       <label className="block">
         <span className="text-sm font-semibold text-[#172023]">
           Contact {targetName}

--- a/test/empty-states.test.ts
+++ b/test/empty-states.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("empty and first-time states", () => {
+  it("guides first-time signed-in users from profile and Quartet Mode forms", () => {
+    const profilePage = source("app/(protected)/app/profile/page.tsx");
+    const listingPage = source("app/(protected)/app/listings/page.tsx");
+
+    expect(profilePage).toContain("Create My Singer Profile");
+    expect(profilePage).toContain("Your profile is hidden");
+    expect(profilePage).toContain("Find Singers");
+    expect(listingPage).toContain("Start Quartet Mode");
+    expect(listingPage).toContain("This quartet listing is hidden");
+    expect(listingPage).toContain("Find Quartet Openings");
+  });
+
+  it("turns public discovery no-results states into next actions", () => {
+    const singersPage = source("app/singers/page.tsx");
+    const quartetsPage = source("app/quartets/page.tsx");
+    const mapPage = source("app/map/page.tsx");
+
+    expect(singersPage).toContain("No visible singer profiles match");
+    expect(singersPage).toContain("Clear filters");
+    expect(quartetsPage).toContain("No visible quartet openings match");
+    expect(quartetsPage).toContain("Quartet Mode listing");
+    expect(mapPage).toContain("No approximate map regions match");
+    expect(mapPage).toContain("approximate public location data");
+  });
+
+  it("explains sign-in for contact and feedback without exposing private data", () => {
+    const contactForm = source("components/contact/contact-request-form.tsx");
+    const helpPage = source("app/help/page.tsx");
+
+    expect(contactForm).toContain("Contact starts through the app");
+    expect(contactForm).toContain("personal email addresses and phone");
+    expect(contactForm).toContain("asked to sign in");
+    expect(helpPage).toContain("Sign in if you want to send private feedback");
+    expect(helpPage).toContain("prevent spam");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds first-time and hidden-state guidance to My Singer Profile and Quartet Mode management pages.
- Turns Find Singers, Find Quartet Openings, and Map no-results states into useful next-action panels.
- Clarifies app-mediated contact and signed-out feedback guidance.
- Adds tests to pin the empty-state and first-time copy.

Closes #38.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`