### PR TITLE
Remove feedback honeypot false positive

### DIFF
--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -1,8 +1,5 @@
 import { submitHelpFeedback } from "@/app/help/actions";
-import {
-  FEEDBACK_HONEYPOT_FIELD,
-  FEEDBACK_MESSAGE_MAX_LENGTH,
-} from "@/lib/feedback/feedback-form";
+import { FEEDBACK_MESSAGE_MAX_LENGTH } from "@/lib/feedback/feedback-form";
 
 type HelpFeedbackFormProps = {
   status?: string;
@@ -57,15 +54,6 @@ export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
 
       <form action={submitHelpFeedback} className="mt-5 grid gap-4">
         <input name="contextPath" type="hidden" value="/help" />
-        <label aria-hidden="true" className="hidden">
-          Leave this field blank
-          <input
-            autoComplete="new-password"
-            name={FEEDBACK_HONEYPOT_FIELD}
-            tabIndex={-1}
-            type="text"
-          />
-        </label>
 
         <label className="block">
           <span className="text-sm font-semibold text-[#172023]">Type</span>

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -172,9 +172,9 @@ The public help page stays readable before login. Signed-out visitors are
 invited to sign in before sending feedback.
 
 Signed-in users can submit private feedback, bug reports, or suggestions from
-the help page. The browser sends only the feedback type, message, current route
-context, and a spam honeypot field. The server action attaches the authenticated
-user ID and auth email when available, then stores the submission in Supabase.
+the help page. The browser sends only the feedback type, message, and current
+route context. The server action attaches the authenticated user ID and auth
+email when available, then stores the submission in Supabase.
 
 Feedback submissions are not public content and are not included in discovery
 views, search results, maps, or public profile/listing UI. Regular authenticated

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -234,8 +234,8 @@ automation can be added later if the product needs stronger enforcement.
 
 The help-page feedback action applies authenticated-only spam protection:
 three feedback submissions per authenticated submitter per hour, message length
-limits, type validation, route/context normalization, and a hidden honeypot
-field. Feedback is not exposed in public discovery views or public pages.
+limits, type validation, and route/context normalization. Feedback is not
+exposed in public discovery views or public pages.
 
 Phone number handling, if added later, should not assume a US-only format.
 

--- a/lib/feedback/feedback-form.ts
+++ b/lib/feedback/feedback-form.ts
@@ -2,7 +2,6 @@ export const FEEDBACK_MESSAGE_MAX_LENGTH = 3000;
 export const FEEDBACK_CONTEXT_MAX_LENGTH = 500;
 export const FEEDBACK_RATE_LIMIT_COUNT = 3;
 export const FEEDBACK_RATE_LIMIT_WINDOW_MINUTES = 60;
-export const FEEDBACK_HONEYPOT_FIELD = "feedbackCompanyUrl";
 
 export const feedbackTypes = ["feedback", "bug", "suggestion"] as const;
 
@@ -38,11 +37,6 @@ export function parseFeedbackFormData(formData: FormData): FeedbackFormValues {
   const contextPath = normalizeFeedbackContext(
     trimToNull(formData.get("contextPath")),
   );
-  const honeypot = trimToNull(formData.get(FEEDBACK_HONEYPOT_FIELD));
-
-  if (honeypot) {
-    throw new Error("Feedback could not be submitted.");
-  }
 
   if (
     feedbackType !== "feedback" &&

--- a/test/feedback-form.test.ts
+++ b/test/feedback-form.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  FEEDBACK_HONEYPOT_FIELD,
   FEEDBACK_RATE_LIMIT_COUNT,
   FEEDBACK_RATE_LIMIT_WINDOW_MINUTES,
   feedbackRateLimitWindowStart,
@@ -24,7 +23,7 @@ describe("feedback form helpers", () => {
     expect(Array.from(formData.keys())).not.toContain("submitterEmail");
   });
 
-  it("rejects unsafe values and spam honeypot submissions", () => {
+  it("rejects unsafe values", () => {
     const formData = new FormData();
     formData.set("feedbackType", "other");
     formData.set("message", "Hello");
@@ -34,11 +33,7 @@ describe("feedback form helpers", () => {
     );
 
     formData.set("feedbackType", "feedback");
-    formData.set(FEEDBACK_HONEYPOT_FIELD, "https://spam.example");
 
-    expect(() => parseFeedbackFormData(formData)).toThrow(
-      "Feedback could not be submitted.",
-    );
     expect(normalizeFeedbackContext("https://example.com/help")).toBeNull();
     expect(normalizeFeedbackContext("//example.com/help")).toBeNull();
   });


### PR DESCRIPTION
## Summary
- remove the hidden feedback honeypot field that could be populated by browser autofill and reject legitimate signed-in feedback
- keep authenticated rate limiting, type validation, message length validation, and route normalization in place
- update feedback tests and privacy/Supabase docs to match the revised form contract

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build