### PR TITLE
Fix feedback submission reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ coverage/
 # system/editor
 .DS_Store
 *.pem
+*.swp
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+.vercel

--- a/app/help/actions.ts
+++ b/app/help/actions.ts
@@ -8,7 +8,10 @@ import {
   feedbackRateLimitWindowStart,
   parseFeedbackFormData,
 } from "@/lib/feedback/feedback-form";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  createSupabaseAdminClient,
+  createSupabaseServerClient,
+} from "@/lib/supabase/server";
 
 function redirectWithFeedbackStatus(
   status: "auth" | "error" | "sent" | "limited",
@@ -39,16 +42,21 @@ export async function submitHelpFeedback(formData: FormData) {
     redirect(`/sign-in?next=${encodeURIComponent("/help")}`);
   }
 
+  const feedbackClient = createSupabaseAdminClient() ?? supabase;
   const rateLimitWindowStart = feedbackRateLimitWindowStart();
   const headerStore = await headers();
   const userAgent = headerStore.get("user-agent");
-  const { count, error: rateLimitError } = await supabase
+  const { count, error: rateLimitError } = await feedbackClient
     .from("feedback_submissions")
     .select("id", { count: "exact", head: true })
     .eq("submitter_user_id", user.id)
     .gte("created_at", rateLimitWindowStart);
 
   if (rateLimitError) {
+    console.error("Feedback rate-limit lookup failed", {
+      code: rateLimitError.code,
+      message: rateLimitError.message,
+    });
     redirectWithFeedbackStatus("error");
   }
 
@@ -56,7 +64,7 @@ export async function submitHelpFeedback(formData: FormData) {
     redirectWithFeedbackStatus("limited");
   }
 
-  const { error: insertError } = await supabase
+  const { error: insertError } = await feedbackClient
     .from("feedback_submissions")
     .insert({
       context_path: values.contextPath,
@@ -68,6 +76,10 @@ export async function submitHelpFeedback(formData: FormData) {
     });
 
   if (insertError) {
+    console.error("Feedback insert failed", {
+      code: insertError.code,
+      message: insertError.message,
+    });
     redirectWithFeedbackStatus("error");
   }
 

--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -1,5 +1,8 @@
 import { submitHelpFeedback } from "@/app/help/actions";
-import { FEEDBACK_MESSAGE_MAX_LENGTH } from "@/lib/feedback/feedback-form";
+import {
+  FEEDBACK_HONEYPOT_FIELD,
+  FEEDBACK_MESSAGE_MAX_LENGTH,
+} from "@/lib/feedback/feedback-form";
 
 type HelpFeedbackFormProps = {
   status?: string;
@@ -54,9 +57,14 @@ export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
 
       <form action={submitHelpFeedback} className="mt-5 grid gap-4">
         <input name="contextPath" type="hidden" value="/help" />
-        <label className="hidden">
-          Website
-          <input autoComplete="off" name="website" tabIndex={-1} type="text" />
+        <label aria-hidden="true" className="hidden">
+          Leave this field blank
+          <input
+            autoComplete="new-password"
+            name={FEEDBACK_HONEYPOT_FIELD}
+            tabIndex={-1}
+            type="text"
+          />
         </label>
 
         <label className="block">

--- a/lib/feedback/feedback-form.ts
+++ b/lib/feedback/feedback-form.ts
@@ -2,6 +2,7 @@ export const FEEDBACK_MESSAGE_MAX_LENGTH = 3000;
 export const FEEDBACK_CONTEXT_MAX_LENGTH = 500;
 export const FEEDBACK_RATE_LIMIT_COUNT = 3;
 export const FEEDBACK_RATE_LIMIT_WINDOW_MINUTES = 60;
+export const FEEDBACK_HONEYPOT_FIELD = "feedbackCompanyUrl";
 
 export const feedbackTypes = ["feedback", "bug", "suggestion"] as const;
 
@@ -37,9 +38,9 @@ export function parseFeedbackFormData(formData: FormData): FeedbackFormValues {
   const contextPath = normalizeFeedbackContext(
     trimToNull(formData.get("contextPath")),
   );
-  const website = trimToNull(formData.get("website"));
+  const honeypot = trimToNull(formData.get(FEEDBACK_HONEYPOT_FIELD));
 
-  if (website) {
+  if (honeypot) {
     throw new Error("Feedback could not be submitted.");
   }
 

--- a/test/feedback-form.test.ts
+++ b/test/feedback-form.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  FEEDBACK_HONEYPOT_FIELD,
   FEEDBACK_RATE_LIMIT_COUNT,
   FEEDBACK_RATE_LIMIT_WINDOW_MINUTES,
   feedbackRateLimitWindowStart,
@@ -33,7 +34,7 @@ describe("feedback form helpers", () => {
     );
 
     formData.set("feedbackType", "feedback");
-    formData.set("website", "https://spam.example");
+    formData.set(FEEDBACK_HONEYPOT_FIELD, "https://spam.example");
 
     expect(() => parseFeedbackFormData(formData)).toThrow(
       "Feedback could not be submitted.",


### PR DESCRIPTION
## Summary
- Use the server-only Supabase admin client for feedback rate-limit and insert operations after verifying the signed-in user.
- Rename the hidden feedback honeypot field to avoid common browser autofill on `website` fields.
- Add safe server-side logging for future feedback write failures.
- Ignore Vercel local project metadata and editor swap files.

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:run`
- `npm run build`