### PR TITLE
Add basic account settings page

### DIFF
--- a/app/(protected)/app/settings/actions.ts
+++ b/app/(protected)/app/settings/actions.ts
@@ -1,0 +1,72 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import {
+  isAccountDistanceUnit,
+  normalizeAccountDistanceUnit,
+} from "@/lib/settings/account-settings";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function redirectWithSettingsStatus(
+  status: "error" | "onboarding-reset" | "saved",
+): never {
+  redirect(`/app/settings?settings=${status}`);
+}
+
+async function getSettingsUser() {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirect("/sign-in?next=/app/settings");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app/settings");
+  }
+
+  return { supabase, user };
+}
+
+export async function saveAccountSettings(formData: FormData) {
+  const preferredDistanceUnit = normalizeAccountDistanceUnit(
+    String(formData.get("preferredDistanceUnit") ?? ""),
+  );
+
+  if (!isAccountDistanceUnit(preferredDistanceUnit)) {
+    redirectWithSettingsStatus("error");
+  }
+
+  const { supabase, user } = await getSettingsUser();
+  const { error } = await supabase
+    .from("account_profiles")
+    .update({ preferred_distance_unit: preferredDistanceUnit })
+    .eq("user_id", user.id);
+
+  if (error) {
+    redirectWithSettingsStatus("error");
+  }
+
+  redirectWithSettingsStatus("saved");
+}
+
+export async function resetOnboarding() {
+  const { supabase, user } = await getSettingsUser();
+  const { error } = await supabase
+    .from("account_profiles")
+    .update({
+      onboarding_completed_at: null,
+      onboarding_last_choice: null,
+      onboarding_skipped_at: null,
+    })
+    .eq("user_id", user.id);
+
+  if (error) {
+    redirectWithSettingsStatus("error");
+  }
+
+  redirect("/app/onboarding?next=%2Fapp%2Fsettings");
+}

