### PR TITLE
Redesign top-level navigation and footer

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { signOut } from "@/app/auth/actions";
-import { signedInNavigationLinks } from "@/lib/navigation/signed-in-nav";
+import {
+  signedInModeNavigationLinks,
+  signedInPrimaryNavigationLinks,
+  signedInUtilityNavigationLinks,
+} from "@/lib/navigation/signed-in-nav";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -39,35 +43,59 @@ export default async function ProtectedAppLayout({
   }
 
   return (
-    <div className="min-h-screen">
+    <div>
       <header className="border-b border-[#d7cec0] bg-[#fffaf2]/90">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <Link className="text-lg font-bold text-[#172023]" href="/app">
               Quartet Member Finder
             </Link>
-            <form action={signOut}>
-              <button
-                className="w-fit rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
-                type="submit"
-              >
-                Sign out
-              </button>
-            </form>
+            <div className="flex flex-wrap items-center gap-3">
+              {signedInUtilityNavigationLinks.map((link) => (
+                <Link
+                  className="text-sm font-semibold text-[#394548] hover:text-[#174b4f]"
+                  href={link.href}
+                  key={link.href}
+                >
+                  {link.label}
+                </Link>
+              ))}
+              <form action={signOut}>
+                <button
+                  className="w-fit rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
+                  type="submit"
+                >
+                  Sign out
+                </button>
+              </form>
+            </div>
           </div>
           <nav
             aria-label="App navigation"
-            className="flex flex-wrap gap-x-4 gap-y-2"
+            className="grid gap-3 lg:grid-cols-[1fr_auto]"
           >
-            {signedInNavigationLinks.map((link) => (
-              <Link
-                className="text-sm font-semibold text-[#394548] hover:text-[#174b4f]"
-                href={link.href}
-                key={link.href}
-              >
-                {link.label}
-              </Link>
-            ))}
+            <div className="flex flex-wrap gap-2" aria-label="Singer tasks">
+              {signedInPrimaryNavigationLinks.map((link) => (
+                <Link
+                  className="rounded-md border border-[#d7cec0] bg-white/60 px-3 py-2 text-sm font-semibold text-[#394548] hover:border-[#2f6f73] hover:text-[#174b4f]"
+                  href={link.href}
+                  key={link.href}
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2" aria-label="Quartet mode">
+              {signedInModeNavigationLinks.map((link) => (
+                <Link
+                  className="rounded-md bg-[#174b4f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#10393c]"
+                  href={link.href}
+                  key={link.href}
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
           </nav>
         </div>
       </header>

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { HelpFeedbackForm } from "@/components/feedback/help-feedback-form";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { publicHelpSections } from "@/lib/content/public-pages";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -17,87 +18,67 @@ export default async function HelpPage({ searchParams }: HelpPageProps) {
   } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
 
   return (
-    <main className="mx-auto min-h-screen w-full max-w-4xl px-6 py-12">
-      <nav aria-label="Public navigation" className="flex flex-wrap gap-4">
-        <Link className="font-semibold text-[#2f6f73]" href="/">
-          Home
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/singers">
-          Find Singers
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-          Find Quartet Openings
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
-          Privacy
-        </Link>
-      </nav>
-
-      <header className="mt-10">
-        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-          Help
-        </p>
-        <h1 className="mt-4 text-4xl font-bold text-[#172023]">
-          How Quartet Member Finder Works
-        </h1>
-        <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
-          A practical guide for singers and quartets using the app before,
-          during, and after first contact.
-        </p>
-      </header>
-
-      <section className="mt-10 grid gap-5">
-        {publicHelpSections.map((section) => (
-          <article
-            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
-            key={section.heading}
-          >
-            <h2 className="text-xl font-bold text-[#172023]">
-              {section.heading}
-            </h2>
-            <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
-              {section.body.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
-              ))}
-            </div>
-          </article>
-        ))}
-      </section>
-
-      {user ? (
-        <HelpFeedbackForm status={params.feedback} />
-      ) : (
-        <section className="mt-10 border-t border-[#d7cec0] pt-8" id="feedback">
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto w-full max-w-4xl px-6 py-12">
+        <header>
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-            Feedback
+            Help
           </p>
-          <h2 className="mt-3 text-2xl font-bold text-[#172023]">
-            Send feedback after signing in
-          </h2>
-          <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Sign in if you want to send private feedback, bug reports, or
-            suggestions. Keeping feedback tied to an account helps prevent spam
-            and gives the project team a way to follow up.
+          <h1 className="mt-4 text-4xl font-bold text-[#172023]">
+            How Quartet Member Finder Works
+          </h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
+            A practical guide for singers and quartets using the app before,
+            during, and after first contact.
           </p>
-          <Link
-            className="mt-4 inline-flex rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
-            href="/sign-in?next=%2Fhelp"
-          >
-            Sign in to send feedback
-          </Link>
-        </section>
-      )}
+        </header>
 
-      <footer className="mt-10 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
-        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
-          Read the privacy overview
-        </Link>
-        {user ? null : (
-          <Link className="font-semibold text-[#2f6f73]" href="/sign-in">
-            Sign in
-          </Link>
+        <section className="mt-10 grid gap-5">
+          {publicHelpSections.map((section) => (
+            <article
+              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+              key={section.heading}
+            >
+              <h2 className="text-xl font-bold text-[#172023]">
+                {section.heading}
+              </h2>
+              <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
+                {section.body.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+
+        {user ? (
+          <HelpFeedbackForm status={params.feedback} />
+        ) : (
+          <section
+            className="mt-10 border-t border-[#d7cec0] pt-8"
+            id="feedback"
+          >
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+              Feedback
+            </p>
+            <h2 className="mt-3 text-2xl font-bold text-[#172023]">
+              Send feedback after signing in
+            </h2>
+            <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
+              Sign in if you want to send private feedback, bug reports, or
+              suggestions. Keeping feedback tied to an account helps prevent
+              spam and gives the project team a way to follow up.
+            </p>
+            <Link
+              className="mt-4 inline-flex rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+              href="/sign-in?next=%2Fhelp"
+            >
+              Sign in to send feedback
+            </Link>
+          </section>
         )}
-      </footer>
-    </main>
+      </main>
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { SiteFooter } from "@/components/navigation/site-footer";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -14,7 +15,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <div className="flex min-h-screen flex-col">
+          <div className="flex-1">{children}</div>
+          <SiteFooter />
+        </div>
+      </body>
     </html>
   );
 }

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
@@ -209,12 +210,10 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
   const markers = buildDiscoveryMapMarkers(mapItems);
 
   return (
-    <main className="mx-auto min-h-screen w-full max-w-6xl px-6 py-12">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
-          <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
-            Quartet Member Finder
-          </Link>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
             Discovery Map
           </h1>
@@ -223,180 +222,173 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
             region.
           </p>
         </div>
-        <div className="flex gap-4">
-          <Link className="font-semibold text-[#2f6f73]" href="/singers">
-            Find Singers
-          </Link>
-          <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-            Find Quartet Openings
-          </Link>
-          <Link className="font-semibold text-[#2f6f73]" href="/help">
-            Help
-          </Link>
-        </div>
-      </div>
 
-      <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5">
-        <label className="block">
-          <span className="text-sm font-semibold">Show</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={kind}
-            name="kind"
-          >
-            {kindOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Country</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.country)}
-            name="country"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Region</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.region)}
-            name="region"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Locality</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.locality)}
-            name="locality"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Part</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.part)}
-            name="part"
-          >
-            {partOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Goal</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.goal)}
-            name="goal"
-          >
-            {goalOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-5">
-          <button
-            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
-            type="submit"
-          >
-            Search
-          </button>
-          <Link className="font-semibold text-[#2f6f73]" href="/map">
-            Clear
-          </Link>
-        </div>
-      </form>
-
-      {errorMessage ? (
-        <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
-          {errorMessage}
-        </p>
-      ) : null}
-
-      <section className="mt-8 overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]">
-        <div
-          aria-label="Privacy-safe discovery map"
-          className="relative min-h-[420px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)]"
-          role="img"
-        >
-          <div className="absolute inset-x-0 top-0 flex items-center justify-between bg-white/80 px-4 py-3 text-sm text-[#394548] backdrop-blur">
-            <span>{markers.length} approximate regions</span>
-            <span>{mapItems.length} visible listings with public location</span>
-          </div>
-
-          {markers.map((marker) => (
-            <div
-              className="absolute max-w-48 -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm"
-              key={marker.id}
-              style={{
-                left: `${marker.xPercent}%`,
-                top: `${marker.yPercent}%`,
-              }}
+        <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5">
+          <label className="block">
+            <span className="text-sm font-semibold">Show</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={kind}
+              name="kind"
             >
-              <p className="font-bold text-[#172023]">{marker.label}</p>
-              <p className="mt-1 text-[#394548]">
-                {marker.count} {markerKindLabel(marker)}
-              </p>
-              {marker.parts.length > 0 ? (
-                <p className="mt-1 text-[#596466]">{tags(marker.parts)}</p>
-              ) : null}
-            </div>
-          ))}
-        </div>
-      </section>
+              {kindOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Country</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.country)}
+              name="country"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Region</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.region)}
+              name="region"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Locality</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.locality)}
+              name="locality"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Part</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.part)}
+              name="part"
+            >
+              {partOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Goal</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.goal)}
+              name="goal"
+            >
+              {goalOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-5">
+            <button
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              type="submit"
+            >
+              Search
+            </button>
+            <Link className="font-semibold text-[#2f6f73]" href="/map">
+              Clear
+            </Link>
+          </div>
+        </form>
 
-      <section className="mt-8 grid gap-4 md:grid-cols-2">
-        {markers.length === 0 && !errorMessage ? (
-          <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548] md:col-span-2">
-            <h2 className="text-xl font-bold text-[#172023]">
-              No approximate map regions match these filters yet
-            </h2>
-            <p className="mt-3 text-sm leading-6">
-              The map only shows visible singer profiles and quartet openings
-              with approximate public location data. Try clearing filters or
-              searching Find Singers and Find Quartet Openings directly.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-4">
-              <Link className="font-semibold text-[#2f6f73]" href="/map">
-                Clear filters
-              </Link>
-              <Link className="font-semibold text-[#2f6f73]" href="/singers">
-                Find Singers
-              </Link>
-              <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-                Find Quartet Openings
-              </Link>
-            </div>
-          </section>
+        {errorMessage ? (
+          <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            {errorMessage}
+          </p>
         ) : null}
 
-        {markers.map((marker) => (
-          <article
-            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
-            key={marker.id}
+        <section className="mt-8 overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]">
+          <div
+            aria-label="Privacy-safe discovery map"
+            className="relative min-h-[420px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)]"
+            role="img"
           >
-            <h2 className="text-xl font-bold text-[#172023]">{marker.label}</h2>
-            <p className="mt-2 text-sm text-[#394548]">
-              {marker.count} visible result{marker.count === 1 ? "" : "s"}:
-              {" " + markerSummary(marker)}
-            </p>
-            {marker.parts.length > 0 ? (
-              <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
-                {tags(marker.parts)}
+            <div className="absolute inset-x-0 top-0 flex items-center justify-between bg-white/80 px-4 py-3 text-sm text-[#394548] backdrop-blur">
+              <span>{markers.length} approximate regions</span>
+              <span>
+                {mapItems.length} visible listings with public location
+              </span>
+            </div>
+
+            {markers.map((marker) => (
+              <div
+                className="absolute max-w-48 -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm"
+                key={marker.id}
+                style={{
+                  left: `${marker.xPercent}%`,
+                  top: `${marker.yPercent}%`,
+                }}
+              >
+                <p className="font-bold text-[#172023]">{marker.label}</p>
+                <p className="mt-1 text-[#394548]">
+                  {marker.count} {markerKindLabel(marker)}
+                </p>
+                {marker.parts.length > 0 ? (
+                  <p className="mt-1 text-[#596466]">{tags(marker.parts)}</p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-4 md:grid-cols-2">
+          {markers.length === 0 && !errorMessage ? (
+            <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548] md:col-span-2">
+              <h2 className="text-xl font-bold text-[#172023]">
+                No approximate map regions match these filters yet
+              </h2>
+              <p className="mt-3 text-sm leading-6">
+                The map only shows visible singer profiles and quartet openings
+                with approximate public location data. Try clearing filters or
+                searching Find Singers and Find Quartet Openings directly.
               </p>
-            ) : null}
-          </article>
-        ))}
-      </section>
-    </main>
+              <div className="mt-4 flex flex-wrap gap-4">
+                <Link className="font-semibold text-[#2f6f73]" href="/map">
+                  Clear filters
+                </Link>
+                <Link className="font-semibold text-[#2f6f73]" href="/singers">
+                  Find Singers
+                </Link>
+                <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+                  Find Quartet Openings
+                </Link>
+              </div>
+            </section>
+          ) : null}
+
+          {markers.map((marker) => (
+            <article
+              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+              key={marker.id}
+            >
+              <h2 className="text-xl font-bold text-[#172023]">
+                {marker.label}
+              </h2>
+              <p className="mt-2 text-sm text-[#394548]">
+                {marker.count} visible result{marker.count === 1 ? "" : "s"}:
+                {" " + markerSummary(marker)}
+              </p>
+              {marker.parts.length > 0 ? (
+                <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
+                  {tags(marker.parts)}
+                </p>
+              ) : null}
+            </article>
+          ))}
+        </section>
+      </main>
+    </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { PRODUCT_NAME, PRODUCT_PROMISE } from "@/lib/app-metadata";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import Link from "next/link";
 
 const discoveryPaths = [
@@ -9,83 +10,77 @@ const discoveryPaths = [
 
 export default function Home() {
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col justify-center px-6 py-16">
-      <section className="max-w-3xl">
-        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-          Barbershop quartet discovery
-        </p>
-        <h1 className="mt-5 text-4xl font-bold leading-tight text-[#172023] sm:text-6xl">
-          {PRODUCT_NAME}
-        </h1>
-        <p className="mt-6 max-w-2xl text-lg leading-8 text-[#394548]">
-          {PRODUCT_PROMISE}
-        </p>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
-          Start as a singer looking for quartet openings, or use Find Singers
-          when you are helping an incomplete quartet fill a part.
-        </p>
-        <div className="mt-8 flex flex-wrap gap-3">
-          <Link
-            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
-            href="/quartets"
-          >
-            Find Quartet Openings
-          </Link>
-          <Link
-            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/singers"
-          >
-            Find Singers
-          </Link>
-          <Link
-            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/map"
-          >
-            View Map
-          </Link>
-          <Link
-            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/sign-in?next=%2Fapp%2Fprofile"
-          >
-            My Singer Profile
-          </Link>
-          <Link
-            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/sign-in?next=%2Fapp%2Flistings"
-          >
-            Quartet Mode
-          </Link>
-          <Link
-            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
-            href="/help"
-          >
-            Help
-          </Link>
-        </div>
-      </section>
-
-      <section
-        aria-label="Initial product scope"
-        className="mt-12 grid gap-4 sm:grid-cols-3"
-      >
-        {discoveryPaths.map((path) => (
-          <div
-            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
-            key={path}
-          >
-            <p className="text-base font-semibold leading-6">{path}</p>
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto flex w-full max-w-5xl flex-col px-6 py-14">
+        <section className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            Barbershop quartet discovery
+          </p>
+          <h1 className="mt-5 text-4xl font-bold leading-tight text-[#172023] sm:text-6xl">
+            {PRODUCT_NAME}
+          </h1>
+          <p className="mt-6 max-w-2xl text-lg leading-8 text-[#394548]">
+            {PRODUCT_PROMISE}
+          </p>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
+            Start as a singer looking for quartet openings, or use Find Singers
+            when you are helping an incomplete quartet fill a part.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+              href="/quartets"
+            >
+              Find Quartet Openings
+            </Link>
+            <Link
+              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              href="/singers"
+            >
+              Find Singers
+            </Link>
+            <Link
+              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              href="/map"
+            >
+              View Map
+            </Link>
+            <Link
+              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              href="/sign-in?next=%2Fapp%2Fprofile"
+            >
+              My Singer Profile
+            </Link>
+            <Link
+              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              href="/sign-in?next=%2Fapp%2Flistings"
+            >
+              Quartet Mode
+            </Link>
+            <Link
+              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              href="/help"
+            >
+              Help
+            </Link>
           </div>
-        ))}
-      </section>
+        </section>
 
-      <footer className="mt-12 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
-        <Link className="font-semibold text-[#2f6f73]" href="/help">
-          Help
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
-          Privacy
-        </Link>
-      </footer>
-    </main>
+        <section
+          aria-label="Initial product scope"
+          className="mt-12 grid gap-4 sm:grid-cols-3"
+        >
+          {discoveryPaths.map((path) => (
+            <div
+              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+              key={path}
+            >
+              <p className="text-base font-semibold leading-6">{path}</p>
+            </div>
+          ))}
+        </section>
+      </main>
+    </>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,63 +1,42 @@
-import Link from "next/link";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { publicPrivacySections } from "@/lib/content/public-pages";
 
 export default function PrivacyPage() {
   return (
-    <main className="mx-auto min-h-screen w-full max-w-4xl px-6 py-12">
-      <nav aria-label="Public navigation" className="flex flex-wrap gap-4">
-        <Link className="font-semibold text-[#2f6f73]" href="/">
-          Home
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/help">
-          Help
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/singers">
-          Find Singers
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-          Find Quartet Openings
-        </Link>
-      </nav>
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto w-full max-w-4xl px-6 py-12">
+        <header>
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            Privacy
+          </p>
+          <h1 className="mt-4 text-4xl font-bold text-[#172023]">
+            Privacy Overview
+          </h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
+            How Quartet Member Finder keeps public discovery useful without
+            exposing private contact details or exact home-location information.
+          </p>
+        </header>
 
-      <header className="mt-10">
-        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-          Privacy
-        </p>
-        <h1 className="mt-4 text-4xl font-bold text-[#172023]">
-          Privacy Overview
-        </h1>
-        <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
-          How Quartet Member Finder keeps public discovery useful without
-          exposing private contact details or exact home-location information.
-        </p>
-      </header>
-
-      <section className="mt-10 grid gap-5">
-        {publicPrivacySections.map((section) => (
-          <article
-            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
-            key={section.heading}
-          >
-            <h2 className="text-xl font-bold text-[#172023]">
-              {section.heading}
-            </h2>
-            <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
-              {section.body.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
-              ))}
-            </div>
-          </article>
-        ))}
-      </section>
-
-      <footer className="mt-10 flex flex-wrap gap-4 border-t border-[#d7cec0] pt-6">
-        <Link className="font-semibold text-[#2f6f73]" href="/help">
-          Read the help page
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/sign-in">
-          Sign in
-        </Link>
-      </footer>
-    </main>
+        <section className="mt-10 grid gap-5">
+          {publicPrivacySections.map((section) => (
+            <article
+              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+              key={section.heading}
+            >
+              <h2 className="text-xl font-bold text-[#172023]">
+                {section.heading}
+              </h2>
+              <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
+                {section.body.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+      </main>
+    </>
   );
 }

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
@@ -152,12 +153,10 @@ export default async function QuartetSearchPage({
   }
 
   return (
-    <main className="mx-auto min-h-screen w-full max-w-6xl px-6 py-12">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
-          <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
-            Quartet Member Finder
-          </Link>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
             Find Quartet Openings
           </h1>
@@ -166,231 +165,220 @@ export default async function QuartetSearchPage({
             missing parts. Results show approximate location only.
           </p>
         </div>
-        <div className="flex gap-4">
-          <Link className="font-semibold text-[#2f6f73]" href="/singers">
-            Find Singers
-          </Link>
-          <Link className="font-semibold text-[#2f6f73]" href="/map">
-            View Map
-          </Link>
-          <Link className="font-semibold text-[#2f6f73]" href="/help">
-            Help
-          </Link>
-        </div>
-      </div>
 
-      <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
-        <label className="block">
-          <span className="text-sm font-semibold">Country</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.country)}
-            name="country"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Region</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.region)}
-            name="region"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Locality</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.locality)}
-            name="locality"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Needed part</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.part)}
-            name="part"
-          >
-            {partOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Goal</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.goal)}
-            name="goal"
-          >
-            {goalOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Commitment</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.experience)}
-            name="experience"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Rehearsal</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.availability)}
-            name="availability"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Travel km</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(
-              filters.travelRadiusKm == null
-                ? null
-                : String(filters.travelRadiusKm),
-            )}
-            min={0}
-            name="travelRadiusKm"
-            type="number"
-          />
-        </label>
-        <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
-          <button
-            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
-            type="submit"
-          >
-            Search
-          </button>
-          <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-            Clear
-          </Link>
-        </div>
-      </form>
+        <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
+          <label className="block">
+            <span className="text-sm font-semibold">Country</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.country)}
+              name="country"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Region</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.region)}
+              name="region"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Locality</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.locality)}
+              name="locality"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Needed part</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.part)}
+              name="part"
+            >
+              {partOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Goal</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.goal)}
+              name="goal"
+            >
+              {goalOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Commitment</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.experience)}
+              name="experience"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Rehearsal</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.availability)}
+              name="availability"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Travel km</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(
+                filters.travelRadiusKm == null
+                  ? null
+                  : String(filters.travelRadiusKm),
+              )}
+              min={0}
+              name="travelRadiusKm"
+              type="number"
+            />
+          </label>
+          <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
+            <button
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              type="submit"
+            >
+              Search
+            </button>
+            <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+              Clear
+            </Link>
+          </div>
+        </form>
 
