### PR TITLE
Expand core logic test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ npm run build
 Copy `.env.example` to `.env.local` when configuring local services. Keep real
 secrets out of source control.
 
+Testing expectations and the current unit-test structure are documented in
+`docs/testing.md`.
+
 ## Early project notes
 
 Project context, privacy expectations, workflow rules, and implementation

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,35 @@
+# Testing
+
+Unit tests live in `test/` and are grouped by the core logic they protect:
+
+- `*-form.test.ts` covers singer profile and quartet listing normalization.
+- `approximate-location.test.ts` covers privacy-safe location summaries, global
+  distance calculations, and miles/kilometers display.
+- `discovery-filters.test.ts` covers public search filter parsing.
+- `contact-relay.test.ts` covers app-mediated contact request parsing,
+  return-path safety, notification copy, and rate-limit constants.
+- `supabase-schema.test.ts` covers migration-level RLS and discovery-view
+  privacy expectations.
+
+New PRs that add or change reusable app logic should add or update unit tests in
+the matching file. Add a new domain-specific test file when a helper does not
+fit an existing area.
+
+Run the unit suite with:
+
+```bash
+npm run test:run
+```
+
+Before finishing a PR, also run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Location, search, and distance tests should include non-US examples whenever the
+helper behavior touches geography, distance units, or public location display.
+Privacy-sensitive tests should assert that public helpers do not expose private
+postal codes, exact coordinates, email addresses, or phone numbers.

--- a/test/approximate-location.test.ts
+++ b/test/approximate-location.test.ts
@@ -30,7 +30,7 @@ describe("approximate location helpers", () => {
     const publicLocation = toPublicLocationSummary({
       countryName: "United Kingdom",
       locality: "Manchester",
-      locationLabelPublic: "Manchester, UK area",
+      locationLabelPublic: "  Manchester, UK area  ",
       region: "England",
     });
 
@@ -81,6 +81,13 @@ describe("approximate location helpers", () => {
     expect(travelRadiusLabel(milesToKilometers(50), "mi")).toBe(
       "50 mi / 80 km",
     );
+    expect(formatApproximateDistance(0)).toBe("about 0 km / 0 mi away");
     expect(travelRadiusLabel(null)).toBeNull();
+  });
+
+  it("does not format invalid public distances", () => {
+    expect(formatDistance(-1)).toBeNull();
+    expect(formatDistance(Number.NaN)).toBeNull();
+    expect(formatApproximateDistance(Number.POSITIVE_INFINITY)).toBeNull();
   });
 });

--- a/test/contact-relay.test.ts
+++ b/test/contact-relay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  CONTACT_MESSAGE_MAX_LENGTH,
   CONTACT_RATE_LIMIT_COUNT,
   CONTACT_RATE_LIMIT_WINDOW_MINUTES,
   buildContactNotificationEmail,