--- a/app/(protected)/app/settings/page.tsx
+++ b/app/(protected)/app/settings/page.tsx
@@ -1,0 +1,177 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import {
+  resetOnboarding,
+  saveAccountSettings,
+} from "@/app/(protected)/app/settings/actions";
+import {
+  accountDistanceUnitOptions,
+  normalizeAccountDistanceUnit,
+} from "@/lib/settings/account-settings";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type AccountSettingsRow = {
+  display_name: string;
+  onboarding_completed_at: string | null;
+  onboarding_skipped_at: string | null;
+  preferred_distance_unit: string | null;
+};
+
+type AccountSettingsPageProps = {
+  searchParams: Promise<{
+    settings?: string;
+  }>;
+};
+
+function statusMessage(status?: string) {
+  if (status === "saved") {
+    return "Account settings saved.";
+  }
+
+  if (status === "error") {
+    return "Account settings could not be saved. Please try again.";
+  }
+
+  return null;
+}
+
+export default async function AccountSettingsPage({
+  searchParams,
+}: AccountSettingsPageProps) {
+  const params = await searchParams;
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirect("/sign-in?next=/app/settings");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in?next=/app/settings");
+  }
+
+  const { data: accountProfile } = await supabase
+    .from("account_profiles")
+    .select(
+      "display_name, onboarding_completed_at, onboarding_skipped_at, preferred_distance_unit",
+    )
+    .eq("user_id", user.id)
+    .maybeSingle<AccountSettingsRow>();
+  const message = statusMessage(params.settings);
+  const preferredDistanceUnit = normalizeAccountDistanceUnit(
+    accountProfile?.preferred_distance_unit ?? null,
+  );
+  const onboardingState = accountProfile?.onboarding_completed_at
+    ? "completed"
+    : accountProfile?.onboarding_skipped_at
+      ? "skipped"
+      : "not completed";
+
+  return (
+    <div className="space-y-8">
+      <header className="max-w-3xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Account Settings
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          Account preferences
+        </h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          Account Settings are for app-level preferences and account actions. My
+          Singer Profile controls how you appear in discovery; Quartet Mode
+          controls a quartet opening.
+        </p>
+      </header>
+
+      {message ? (
+        <p
+          className={`max-w-3xl rounded-lg border p-4 text-sm ${
+            params.settings === "error"
+              ? "border-red-200 bg-red-50 text-red-800"
+              : "border-[#b7d7ce] bg-[#eef8f4] text-[#174b4f]"
+          }`}
+        >
+          {message}
+        </p>
+      ) : null}
+
+      <section className="max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+        <h2 className="text-xl font-bold text-[#172023]">Preferences</h2>
+        <form action={saveAccountSettings} className="mt-4 grid gap-4">
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Preferred distance unit
+            </span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={preferredDistanceUnit}
+              name="preferredDistanceUnit"
+            >
+              {accountDistanceUnitOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <p className="text-sm leading-6 text-[#394548]">
+            This account-level preference is saved for future distance displays.
+            Singer profiles and quartet listings still keep their own distance
+            settings for discovery details.
+          </p>
+          <button
+            className="w-fit rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            type="submit"
+          >
+            Save settings
+          </button>
+        </form>
+      </section>
+
+      <section className="max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+        <h2 className="text-xl font-bold text-[#172023]">Onboarding</h2>
+        <p className="mt-3 text-sm leading-6 text-[#394548]">
+          Current onboarding state: {onboardingState}. Reset onboarding if you
+          want to see the first-run choices again.
+        </p>
+        <form action={resetOnboarding} className="mt-4">
+          <button
+            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-white"
+            type="submit"
+          >
+            Re-run onboarding
+          </button>
+        </form>
+      </section>
+
+      <section className="max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+        <h2 className="text-xl font-bold text-[#172023]">Support</h2>
+        <div className="mt-4 flex flex-wrap gap-4">
+          <Link className="font-semibold text-[#2f6f73]" href="/help">
+            Help
+          </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/privacy">
+            Privacy
+          </Link>
+          <Link className="font-semibold text-[#2f6f73]" href="/help#feedback">
+            Feedback
+          </Link>
+        </div>
+      </section>
+
+      <section className="max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+        <h2 className="text-xl font-bold text-[#172023]">
+          Future account actions
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-[#394548]">
+          Account export, deactivation, and deletion are not available yet.
+          Those actions will need clear privacy and data-retention rules before
+          they are added.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -67,7 +67,7 @@ export default async function HelpPage({ searchParams }: HelpPageProps) {
       {user ? (
         <HelpFeedbackForm status={params.feedback} />
       ) : (
-        <section className="mt-10 border-t border-[#d7cec0] pt-8">
+        <section className="mt-10 border-t border-[#d7cec0] pt-8" id="feedback">
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
             Feedback
           </p>

--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -26,7 +26,7 @@ export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
   const isSuccess = status === "sent";
 
   return (
-    <section className="mt-10 border-t border-[#d7cec0] pt-8">
+    <section className="mt-10 border-t border-[#d7cec0] pt-8" id="feedback">
       <div>
         <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
           Feedback

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -196,6 +196,17 @@ The onboarding copy reminds users that exact locations are not shown publicly,
 location fields should work outside the United States, and first contact starts
 through the app.
 
+## Account settings model
+
+Account Settings are separate from My Singer Profile and Quartet Mode. They are
+for app-level preferences and account-level actions that should not change
+public discovery content by accident.
+
+The initial settings page lets a signed-in user save an account-level preferred
+distance unit and reset first-run onboarding. Future export, deactivation, and
+delete actions are shown only as placeholders until the product has clear
+privacy and data-retention behavior for them.
+
 ## Abuse and safety considerations
 
 Future work may include:

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -42,6 +42,8 @@ Baritone, and Bass unless the product explicitly adds alternate naming later.
 An `account_profiles` row belongs to one authenticated user by `user_id`.
 It also stores first-run onboarding completion/skipped state so new users can be
 guided to a first action after sign-in without choosing a permanent role.
+Account-level preferences that do not belong to My Singer Profile or Quartet
+Mode also live here, including `preferred_distance_unit`.
 
 A `singer_profiles` row belongs to one authenticated user by `user_id`. The
 initial schema enforces one singer profile per user.
@@ -72,6 +74,11 @@ First-run onboarding writes these `account_profiles` fields:
 The server creates the account profile row after sign-in when needed. If neither
 completion nor skipped state is present, sign-in routes the user through
 `/app/onboarding` before continuing to the requested app destination.
+
+Account Settings at `/app/settings` writes `preferred_distance_unit` on
+`account_profiles`. This is an app/account preference for future distance
+displays. Singer profiles and quartet listings keep their own
+`preferred_distance_unit` values for discovery rows.
 
 The public discovery routes are:
 

--- a/lib/dashboard/app-dashboard.ts
+++ b/lib/dashboard/app-dashboard.ts
@@ -49,6 +49,12 @@ export const quartetModeDashboardActions: DashboardAction[] = [
 export const supportDashboardActions: DashboardAction[] = [
   {
     description:
+      "Review account-level preferences, re-run onboarding, and find future account-management placeholders.",
+    href: "/app/settings",
+    label: "Account Settings",
+  },
+  {
+    description:
       "Review how profiles, listings, discovery, visibility, and app-mediated contact work.",
     href: "/help",
     label: "Help",

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -24,6 +24,10 @@ export const signedInNavigationLinks = [
     label: "Quartet Mode",
   },
   {
+    href: "/app/settings",
+    label: "Account Settings",
+  },
+  {
     href: "/help",
     label: "Help",
   },

--- a/lib/settings/account-settings.ts
+++ b/lib/settings/account-settings.ts
@@ -1,0 +1,23 @@
+export const accountDistanceUnitOptions = [
+  {
+    label: "Kilometers",
+    value: "km",
+  },
+  {
+    label: "Miles",
+    value: "mi",
+  },
+] as const;
+
+export type AccountDistanceUnit =
+  (typeof accountDistanceUnitOptions)[number]["value"];
+
+export function isAccountDistanceUnit(
+  value: string,
+): value is AccountDistanceUnit {
+  return value === "km" || value === "mi";
+}
+
+export function normalizeAccountDistanceUnit(value: string | null) {
+  return value && isAccountDistanceUnit(value) ? value : "km";
+}

--- a/supabase/migrations/20260430200000_account_settings.sql
+++ b/supabase/migrations/20260430200000_account_settings.sql
@@ -1,0 +1,2 @@
+alter table public.account_profiles
+add column preferred_distance_unit public.distance_unit not null default 'km';

--- a/test/account-settings.test.ts
+++ b/test/account-settings.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  accountDistanceUnitOptions,
+  normalizeAccountDistanceUnit,
+} from "@/lib/settings/account-settings";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("account settings", () => {
+  it("supports account-level distance unit preferences", () => {
+    expect(accountDistanceUnitOptions).toEqual([
+      { label: "Kilometers", value: "km" },
+      { label: "Miles", value: "mi" },
+    ]);
+    expect(normalizeAccountDistanceUnit("mi")).toBe("mi");
+    expect(normalizeAccountDistanceUnit("yards")).toBe("km");
+  });
+
+  it("keeps settings distinct from singer profile and Quartet Mode", () => {
+    const page = source("app/(protected)/app/settings/page.tsx");
+
+    expect(page).toContain("Account Settings");
+    expect(page).toMatch(/My\s+Singer Profile/);
+    expect(page).toContain("controls how you appear in discovery");
+    expect(page).toContain("Quartet Mode");
+    expect(page).toContain("Re-run onboarding");
+    expect(page).toContain("not available yet");
+  });
+
+  it("stores account settings on account profiles", () => {
+    const migration = source(
+      "supabase/migrations/20260430200000_account_settings.sql",
+    );
+
+    expect(migration).toContain("alter table public.account_profiles");
+    expect(migration).toContain("preferred_distance_unit public.distance_unit");
+  });
+});

--- a/test/app-dashboard.test.ts
+++ b/test/app-dashboard.test.ts
@@ -34,6 +34,7 @@ describe("signed-in app dashboard", () => {
       expect.objectContaining({ href: "/map" }),
       expect.objectContaining({ href: "/app/listings" }),
       expect.objectContaining({ href: "/singers" }),
+      expect.objectContaining({ href: "/app/settings" }),
       expect.objectContaining({ href: "/help" }),
       expect.objectContaining({ href: "/privacy" }),
     ]);

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -10,6 +10,7 @@ describe("signed-in navigation", () => {
       "Find Singers",
       "Map",
       "Quartet Mode",
+      "Account Settings",
       "Help",
       "Privacy",
     ]);
@@ -23,6 +24,7 @@ describe("signed-in navigation", () => {
       { href: "/singers", label: "Find Singers" },
       { href: "/map", label: "Map" },
       { href: "/app/listings", label: "Quartet Mode" },
+      { href: "/app/settings", label: "Account Settings" },
       { href: "/help", label: "Help" },
       { href: "/privacy", label: "Privacy" },
     ]);


### PR DESCRIPTION
Closes #41.

## Summary
- Add a signed-in `/app/settings` page for account-level settings and support links.
- Store account-level preferred distance unit on `account_profiles` via migration.
- Add an onboarding reset/re-run action that clears onboarding state and sends users back through onboarding.
- Link Account Settings from signed-in navigation and the dashboard support area.
- Document the new account-level setting and privacy boundaries.

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`