-      {contactStatus ? (
-        <p className={contactBannerClass(contactStatus.tone)}>
-          {contactStatus.text}
-        </p>
-      ) : null}
-
-      {errorMessage ? (
-        <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
-          {errorMessage}
-        </p>
-      ) : null}
-
-      <section className="mt-8 grid gap-4">
-        {quartets.length === 0 && !errorMessage ? (
-          <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
-            <h2 className="text-xl font-bold text-[#172023]">
-              No visible quartet openings match these filters yet
-            </h2>
-            <p className="mt-3 text-sm leading-6">
-              Try clearing filters, widening the country/region/locality, or
-              checking the map. Some quartets may not have turned on discovery
-              for their Quartet Mode listing yet.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-4">
-              <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-                Clear filters
-              </Link>
-              <Link className="font-semibold text-[#2f6f73]" href="/map">
-                View Map
-              </Link>
-              <Link className="font-semibold text-[#2f6f73]" href="/singers">
-                Find Singers
-              </Link>
-            </div>
-          </section>
+        {contactStatus ? (
+          <p className={contactBannerClass(contactStatus.tone)}>
+            {contactStatus.text}
+          </p>
         ) : null}
 
-        {quartets.map((quartet) => (
-          <article
-            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
-            key={quartet.id}
-          >
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h2 className="text-xl font-bold text-[#172023]">
-                  {quartet.name}
-                </h2>
-                <p className="mt-1 text-sm text-[#596466]">
-                  {approximateLocationLabel(
-                    toPublicLocationSummary({
-                      countryName: quartet.country_name,
-                      locality: quartet.locality,
-                      locationLabelPublic: quartet.location_label_public,
-                      region: quartet.region,
-                    }),
-                  )}
+        {errorMessage ? (
+          <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <section className="mt-8 grid gap-4">
+          {quartets.length === 0 && !errorMessage ? (
+            <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+              <h2 className="text-xl font-bold text-[#172023]">
+                No visible quartet openings match these filters yet
+              </h2>
+              <p className="mt-3 text-sm leading-6">
+                Try clearing filters, widening the country/region/locality, or
+                checking the map. Some quartets may not have turned on discovery
+                for their Quartet Mode listing yet.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-4">
+                <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+                  Clear filters
+                </Link>
+                <Link className="font-semibold text-[#2f6f73]" href="/map">
+                  View Map
+                </Link>
+                <Link className="font-semibold text-[#2f6f73]" href="/singers">
+                  Find Singers
+                </Link>
+              </div>
+            </section>
+          ) : null}
+
+          {quartets.map((quartet) => (
+            <article
+              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+              key={quartet.id}
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-xl font-bold text-[#172023]">
+                    {quartet.name}
+                  </h2>
+                  <p className="mt-1 text-sm text-[#596466]">
+                    {approximateLocationLabel(
+                      toPublicLocationSummary({
+                        countryName: quartet.country_name,
+                        locality: quartet.locality,
+                        locationLabelPublic: quartet.location_label_public,
+                        region: quartet.region,
+                      }),
+                    )}
+                  </p>
+                </div>
+                <p className="text-sm font-semibold text-[#2f6f73]">
+                  Seeking {tags(quartet.parts_needed)}
                 </p>
               </div>
-              <p className="text-sm font-semibold text-[#2f6f73]">
-                Seeking {tags(quartet.parts_needed)}
-              </p>
-            </div>
-            {quartet.description ? (
-              <p className="mt-4 text-sm leading-6 text-[#394548]">
-                {quartet.description}
-              </p>
-            ) : null}
-            <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">
-              {quartet.parts_covered.length > 0 ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Covered</dt>
-                  <dd>{tags(quartet.parts_covered)}</dd>
-                </div>
+              {quartet.description ? (
+                <p className="mt-4 text-sm leading-6 text-[#394548]">
+                  {quartet.description}
+                </p>
               ) : null}
-              {quartet.goals.length > 0 ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Goals</dt>
-                  <dd>{tags(quartet.goals)}</dd>
-                </div>
-              ) : null}
-              {quartet.experience_level ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Commitment</dt>
-                  <dd>{quartet.experience_level}</dd>
-                </div>
-              ) : null}
-              {quartet.availability ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Rehearsal</dt>
-                  <dd>{quartet.availability}</dd>
-                </div>
-              ) : null}
-              {travelRadiusLabel(
-                quartet.travel_radius_km,
-                quartet.preferred_distance_unit,
-              ) ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Travel</dt>
-                  <dd>
-                    {travelRadiusLabel(
-                      quartet.travel_radius_km,
-                      quartet.preferred_distance_unit,
-                    )}
-                  </dd>
-                </div>
-              ) : null}
-            </dl>
-            <ContactRequestForm
-              returnTo={returnTo}
-              targetId={quartet.id}
-              targetKind="quartet"
-              targetName={quartet.name}
-            />
-          </article>
-        ))}
-      </section>
-    </main>
+              <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">
+                {quartet.parts_covered.length > 0 ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Covered</dt>
+                    <dd>{tags(quartet.parts_covered)}</dd>
+                  </div>
+                ) : null}
+                {quartet.goals.length > 0 ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Goals</dt>
+                    <dd>{tags(quartet.goals)}</dd>
+                  </div>
+                ) : null}
+                {quartet.experience_level ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Commitment</dt>
+                    <dd>{quartet.experience_level}</dd>
+                  </div>
+                ) : null}
+                {quartet.availability ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Rehearsal</dt>
+                    <dd>{quartet.availability}</dd>
+                  </div>
+                ) : null}
+                {travelRadiusLabel(
+                  quartet.travel_radius_km,
+                  quartet.preferred_distance_unit,
+                ) ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Travel</dt>
+                    <dd>
+                      {travelRadiusLabel(
+                        quartet.travel_radius_km,
+                        quartet.preferred_distance_unit,
+                      )}
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+              <ContactRequestForm
+                returnTo={returnTo}
+                targetId={quartet.id}
+                targetKind="quartet"
+                targetName={quartet.name}
+              />
+            </article>
+          ))}
+        </section>
+      </main>
+    </>
   );
 }

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { signInWithEmail, verifyEmailOtp } from "@/app/auth/actions";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 
 type SignInPageProps = {
   searchParams: Promise<{
@@ -16,85 +16,77 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
   const email = params.email ?? "";
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-16">
-      <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
-        Quartet Member Finder
-      </Link>
-      <div className="mt-4 flex gap-4 text-sm">
-        <Link className="font-semibold text-[#2f6f73]" href="/help">
-          Help
-        </Link>
-        <Link className="font-semibold text-[#2f6f73]" href="/privacy">
-          Privacy
-        </Link>
-      </div>
-      <h1 className="mt-6 text-3xl font-bold text-[#172023]">Sign in</h1>
-      <p className="mt-3 text-base leading-7 text-[#394548]">
-        Enter your email address and Supabase will send a one-time code.
-      </p>
-
-      {params.error ? (
-        <p className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
-          {params.error}
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto flex w-full max-w-md flex-col px-6 py-12">
+        <h1 className="mt-6 text-3xl font-bold text-[#172023]">Sign in</h1>
+        <p className="mt-3 text-base leading-7 text-[#394548]">
+          Enter your email address and Supabase will send a one-time code.
         </p>
-      ) : null}
 
-      {params.message ? (
-        <p className="mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
-          {params.message}
-        </p>
-      ) : null}
+        {params.error ? (
+          <p className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            {params.error}
+          </p>
+        ) : null}
 
-      <form action={signInWithEmail} className="mt-8 space-y-4">
-        <input name="next" type="hidden" value={next} />
-        <label className="block">
-          <span className="text-sm font-semibold text-[#172023]">Email</span>
-          <input
-            autoComplete="email"
-            className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-            defaultValue={email}
-            name="email"
-            placeholder="singer@example.com"
-            required
-            type="email"
-          />
-        </label>
-        <button
-          className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
-          type="submit"
-        >
-          Send one-time code
-        </button>
-      </form>
+        {params.message ? (
+          <p className="mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+            {params.message}
+          </p>
+        ) : null}
 
-      {email ? (
-        <form
-          action={verifyEmailOtp}
-          className="mt-6 space-y-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4"
-        >
-          <input name="email" type="hidden" value={email} />
+        <form action={signInWithEmail} className="mt-8 space-y-4">
           <input name="next" type="hidden" value={next} />
           <label className="block">
-            <span className="text-sm font-semibold text-[#172023]">
-              One-time code
-            </span>
+            <span className="text-sm font-semibold text-[#172023]">Email</span>
             <input
-              autoComplete="one-time-code"
+              autoComplete="email"
               className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-              inputMode="numeric"
-              name="token"
-              placeholder="123456"
+              defaultValue={email}
+              name="email"
+              placeholder="singer@example.com"
               required
+              type="email"
             />
           </label>
           <button
             className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
             type="submit"
           >
-            Verify code
+            Send one-time code
           </button>
         </form>
-      ) : null}
-    </main>
+
+        {email ? (
+          <form
+            action={verifyEmailOtp}
+            className="mt-6 space-y-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4"
+          >
+            <input name="email" type="hidden" value={email} />
+            <input name="next" type="hidden" value={next} />
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                One-time code
+              </span>
+              <input
+                autoComplete="one-time-code"
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                inputMode="numeric"
+                name="token"
+                placeholder="123456"
+                required
+              />
+            </label>
+            <button
+              className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+              type="submit"
+            >
+              Verify code
+            </button>
+          </form>
+        ) : null}
+      </main>
+    </>
   );
 }

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
@@ -150,12 +151,10 @@ export default async function SingerSearchPage({
   }
 
   return (
-    <main className="mx-auto min-h-screen w-full max-w-6xl px-6 py-12">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <>
+      <PublicSiteHeader />
+      <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
-          <Link className="text-sm font-semibold text-[#2f6f73]" href="/">
-            Quartet Member Finder
-          </Link>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
             Find Singers
           </h1>
@@ -165,220 +164,211 @@ export default async function SingerSearchPage({
             show approximate location only.
           </p>
         </div>
-        <div className="flex gap-4">
-          <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-            Find Quartet Openings
-          </Link>
-          <Link className="font-semibold text-[#2f6f73]" href="/map">
-            View Map
-          </Link>
-          <Link className="font-semibold text-[#2f6f73]" href="/help">
-            Help
-          </Link>
-        </div>
-      </div>
 
-      <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
-        <label className="block">
-          <span className="text-sm font-semibold">Country</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.country)}
-            name="country"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Region</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.region)}
-            name="region"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Locality</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.locality)}
-            name="locality"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Part</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.part)}
-            name="part"
-          >
-            {partOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Goal</span>
-          <select
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.goal)}
-            name="goal"
-          >
-            {goalOptions.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Experience</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.experience)}
-            name="experience"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Availability</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(filters.availability)}
-            name="availability"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-semibold">Travel km</span>
-          <input
-            className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
-            defaultValue={textValue(
-              filters.travelRadiusKm == null
-                ? null
-                : String(filters.travelRadiusKm),
-            )}
-            min={0}
-            name="travelRadiusKm"
-            type="number"
-          />
-        </label>
-        <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
-          <button
-            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
-            type="submit"
-          >
-            Search
-          </button>
-          <Link className="font-semibold text-[#2f6f73]" href="/singers">
-            Clear
-          </Link>
-        </div>
-      </form>
+        <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
+          <label className="block">
+            <span className="text-sm font-semibold">Country</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.country)}
+              name="country"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Region</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.region)}
+              name="region"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Locality</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.locality)}
+              name="locality"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Part</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.part)}
+              name="part"
+            >
+              {partOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Goal</span>
+            <select
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.goal)}
+              name="goal"
+            >
+              {goalOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Experience</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.experience)}
+              name="experience"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Availability</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(filters.availability)}
+              name="availability"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">Travel km</span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              defaultValue={textValue(
+                filters.travelRadiusKm == null
+                  ? null
+                  : String(filters.travelRadiusKm),
+              )}
+              min={0}
+              name="travelRadiusKm"
+              type="number"
+            />
+          </label>
+          <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
+            <button
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              type="submit"
+            >
+              Search
+            </button>
+            <Link className="font-semibold text-[#2f6f73]" href="/singers">
+              Clear
+            </Link>
+          </div>
+        </form>
 
