### PR TITLE
Add Supabase demo seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ secrets out of source control.
 Testing expectations and the current unit-test structure are documented in
 `docs/testing.md`.
 
+Local and staging demo data is documented in `docs/seed-data.md`; the seed file
+is intentionally opt-in and must not be run against production.
+
 ## Early project notes
 
 Project context, privacy expectations, workflow rules, and implementation

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -104,6 +104,10 @@ Supabase schema and Row Level Security changes should be managed by committed mi
 
 Production deploys should not depend on undocumented manual database changes.
 
+Demo data for local development and safe staging/preview validation lives in
+`supabase/seed.sql` and is documented in `docs/seed-data.md`. It is not a
+production migration and must not be run against production data.
+
 Supabase Auth should be configured with the deployed app URL as the site URL and
 the app callback route as an allowed redirect URL:
 

--- a/docs/seed-data.md
+++ b/docs/seed-data.md
@@ -1,0 +1,65 @@
+# Seed And Demo Data
+
+The project includes an intentional Supabase seed file at `supabase/seed.sql`
+for local development and safe staging or preview validation.
+
+The seed data is clearly fake. It creates deterministic demo users, singer
+profiles, quartet openings, part rows, and a small number of contact requests so
+search, map, visibility, and contact-target behavior can be tested without real
+personal data.
+
+Do not run the seed file against production.
+
+## What It Includes
+
+- multiple singer profiles
+- multiple quartet openings
+- Tenor, Lead, Baritone, and Bass examples
+- visible and hidden profiles/listings
+- United States, Canada, United Kingdom, Ireland, Australia, and New Zealand
+  examples
+- mixed miles/kilometers preferences
+- goals, availability, experience/commitment, and travel-radius examples
+- contact requests aimed at visible singer and quartet targets
+
+Private postal-code fields use demo-only values such as `80521-DEMO` and
+`M5V-DEMO`. Public labels stay approximate, such as `Manchester, UK area`.
+
+## Load Locally
+
+After applying migrations to a local Supabase database, load the seed data with:
+
+```bash
+supabase db reset
+```
+
+Supabase CLI runs `supabase/seed.sql` during a local reset. This recreates the
+local database, applies migrations, and loads the demo rows.
+
+## Load In Safe Staging
+
+Only use staging or preview databases that can safely contain fake demo rows.
+Apply the SQL intentionally with your normal Supabase SQL workflow, for example
+through the SQL editor or a reviewed command-line connection.
+
+The seed file starts by removing the deterministic demo users and their related
+demo app rows, then recreates them. It does not delete non-demo users.
+
+## Reset Or Remove Demo Data
+
+To reset local demo data, run:
+
+```bash
+supabase db reset
+```
+
+To remove demo data from a staging database, delete the deterministic demo auth
+users listed in `supabase/seed.sql`. The app tables reference those users with
+cascade rules, and demo contact requests are also removed by the seed file
+before reseeding.
+
+## Production Safety
+
+The seed file is not a migration and is not part of the production deployment
+path. Production data should only change through approved application behavior,
+reviewed migrations, or explicit operational procedures.

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,453 @@
+-- Quartet Member Finder demo seed data.
+--
+-- Intended for local development and safe staging/preview validation only.
+-- Do not run this against production data.
+
+begin;
+
+delete from public.contact_requests
+where sender_user_id in (
+  '00000000-0000-4000-8000-000000000101',
+  '00000000-0000-4000-8000-000000000102',
+  '00000000-0000-4000-8000-000000000103',
+  '00000000-0000-4000-8000-000000000104',
+  '00000000-0000-4000-8000-000000000105',
+  '00000000-0000-4000-8000-000000000106'
+)
+or recipient_user_id in (
+  '00000000-0000-4000-8000-000000000101',
+  '00000000-0000-4000-8000-000000000102',
+  '00000000-0000-4000-8000-000000000103',
+  '00000000-0000-4000-8000-000000000104',
+  '00000000-0000-4000-8000-000000000105',
+  '00000000-0000-4000-8000-000000000106'
+);
+
+delete from auth.users
+where id in (
+  '00000000-0000-4000-8000-000000000101',
+  '00000000-0000-4000-8000-000000000102',
+  '00000000-0000-4000-8000-000000000103',
+  '00000000-0000-4000-8000-000000000104',
+  '00000000-0000-4000-8000-000000000105',
+  '00000000-0000-4000-8000-000000000106'
+);
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  raw_app_meta_data,
+  raw_user_meta_data
+)
+values
+  (
+    '00000000-0000-4000-8000-000000000101',
+    'authenticated',
+    'authenticated',
+    'demo.avery.tenor@example.invalid',
+    crypt('quartet-demo-password', gen_salt('bf')),
+    now(),
+    now(),
+    now(),
+    '{"provider": "email", "providers": ["email"]}'::jsonb,
+    '{"name": "Avery Demo"}'::jsonb
+  ),
+  (
+    '00000000-0000-4000-8000-000000000102',
+    'authenticated',
+    'authenticated',
+    'demo.morgan.lead@example.invalid',
+    crypt('quartet-demo-password', gen_salt('bf')),
+    now(),
+    now(),
+    now(),
+    '{"provider": "email", "providers": ["email"]}'::jsonb,
+    '{"name": "Morgan Demo"}'::jsonb
+  ),
+  (
+    '00000000-0000-4000-8000-000000000103',
+    'authenticated',
+    'authenticated',
+    'demo.priya.bari@example.invalid',
+    crypt('quartet-demo-password', gen_salt('bf')),
+    now(),
+    now(),
+    now(),
+    '{"provider": "email", "providers": ["email"]}'::jsonb,
+    '{"name": "Priya Demo"}'::jsonb
+  ),
+  (
+    '00000000-0000-4000-8000-000000000104',
+    'authenticated',
+    'authenticated',
+    'demo.noah.bass@example.invalid',
+    crypt('quartet-demo-password', gen_salt('bf')),
+    now(),
+    now(),
+    now(),
+    '{"provider": "email", "providers": ["email"]}'::jsonb,
+    '{"name": "Noah Demo"}'::jsonb
+  ),
+  (
+    '00000000-0000-4000-8000-000000000105',
+    'authenticated',
+    'authenticated',
+    'demo.hidden.singer@example.invalid',
+    crypt('quartet-demo-password', gen_salt('bf')),
+    now(),
+    now(),
+    now(),
+    '{"provider": "email", "providers": ["email"]}'::jsonb,
+    '{"name": "Hidden Demo"}'::jsonb
+  ),
+  (
+    '00000000-0000-4000-8000-000000000106',
+    'authenticated',
+    'authenticated',
+    'demo.quartet.owner@example.invalid',
+    crypt('quartet-demo-password', gen_salt('bf')),
+    now(),
+    now(),
+    now(),
+    '{"provider": "email", "providers": ["email"]}'::jsonb,
+    '{"name": "Quartet Owner Demo"}'::jsonb
+  );
+
+insert into public.account_profiles (
+  user_id,
+  display_name,
+  onboarding_completed_at,
+  onboarding_last_choice,
+  preferred_distance_unit
+)
+values
+  (
+    '00000000-0000-4000-8000-000000000101',
+    'Avery Demo',
+    now(),
+    'my-singer-profile',
+    'mi'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000102',
+    'Morgan Demo',
+    now(),
+    'find-quartet-openings',
+    'km'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000103',
+    'Priya Demo',
+    now(),
+    'my-singer-profile',
+    'km'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000104',
+    'Noah Demo',
+    now(),
+    'find-singers-as-singer',
+    'mi'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000105',
+    'Hidden Demo',
+    now(),
+    'browse-for-now',
+    'km'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000106',
+    'Quartet Owner Demo',
+    now(),
+    'quartet-mode-listing',
+    'km'
+  );
+
+insert into public.singer_profiles (
+  id,
+  user_id,
+  display_name,
+  bio,
+  goals,
+  experience_level,
+  availability,
+  travel_radius_km,
+  preferred_distance_unit,
+  is_visible,
+  is_active,
+  country_code,
+  country_name,
+  region,
+  locality,
+  postal_code_private,
+  location_label_public,
+  location_precision
+)
+values
+  (
+    '10000000-0000-4000-8000-000000000101',
+    '00000000-0000-4000-8000-000000000101',
+    'Avery Demo',
+    'Demo tenor who likes casual tags, pickup singing, and helping quartets test contact flows.',
+    array['pickup', 'casual'],
+    'Experienced chorus singer',
+    'Weeknights and occasional convention weekends',
+    80,
+    'mi',
+    true,
+    true,
+    'US',
+    'United States',
+    'Colorado',
+    'Fort Collins',
+    '80521-DEMO',
+    'Fort Collins, CO area',
+    'postal_code'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000102',
+    '00000000-0000-4000-8000-000000000102',
+    'Morgan Demo',
+    'Demo lead open to regular rehearsals and contest preparation.',
+    array['regular_rehearsal', 'contest'],
+    'Chapter quartet experience',
+    'Sunday afternoons or Tuesday evenings',
+    60,
+    'km',
+    true,
+    true,
+    'CA',
+    'Canada',
+    'Ontario',
+    'Toronto',
+    'M5V-DEMO',
+    'Toronto, Ontario area',
+    'postal_code'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000103',
+    '00000000-0000-4000-8000-000000000103',
+    'Priya Demo',
+    'Demo baritone with flexible goals for learning, pickup singing, and coaching weekends.',
+    array['learning', 'pickup'],
+    'Returning singer',
+    'Monthly rehearsals and festival weekends',
+    40,
+    'km',
+    true,
+    true,
+    'GB',
+    'United Kingdom',
+    'England',
+    'Manchester',
+    'M1-DEMO',
+    'Manchester, UK area',
+    'postal_code'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000104',
+    '00000000-0000-4000-8000-000000000104',
+    'Noah Demo',
+    'Demo bass comfortable with casual singing, afterglows, and short-notice fill-ins.',
+    array['casual', 'paid_gigs'],
+    'Gig-ready bass',
+    'Most weekends with notice',
+    120,
+    'mi',
+    true,
+    true,
+    'AU',
+    'Australia',
+    'Victoria',
+    'Melbourne',
+    '3000-DEMO',
+    'Melbourne, Victoria area',
+    'postal_code'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000105',
+    '00000000-0000-4000-8000-000000000105',
+    'Hidden Singer Demo',
+    'Hidden demo profile for visibility-filter testing.',
+    array['contest'],
+    'Hidden profile',
+    'Not publicly visible',
+    25,
+    'km',
+    false,
+    true,
+    'IE',
+    'Ireland',
+    'Leinster',
+    'Dublin',
+    'D02-DEMO',
+    'Dublin, Ireland area',
+    'postal_code'
+  );
+
+insert into public.singer_profile_parts (singer_profile_id, part)
+values
+  ('10000000-0000-4000-8000-000000000101', 'tenor'),
+  ('10000000-0000-4000-8000-000000000102', 'lead'),
+  ('10000000-0000-4000-8000-000000000103', 'baritone'),
+  ('10000000-0000-4000-8000-000000000103', 'lead'),
+  ('10000000-0000-4000-8000-000000000104', 'bass'),
+  ('10000000-0000-4000-8000-000000000105', 'lead');
+
+insert into public.quartet_listings (
+  id,
+  owner_user_id,
+  name,
+  description,
+  goals,
+  experience_level,
+  availability,
+  travel_radius_km,
+  preferred_distance_unit,
+  is_visible,
+  is_active,
+  country_code,
+  country_name,
+  region,
+  locality,
+  postal_code_private,
+  location_label_public,
+  location_precision
+)
+values
+  (
+    '20000000-0000-4000-8000-000000000201',
+    '00000000-0000-4000-8000-000000000106',
+    'Demo Front Range Pickup',
+    'Visible demo quartet opening seeking a lead for pickup singing and local events.',
+    array['pickup', 'casual'],
+    'Friendly chapter-level quartet',
+    'Two weeknight rehearsals per month',
+    100,
+    'mi',
+    true,
+    true,
+    'US',
+    'United States',
+    'Colorado',
+    'Denver',
+    '80202-DEMO',
+    'Denver, CO area',
+    'postal_code'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000202',
+    '00000000-0000-4000-8000-000000000102',
+    'Demo Harbour Chords',
+    'Visible Canadian demo listing looking for a bass and baritone for regular rehearsals.',
+    array['regular_rehearsal', 'contest'],
+    'Contest-curious quartet',
+    'Weekly Sunday rehearsals',
+    90,
+    'km',
+    true,
+    true,
+    'CA',
+    'Canada',
+    'British Columbia',
+    'Vancouver',
+    'V6B-DEMO',
+    'Vancouver, BC area',
+    'postal_code'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000203',
+    '00000000-0000-4000-8000-000000000103',
+    'Demo Liffey Tags',
+    'Visible Irish demo quartet opening for a tenor, useful for non-US map and search checks.',
+    array['learning', 'pickup'],
+    'Developing quartet',
+    'Monthly Saturday rehearsals',
+    50,
+    'km',
+    true,
+    true,
+    'IE',
+    'Ireland',
+    'Leinster',
+    'Dublin',
+    'D02-DEMO',
+    'Dublin, Ireland area',
+    'postal_code'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000204',
+    '00000000-0000-4000-8000-000000000104',
+    'Hidden Demo Quartet',
+    'Hidden demo listing for visibility-filter testing.',
+    array['contest'],
+    'Hidden listing',
+    'Not publicly visible',
+    30,
+    'km',
+    false,
+    true,
+    'NZ',
+    'New Zealand',
+    'Auckland',
+    'Auckland',
+    '1010-DEMO',
+    'Auckland, New Zealand area',
+    'postal_code'
+  );
+
+insert into public.quartet_listing_parts (quartet_listing_id, part, status)
+values
+  ('20000000-0000-4000-8000-000000000201', 'tenor', 'covered'),
+  ('20000000-0000-4000-8000-000000000201', 'baritone', 'covered'),
+  ('20000000-0000-4000-8000-000000000201', 'bass', 'covered'),
+  ('20000000-0000-4000-8000-000000000201', 'lead', 'needed'),
+  ('20000000-0000-4000-8000-000000000202', 'tenor', 'covered'),
+  ('20000000-0000-4000-8000-000000000202', 'lead', 'covered'),
+  ('20000000-0000-4000-8000-000000000202', 'baritone', 'needed'),
+  ('20000000-0000-4000-8000-000000000202', 'bass', 'needed'),
+  ('20000000-0000-4000-8000-000000000203', 'lead', 'covered'),
+  ('20000000-0000-4000-8000-000000000203', 'baritone', 'covered'),
+  ('20000000-0000-4000-8000-000000000203', 'bass', 'covered'),
+  ('20000000-0000-4000-8000-000000000203', 'tenor', 'needed'),
+  ('20000000-0000-4000-8000-000000000204', 'lead', 'covered'),
+  ('20000000-0000-4000-8000-000000000204', 'tenor', 'needed');
+
+insert into public.contact_requests (
+  id,
+  sender_user_id,
+  singer_profile_id,
+  message_body,
+  status
+)
+values (
+  '30000000-0000-4000-8000-000000000301',
+  '00000000-0000-4000-8000-000000000106',
+  '10000000-0000-4000-8000-000000000101',
+  'Demo contact request for a visible singer profile. This message uses fake data only.',
+  'pending'
+);
+
+insert into public.contact_requests (
+  id,
+  sender_user_id,
+  quartet_listing_id,
+  message_body,
+  status
+)
+values (
+  '30000000-0000-4000-8000-000000000302',
+  '00000000-0000-4000-8000-000000000101',
+  '20000000-0000-4000-8000-000000000203',
+  'Demo contact request for a visible quartet listing. This message uses fake data only.',
+  'delivered'
+);
+
+commit;