@@ -37,6 +38,26 @@ describe("contact relay helpers", () => {
     );
     expect(normalizeReturnTo("https://example.com")).toBe("/");
     expect(normalizeReturnTo("//example.com")).toBe("/");
+  });
+
+  it("accepts quartet targets and enforces message length", () => {
+    const formData = new FormData();
+    formData.set("targetKind", "quartet");
+    formData.set("targetId", "123e4567-e89b-12d3-a456-426614174000");
+    formData.set("message", "x".repeat(CONTACT_MESSAGE_MAX_LENGTH));
+    formData.set("returnTo", "/quartets?part=bass");
+
+    expect(parseContactRequestFormData(formData)).toEqual({
+      message: "x".repeat(CONTACT_MESSAGE_MAX_LENGTH),
+      returnTo: "/quartets?part=bass",
+      targetId: "123e4567-e89b-12d3-a456-426614174000",
+      targetKind: "quartet",
+    });
+
+    formData.set("message", "x".repeat(CONTACT_MESSAGE_MAX_LENGTH + 1));
+    expect(() => parseContactRequestFormData(formData)).toThrow(
+      `Keep contact messages under ${CONTACT_MESSAGE_MAX_LENGTH} characters.`,
+    );
   });
 
   it("builds recipient notification without revealing direct sender contact", () => {

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -7,11 +7,17 @@ import {
 describe("discovery filters", () => {
   it("parses allowed part and goal filters", () => {
     const filters = parseDiscoveryFilters({
+      country: "  United Kingdom  ",
+      locality: " Manchester ",
+      region: " Greater Manchester ",
       goal: "contest",
       part: "lead",
       travelRadiusKm: "50",
     });
 
+    expect(filters.country).toBe("United Kingdom");
+    expect(filters.locality).toBe("Manchester");
+    expect(filters.region).toBe("Greater Manchester");
     expect(filters.goal).toBe("contest");
     expect(filters.part).toBe("lead");
     expect(filters.travelRadiusKm).toBe(50);
@@ -29,5 +35,33 @@ describe("discovery filters", () => {
     expect(filters.part).toBeNull();
     expect(filters.travelRadiusKm).toBeNull();
     expect(hasDiscoveryFilters(filters)).toBe(false);
+  });
+
+  it("uses the first submitted query value and keeps global text filters", () => {
+    const filters = parseDiscoveryFilters({
+      country: ["Ireland", "United States"],
+      goal: ["pickup", "contest"],
+      locality: ["Dublin", "Boston"],
+      part: ["tenor", "melody"],
+      travelRadiusKm: ["10000", "25"],
+    });
+
+    expect(filters.country).toBe("Ireland");
+    expect(filters.locality).toBe("Dublin");
+    expect(filters.goal).toBe("pickup");
+    expect(filters.part).toBe("tenor");
+    expect(filters.travelRadiusKm).toBe(10000);
+  });
+
+  it("rejects decimal, negative, and too-large travel radius filters", () => {
+    expect(
+      parseDiscoveryFilters({ travelRadiusKm: "10.5" }).travelRadiusKm,
+    ).toBeNull();
+    expect(
+      parseDiscoveryFilters({ travelRadiusKm: "-1" }).travelRadiusKm,
+    ).toBeNull();
+    expect(
+      parseDiscoveryFilters({ travelRadiusKm: "10001" }).travelRadiusKm,
+    ).toBeNull();
   });
 });

--- a/test/quartet-listing-form.test.ts
+++ b/test/quartet-listing-form.test.ts
@@ -56,6 +56,21 @@ describe("quartet listing form parsing", () => {
     expect(values.partsNeeded).toEqual(["lead", "baritone"]);
   });
 
+  it("preserves every valid needed part for an incomplete quartet", () => {
+    const values = parseQuartetListingFormData(
+      formData([
+        ["name", "Festival Pickup Quartet"],
+        ["partsCovered", "lead"],
+        ["partsNeeded", "tenor"],
+        ["partsNeeded", "baritone"],
+        ["partsNeeded", "bass"],
+      ]),
+    );
+
+    expect(values.partsCovered).toEqual(["lead"]);
+    expect(values.partsNeeded).toEqual(["tenor", "baritone", "bass"]);
+  });
+
   it("builds an approximate public location without postal code", () => {
     const values = parseQuartetListingFormData(
       formData([

--- a/test/singer-profile-form.test.ts
+++ b/test/singer-profile-form.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  BARBERSHOP_PARTS,
   buildPublicLocationLabel,
   inferLocationPrecision,
   parseSingerProfileFormData,
@@ -16,6 +17,12 @@ function formData(entries: Array<[string, string]>) {
 }
 
 describe("singer profile form parsing", () => {
+  it("keeps barbershop part constants explicit and does not rename Lead", () => {
+    expect(BARBERSHOP_PARTS).toEqual(["tenor", "lead", "baritone", "bass"]);
+    expect(BARBERSHOP_PARTS).toContain("lead");
+    expect(BARBERSHOP_PARTS).not.toContain("melody");
+  });
+
   it("accepts globally tolerant location fields without US-only requirements", () => {
     const values = parseSingerProfileFormData(
       formData([
@@ -43,6 +50,7 @@ describe("singer profile form parsing", () => {
     const values = parseSingerProfileFormData(
       formData([
         ["displayName", "Jordan"],
+        ["countryCode", "usa"],
         ["parts", "lead"],
         ["parts", "melody"],
         ["goals", "contest"],
@@ -50,6 +58,7 @@ describe("singer profile form parsing", () => {
       ]),
     );
 
+    expect(values.countryCode).toBeNull();
     expect(values.parts).toEqual(["lead"]);
     expect(values.goals).toEqual(["contest"]);
   });


### PR DESCRIPTION
Closes #25.

## Summary
- Expand unit coverage for barbershop part constants, profile/listing normalization, search filters, distance formatting, and contact relay safeguards.
- Add non-US/global examples across location and discovery-filter tests.
- Document the test structure and expectations for future core-logic PRs in docs/testing.md.

## Verification
- npm run lint
- npm run typecheck
- npm run format:check
- npm run test:run
- npm run build