-      {contactStatus ? (
-        <p className={contactBannerClass(contactStatus.tone)}>
-          {contactStatus.text}
-        </p>
-      ) : null}
-
-      {errorMessage ? (
-        <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
-          {errorMessage}
-        </p>
-      ) : null}
-
-      <section className="mt-8 grid gap-4">
-        {singers.length === 0 && !errorMessage ? (
-          <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
-            <h2 className="text-xl font-bold text-[#172023]">
-              No visible singer profiles match these filters yet
-            </h2>
-            <p className="mt-3 text-sm leading-6">
-              Try clearing filters, widening the country/region/locality, or
-              checking the map. Early on, some singers may still be creating My
-              Singer Profile or keeping it hidden.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-4">
-              <Link className="font-semibold text-[#2f6f73]" href="/singers">
-                Clear filters
-              </Link>
-              <Link className="font-semibold text-[#2f6f73]" href="/map">
-                View Map
-              </Link>
-              <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-                Find Quartet Openings
-              </Link>
-            </div>
-          </section>
+        {contactStatus ? (
+          <p className={contactBannerClass(contactStatus.tone)}>
+            {contactStatus.text}
+          </p>
         ) : null}
 
-        {singers.map((singer) => (
-          <article
-            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
-            key={singer.id}
-          >
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h2 className="text-xl font-bold text-[#172023]">
-                  {singer.display_name}
-                </h2>
-                <p className="mt-1 text-sm text-[#596466]">
-                  {approximateLocationLabel(
-                    toPublicLocationSummary({
-                      countryName: singer.country_name,
-                      locality: singer.locality,
-                      locationLabelPublic: singer.location_label_public,
-                      region: singer.region,
-                    }),
-                  )}
+        {errorMessage ? (
+          <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <section className="mt-8 grid gap-4">
+          {singers.length === 0 && !errorMessage ? (
+            <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+              <h2 className="text-xl font-bold text-[#172023]">
+                No visible singer profiles match these filters yet
+              </h2>
+              <p className="mt-3 text-sm leading-6">
+                Try clearing filters, widening the country/region/locality, or
+                checking the map. Early on, some singers may still be creating
+                My Singer Profile or keeping it hidden.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-4">
+                <Link className="font-semibold text-[#2f6f73]" href="/singers">
+                  Clear filters
+                </Link>
+                <Link className="font-semibold text-[#2f6f73]" href="/map">
+                  View Map
+                </Link>
+                <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+                  Find Quartet Openings
+                </Link>
+              </div>
+            </section>
+          ) : null}
+
+          {singers.map((singer) => (
+            <article
+              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+              key={singer.id}
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-xl font-bold text-[#172023]">
+                    {singer.display_name}
+                  </h2>
+                  <p className="mt-1 text-sm text-[#596466]">
+                    {approximateLocationLabel(
+                      toPublicLocationSummary({
+                        countryName: singer.country_name,
+                        locality: singer.locality,
+                        locationLabelPublic: singer.location_label_public,
+                        region: singer.region,
+                      }),
+                    )}
+                  </p>
+                </div>
+                <p className="text-sm font-semibold text-[#2f6f73]">
+                  {tags(singer.parts)}
                 </p>
               </div>
-              <p className="text-sm font-semibold text-[#2f6f73]">
-                {tags(singer.parts)}
-              </p>
-            </div>
-            <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">
-              {singer.goals.length > 0 ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Goals</dt>
-                  <dd>{tags(singer.goals)}</dd>
-                </div>
-              ) : null}
-              {singer.experience_level ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Experience</dt>
-                  <dd>{singer.experience_level}</dd>
-                </div>
-              ) : null}
-              {singer.availability ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Availability</dt>
-                  <dd>{singer.availability}</dd>
-                </div>
-              ) : null}
-              {travelRadiusLabel(
-                singer.travel_radius_km,
-                singer.preferred_distance_unit,
-              ) ? (
-                <div>
-                  <dt className="font-semibold text-[#172023]">Travel</dt>
-                  <dd>
-                    {travelRadiusLabel(
-                      singer.travel_radius_km,
-                      singer.preferred_distance_unit,
-                    )}
-                  </dd>
-                </div>
-              ) : null}
-            </dl>
-            <ContactRequestForm
-              returnTo={returnTo}
-              targetId={singer.id}
-              targetKind="singer"
-              targetName={singer.display_name}
-            />
-          </article>
-        ))}
-      </section>
-    </main>
+              <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">
+                {singer.goals.length > 0 ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Goals</dt>
+                    <dd>{tags(singer.goals)}</dd>
+                  </div>
+                ) : null}
+                {singer.experience_level ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Experience</dt>
+                    <dd>{singer.experience_level}</dd>
+                  </div>
+                ) : null}
+                {singer.availability ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">
+                      Availability
+                    </dt>
+                    <dd>{singer.availability}</dd>
+                  </div>
+                ) : null}
+                {travelRadiusLabel(
+                  singer.travel_radius_km,
+                  singer.preferred_distance_unit,
+                ) ? (
+                  <div>
+                    <dt className="font-semibold text-[#172023]">Travel</dt>
+                    <dd>
+                      {travelRadiusLabel(
+                        singer.travel_radius_km,
+                        singer.preferred_distance_unit,
+                      )}
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+              <ContactRequestForm
+                returnTo={returnTo}
+                targetId={singer.id}
+                targetKind="singer"
+                targetName={singer.display_name}
+              />
+            </article>
+          ))}
+        </section>
+      </main>
+    </>
   );
 }