--- a/test/seed-data.test.ts
+++ b/test/seed-data.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const seedSql = readFileSync("supabase/seed.sql", "utf8");
+const seedDocs = readFileSync("docs/seed-data.md", "utf8");
+
+describe("Supabase seed data", () => {
+  it("is clearly documented as fake and non-production data", () => {
+    expect(seedSql).toContain("Do not run this against production data.");
+    expect(seedSql).toContain("@example.invalid");
+    expect(seedDocs).toContain("Do not run the seed file against production.");
+  });
+
+  it("covers all barbershop parts across demo singers and quartet openings", () => {
+    for (const part of ["tenor", "lead", "baritone", "bass"]) {
+      expect(seedSql).toContain(`'${part}'`);
+    }
+
+    expect(seedSql).toContain("'covered'");
+    expect(seedSql).toContain("'needed'");
+  });
+
+  it("includes visible and hidden examples across US and non-US locations", () => {
+    for (const countryCode of ["US", "CA", "GB", "IE", "AU", "NZ"]) {
+      expect(seedSql).toContain(`'${countryCode}'`);
+    }
+
+    expect(seedSql).toContain("'Fort Collins, CO area'");
+    expect(seedSql).toContain("'Manchester, UK area'");
+    expect(seedSql).toContain("'Dublin, Ireland area'");
+    expect(seedSql).toContain("true,\n    true,");
+    expect(seedSql).toContain("false,\n    true,");
+  });
+
+  it("exercises mixed distance preferences and contact relay targets", () => {
+    expect(seedSql).toContain("'mi'");
+    expect(seedSql).toContain("'km'");
+    expect(seedSql).toContain("singer_profile_id");
+    expect(seedSql).toContain("quartet_listing_id");
+    expect(seedSql).toContain("Demo contact request for a visible singer");
+    expect(seedSql).toContain("Demo contact request for a visible quartet");
+  });
+});


### PR DESCRIPTION
Closes #40.

## Summary
- Add an intentional Supabase seed file with fake demo auth users, account profiles, singer profiles, quartet listings, part rows, and contact requests.
- Include visible and hidden examples, all four barbershop parts, US and non-US locations, and mixed miles/kilometers preferences.
- Document how to load, reset, and safely use seed data outside production.
- Add a seed-data unit test to preserve the demo data contract.

## Verification
- npm run lint
- npm run typecheck
- npm run format:check
- npm run test:run
- npm run build