### PR TITLE
Ignore Supabase CLI temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 .vercel
+supabase/.temp/


### PR DESCRIPTION
## Summary
- ignore local Supabase CLI link metadata under `supabase/.temp/`

## Verification
- not run; gitignore-only change