### PR TITLE
Email help feedback to project team

### DIFF
--- a/app/help/actions.ts
+++ b/app/help/actions.ts
@@ -9,6 +9,10 @@ import {
   parseFeedbackFormData,
 } from "@/lib/feedback/feedback-form";
 import {
+  getFeedbackNotificationConfig,
+  sendFeedbackNotification,
+} from "@/lib/feedback/feedback-notification";
+import {
   createSupabaseAdminClient,
   createSupabaseServerClient,
 } from "@/lib/supabase/server";
@@ -64,7 +68,7 @@ export async function submitHelpFeedback(formData: FormData) {
     redirectWithFeedbackStatus("limited");
   }
 
-  const { error: insertError } = await feedbackClient
+  const { data: feedbackSubmission, error: insertError } = await feedbackClient
     .from("feedback_submissions")
     .insert({
       context_path: values.contextPath,
@@ -73,12 +77,36 @@ export async function submitHelpFeedback(formData: FormData) {
       submitter_email_private: user.email ?? null,
       submitter_user_id: user.id,
       user_agent: userAgent ? userAgent.slice(0, 500) : null,
-    });
+    })
+    .select("id")
+    .single();
 
-  if (insertError) {
+  if (insertError || !feedbackSubmission) {
     console.error("Feedback insert failed", {
-      code: insertError.code,
-      message: insertError.message,
+      code: insertError?.code,
+      message: insertError?.message,
+    });
+    redirectWithFeedbackStatus("error");
+  }
+
+  const notificationConfig = getFeedbackNotificationConfig();
+
+  if (!notificationConfig) {
+    console.error("Feedback notification configuration is missing");
+    redirectWithFeedbackStatus("error");
+  }
+
+  try {
+    await sendFeedbackNotification(notificationConfig, {
+      contextPath: values.contextPath,
+      feedbackId: feedbackSubmission.id,
+      feedbackType: values.feedbackType,
+      message: values.message,
+      submitterEmail: user.email ?? null,
+    });
+  } catch (error) {
+    console.error("Feedback notification failed", {
+      message: error instanceof Error ? error.message : "Unknown error",
     });
     redirectWithFeedbackStatus("error");
   }

--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -7,7 +7,7 @@ type HelpFeedbackFormProps = {
 
 function feedbackStatusMessage(status?: string) {
   if (status === "sent") {
-    return "Thanks for the note. Your feedback was sent.";
+    return "Thanks for the note. Your feedback was emailed to the project team.";
   }
 
   if (status === "limited") {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -272,10 +272,11 @@ request. It must not be exposed to browser code. If Resend or service-role
 configuration is missing, contact requests can still be stored, but notification
 delivery is deferred.
 
-Help-page feedback currently stores authenticated submissions in Supabase rather
-than sending transactional email. Admin review should use service-role/server
-access or a future protected admin surface; feedback must not be exposed through
-public routes or browser-side service-role code.
+Help-page feedback stores authenticated submissions in Supabase and sends a
+Resend notification to the project-team inbox at `cubuff98@gmail.com`. Admin
+review should use service-role/server access or a future protected admin
+surface; feedback must not be exposed through public routes or browser-side
+service-role code.
 
 ## Maps and geocoding
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -174,7 +174,8 @@ invited to sign in before sending feedback.
 Signed-in users can submit private feedback, bug reports, or suggestions from
 the help page. The browser sends only the feedback type, message, and current
 route context. The server action attaches the authenticated user ID and auth
-email when available, then stores the submission in Supabase.
+email when available, stores the submission in Supabase, and sends a Resend
+notification to the project-team inbox at `cubuff98@gmail.com`.
 
 Feedback submissions are not public content and are not included in discovery
 views, search results, maps, or public profile/listing UI. Regular authenticated

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -149,6 +149,9 @@ The feedback table is private. Anonymous users have no direct table grants.
 Authenticated users may insert their own feedback and read only their own
 feedback rows so the server action can apply a basic sender-side rate limit.
 Service-role/admin access is required for cross-user review, triage, or export.
+After storage succeeds, the server action sends a Resend notification to
+`cubuff98@gmail.com` with the feedback type, message, submitter auth email when
+available, context path, and feedback row ID.
 
 ## Location data expectations
 

--- a/lib/feedback/feedback-notification.ts
+++ b/lib/feedback/feedback-notification.ts
@@ -1,0 +1,87 @@
+import { getAppUrl } from "@/lib/supabase/env";
+
+export const FEEDBACK_NOTIFICATION_RECIPIENT = "cubuff98@gmail.com";
+
+export type FeedbackNotificationConfig = {
+  apiKey: string;
+  fromEmail: string;
+};
+
+export type FeedbackNotification = {
+  contextPath: string | null;
+  feedbackId: string;
+  feedbackType: string;
+  message: string;
+  submitterEmail: string | null;
+};
+
+export function getFeedbackNotificationConfig(): FeedbackNotificationConfig | null {
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.RESEND_FROM_EMAIL;
+
+  if (!apiKey || !fromEmail) {
+    return null;
+  }
+
+  return { apiKey, fromEmail };
+}
+
+function feedbackTypeLabel(feedbackType: string) {
+  if (feedbackType === "bug") {
+    return "Bug report";
+  }
+
+  if (feedbackType === "suggestion") {
+    return "Suggestion";
+  }
+
+  return "General feedback";
+}
+
+export function buildFeedbackNotificationEmail({
+  contextPath,
+  feedbackId,
+  feedbackType,
+  message,
+  submitterEmail,
+}: FeedbackNotification) {
+  const appUrl = getAppUrl();
+  const typeLabel = feedbackTypeLabel(feedbackType);
+  const subject = `Quartet Member Finder feedback: ${typeLabel}`;
+  const text = [
+    `New ${typeLabel.toLowerCase()} from Quartet Member Finder.`,
+    "",
+    `From: ${submitterEmail ?? "Unknown signed-in user"}`,
+    `Context: ${contextPath ? `${appUrl}${contextPath}` : appUrl}`,
+    `Feedback ID: ${feedbackId}`,
+    "",
+    "Message:",
+    message,
+  ].join("\n");
+
+  return { subject, text };
+}
+
+export async function sendFeedbackNotification(
+  config: FeedbackNotificationConfig,
+  notification: FeedbackNotification,
+) {
+  const { subject, text } = buildFeedbackNotificationEmail(notification);
+  const response = await fetch("https://api.resend.com/emails", {
+    body: JSON.stringify({
+      from: config.fromEmail,
+      subject,
+      text,
+      to: FEEDBACK_NOTIFICATION_RECIPIENT,
+    }),
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Feedback notification failed with ${response.status}.`);
+  }
+}

--- a/test/feedback-notification.test.ts
+++ b/test/feedback-notification.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildFeedbackNotificationEmail,
+  FEEDBACK_NOTIFICATION_RECIPIENT,
+  sendFeedbackNotification,
+} from "@/lib/feedback/feedback-notification";
+
+describe("feedback notification helpers", () => {
+  it("builds a project-team feedback email", () => {
+    const email = buildFeedbackNotificationEmail({
+      contextPath: "/help",
+      feedbackId: "feedback-123",
+      feedbackType: "bug",
+      message: "The feedback form was confusing.",
+      submitterEmail: "singer@example.com",
+    });
+
+    expect(email.subject).toBe("Quartet Member Finder feedback: Bug report");
+    expect(email.text).toContain("From: singer@example.com");
+    expect(email.text).toContain("Feedback ID: feedback-123");
+    expect(email.text).toContain("Message:\nThe feedback form was confusing.");
+  });
+
+  it("sends feedback to the project-team inbox", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await sendFeedbackNotification(
+      {
+        apiKey: "resend-key",
+        fromEmail: "messages@quartetmemberfinder.org",
+      },
+      {
+        contextPath: "/help",
+        feedbackId: "feedback-123",
+        feedbackType: "feedback",
+        message: "Nice start.",
+        submitterEmail: "singer@example.com",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.resend.com/emails",
+      expect.objectContaining({
+        body: expect.stringContaining(FEEDBACK_NOTIFICATION_RECIPIENT),
+        method: "POST",
+      }),
+    );
+
+    fetchMock.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- send successful help-page feedback submissions to `cubuff98@gmail.com` through Resend
- include a Quartet Member Finder subject line, submitter email, context path, message, and Supabase feedback row ID
- update the feedback success message and docs so the behavior matches the product promise

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build

## Supabase
- No schema or RLS changes; no migration required.