--- a/components/navigation/public-site-header.tsx
+++ b/components/navigation/public-site-header.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { publicNavigationLinks } from "@/lib/navigation/site-navigation";
+
+type PublicSiteHeaderProps = {
+  className?: string;
+};
+
+export function PublicSiteHeader({ className = "" }: PublicSiteHeaderProps) {
+  return (
+    <header className={`mx-auto w-full max-w-6xl px-6 pt-6 ${className}`}>
+      <div className="flex flex-col gap-4 border-b border-[#d7cec0] pb-4 sm:flex-row sm:items-center sm:justify-between">
+        <Link className="text-base font-bold text-[#172023]" href="/">
+          Quartet Member Finder
+        </Link>
+        <nav
+          aria-label="Public navigation"
+          className="flex flex-wrap gap-x-4 gap-y-2 text-sm"
+        >
+          {publicNavigationLinks.map((link) => (
+            <Link
+              className="font-semibold text-[#2f6f73] hover:text-[#174b4f]"
+              href={link.href}
+              key={link.href}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/navigation/site-footer.tsx
+++ b/components/navigation/site-footer.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { siteFooterLinks } from "@/lib/navigation/site-navigation";
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-[#d7cec0] bg-[#fffaf2]/70">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-[#596466]">
+          Quartet Member Finder helps singers and quartets connect with privacy
+          in mind.
+        </p>
+        <nav
+          aria-label="Site resources"
+          className="flex flex-wrap gap-x-4 gap-y-2 text-sm"
+        >
+          {siteFooterLinks.map((link) => (
+            <Link
+              className="font-semibold text-[#2f6f73] hover:text-[#174b4f]"
+              href={link.href}
+              key={link.href}
+              rel={link.href.startsWith("https://") ? "noreferrer" : undefined}
+              target={link.href.startsWith("https://") ? "_blank" : undefined}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -1,8 +1,4 @@
-export const signedInNavigationLinks = [
-  {
-    href: "/app",
-    label: "Home",
-  },
+export const signedInPrimaryNavigationLinks = [
   {
     href: "/app/profile",
     label: "My Singer Profile",
@@ -19,20 +15,24 @@ export const signedInNavigationLinks = [
     href: "/map",
     label: "Map",
   },
+] as const;
+
+export const signedInModeNavigationLinks = [
   {
     href: "/app/listings",
     label: "Quartet Mode",
   },
+] as const;
+
+export const signedInUtilityNavigationLinks = [
   {
     href: "/app/settings",
     label: "Account Settings",
   },
-  {
-    href: "/help",
-    label: "Help",
-  },
-  {
-    href: "/privacy",
-    label: "Privacy",
-  },
+] as const;
+
+export const signedInNavigationLinks = [
+  ...signedInPrimaryNavigationLinks,
+  ...signedInModeNavigationLinks,
+  ...signedInUtilityNavigationLinks,
 ] as const;

--- a/lib/navigation/site-navigation.ts
+++ b/lib/navigation/site-navigation.ts
@@ -1,0 +1,37 @@
+export const publicNavigationLinks = [
+  {
+    href: "/quartets",
+    label: "Find Quartet Openings",
+  },
+  {
+    href: "/singers",
+    label: "Find Singers",
+  },
+  {
+    href: "/map",
+    label: "Map",
+  },
+  {
+    href: "/sign-in",
+    label: "Sign in",
+  },
+  {
+    href: "/help",
+    label: "Help",
+  },
+] as const;
+
+export const siteFooterLinks = [
+  {
+    href: "/help",
+    label: "Help",
+  },
+  {
+    href: "/privacy",
+    label: "Privacy",
+  },
+  {
+    href: "https://github.com/coloradotim/quartet-member-finder",
+    label: "GitHub",
+  },
+] as const;

--- a/test/empty-states.test.ts
+++ b/test/empty-states.test.ts
@@ -5,6 +5,10 @@ function source(path: string) {
   return readFileSync(path, "utf8");
 }
 
+function normalizedSource(path: string) {
+  return source(path).replace(/\s+/g, " ");
+}
+
 describe("empty and first-time states", () => {
   it("guides first-time signed-in users from profile and Quartet Mode forms", () => {
     const profilePage = source("app/(protected)/app/profile/page.tsx");
@@ -33,7 +37,7 @@ describe("empty and first-time states", () => {
 
   it("explains sign-in for contact and feedback without exposing private data", () => {
     const contactForm = source("components/contact/contact-request-form.tsx");
-    const helpPage = source("app/help/page.tsx");
+    const helpPage = normalizedSource("app/help/page.tsx");
 
     expect(contactForm).toContain("Contact starts through the app");
     expect(contactForm).toContain("personal email addresses and phone");

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -1,32 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { signedInNavigationLinks } from "@/lib/navigation/signed-in-nav";
+import {
+  signedInModeNavigationLinks,
+  signedInNavigationLinks,
+  signedInPrimaryNavigationLinks,
+  signedInUtilityNavigationLinks,
+} from "@/lib/navigation/signed-in-nav";
 
 describe("signed-in navigation", () => {
-  it("foregrounds singer-first tasks before quartet mode", () => {
-    expect(signedInNavigationLinks.map((link) => link.label)).toEqual([
-      "Home",
+  it("groups singer-first tasks apart from quartet mode and utility actions", () => {
+    expect(signedInPrimaryNavigationLinks.map((link) => link.label)).toEqual([
       "My Singer Profile",
       "Find Quartet Openings",
       "Find Singers",
       "Map",
-      "Quartet Mode",
-      "Account Settings",
-      "Help",
-      "Privacy",
+    ]);
+    expect(signedInModeNavigationLinks).toEqual([
+      { href: "/app/listings", label: "Quartet Mode" },
+    ]);
+    expect(signedInUtilityNavigationLinks).toEqual([
+      { href: "/app/settings", label: "Account Settings" },
     ]);
   });
 
   it("keeps existing route targets for the reorganized labels", () => {
     expect(signedInNavigationLinks).toEqual([
-      { href: "/app", label: "Home" },
       { href: "/app/profile", label: "My Singer Profile" },
       { href: "/quartets", label: "Find Quartet Openings" },
       { href: "/singers", label: "Find Singers" },
       { href: "/map", label: "Map" },
       { href: "/app/listings", label: "Quartet Mode" },
       { href: "/app/settings", label: "Account Settings" },
-      { href: "/help", label: "Help" },
-      { href: "/privacy", label: "Privacy" },
     ]);
   });
 });

--- a/test/site-navigation.test.ts
+++ b/test/site-navigation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  publicNavigationLinks,
+  siteFooterLinks,
+} from "@/lib/navigation/site-navigation";
+
+describe("site navigation", () => {
+  it("keeps public discovery and help links available before login", () => {
+    expect(publicNavigationLinks).toEqual([
+      { href: "/quartets", label: "Find Quartet Openings" },
+      { href: "/singers", label: "Find Singers" },
+      { href: "/map", label: "Map" },
+      { href: "/sign-in", label: "Sign in" },
+      { href: "/help", label: "Help" },
+    ]);
+  });
+
+  it("keeps stable site resources in the shared footer", () => {
+    expect(siteFooterLinks).toEqual([
+      { href: "/help", label: "Help" },
+      { href: "/privacy", label: "Privacy" },
+      {
+        href: "https://github.com/coloradotim/quartet-member-finder",
+        label: "GitHub",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared public navigation and a root-level site footer with Help, Privacy, and GitHub links
- replace ad hoc public-page link clusters with the shared public header
- regroup signed-in navigation into singer-first tasks, Quartet Mode, and account utilities
- add navigation tests for public/footer links and signed-in grouping

Closes #54

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build
- local dev smoke check: /, /help, /privacy, /singers, /quartets, /map, and /sign-in returned 200 and rendered shared public nav/footer markers

## Supabase
- No schema, RLS, or data-contract changes; no migration required.