### PR TITLE
Improve accessibility and mobile usability

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -47,13 +47,16 @@ export default async function ProtectedAppLayout({
       <header className="border-b border-[#d7cec0] bg-[#fffaf2]/90">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <Link className="text-lg font-bold text-[#172023]" href="/app">
+            <Link
+              className="w-fit rounded-sm text-lg font-bold text-[#172023]"
+              href="/app"
+            >
               Quartet Member Finder
             </Link>
-            <div className="flex flex-wrap items-center gap-3">
+            <div className="flex flex-wrap items-center gap-2">
               {signedInUtilityNavigationLinks.map((link) => (
                 <Link
-                  className="text-sm font-semibold text-[#394548] hover:text-[#174b4f]"
+                  className="inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm font-semibold text-[#394548] hover:bg-white/70 hover:text-[#174b4f]"
                   href={link.href}
                   key={link.href}
                 >
@@ -74,10 +77,13 @@ export default async function ProtectedAppLayout({
             aria-label="App navigation"
             className="grid gap-3 lg:grid-cols-[1fr_auto]"
           >
-            <div className="flex flex-wrap gap-2" aria-label="Singer tasks">
+            <div
+              className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap"
+              aria-label="Singer tasks"
+            >
               {signedInPrimaryNavigationLinks.map((link) => (
                 <Link
-                  className="rounded-md border border-[#d7cec0] bg-white/60 px-3 py-2 text-sm font-semibold text-[#394548] hover:border-[#2f6f73] hover:text-[#174b4f]"
+                  className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] bg-white/60 px-3 py-2 text-center text-sm font-semibold text-[#394548] hover:border-[#2f6f73] hover:text-[#174b4f]"
                   href={link.href}
                   key={link.href}
                 >
@@ -85,10 +91,13 @@ export default async function ProtectedAppLayout({
                 </Link>
               ))}
             </div>
-            <div className="flex flex-wrap gap-2" aria-label="Quartet mode">
+            <div
+              className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap lg:justify-end"
+              aria-label="Quartet mode"
+            >
               {signedInModeNavigationLinks.map((link) => (
                 <Link
-                  className="rounded-md bg-[#174b4f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#10393c]"
+                  className="inline-flex min-h-11 items-center justify-center rounded-md bg-[#174b4f] px-3 py-2 text-center text-sm font-semibold text-white hover:bg-[#10393c]"
                   href={link.href}
                   key={link.href}
                 >

--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -112,13 +112,19 @@ export default async function ManageListingsPage({
       </div>
 
       {params.error ? (
-        <p className="mt-8 max-w-3xl rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+        <p
+          className="mt-8 max-w-3xl rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+          role="alert"
+        >
           {params.error}
         </p>
       ) : null}
 
       {params.message ? (
-        <p className="mt-8 max-w-3xl rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+        <p
+          className="mt-8 max-w-3xl rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]"
+          role="status"
+        >
           {params.message}
         </p>
       ) : null}
@@ -229,6 +235,10 @@ export default async function ManageListingsPage({
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Location</h2>
+          <p className="text-sm leading-6 text-[#394548]">
+            Use globally recognizable place names. Postal code is private and
+            public discovery should stay approximate.
+          </p>
           <label className="block">
             <span className="text-sm font-semibold text-[#172023]">
               Public approximate location
@@ -379,7 +389,7 @@ export default async function ManageListingsPage({
         </section>
 
         <button
-          className="rounded-md bg-[#174b4f] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          className="w-full rounded-md bg-[#174b4f] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
           type="submit"
         >
           Save quartet listing

--- a/app/(protected)/app/onboarding/page.tsx
+++ b/app/(protected)/app/onboarding/page.tsx
@@ -70,7 +70,10 @@ export default async function OnboardingPage({
       </header>
 
       {params.error ? (
-        <p className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+        <p
+          className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+          role="alert"
+        >
           {params.error}
         </p>
       ) : null}
@@ -92,7 +95,7 @@ export default async function OnboardingPage({
             <div className="mt-4 grid gap-4 md:grid-cols-2">
               {section.choices.map((choice) => (
                 <label
-                  className="block cursor-pointer rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm has-[:checked]:border-[#2f6f73] has-[:checked]:ring-2 has-[:checked]:ring-[#2f6f73]/20"
+                  className="block cursor-pointer rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm has-[:checked]:border-[#2f6f73] has-[:checked]:ring-2 has-[:checked]:ring-[#2f6f73]/20 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-[#2f6f73]"
                   key={choice.id}
                 >
                   <input
@@ -116,7 +119,7 @@ export default async function OnboardingPage({
 
         <div className="flex flex-wrap gap-3 border-t border-[#d7cec0] pt-6">
           <button
-            className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
             type="submit"
           >
             Continue
@@ -126,7 +129,10 @@ export default async function OnboardingPage({
 
       <form action={skipOnboarding}>
         <input name="next" type="hidden" value={next} />
-        <button className="font-semibold text-[#2f6f73]" type="submit">
+        <button
+          className="rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70"
+          type="submit"
+        >
           Skip for now
         </button>
       </form>

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -104,13 +104,19 @@ export default async function ManageProfilePage({
       </div>
 
       {params.error ? (
-        <p className="mt-8 max-w-3xl rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+        <p
+          className="mt-8 max-w-3xl rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+          role="alert"
+        >
           {params.error}
         </p>
       ) : null}
 
       {params.message ? (
-        <p className="mt-8 max-w-3xl rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+        <p
+          className="mt-8 max-w-3xl rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]"
+          role="status"
+        >
           {params.message}
         </p>
       ) : null}
@@ -195,6 +201,10 @@ export default async function ManageProfilePage({
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Location</h2>
+          <p className="text-sm leading-6 text-[#394548]">
+            Use globally recognizable place names. Postal code is private and
+            public discovery should stay approximate.
+          </p>
           <label className="block">
             <span className="text-sm font-semibold text-[#172023]">
               Public approximate location
@@ -347,7 +357,7 @@ export default async function ManageProfilePage({
         </section>
 
         <button
-          className="rounded-md bg-[#174b4f] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          className="w-full rounded-md bg-[#174b4f] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
           type="submit"
         >
           Save singer profile

--- a/app/(protected)/app/settings/page.tsx
+++ b/app/(protected)/app/settings/page.tsx
@@ -93,6 +93,7 @@ export default async function AccountSettingsPage({
               ? "border-red-200 bg-red-50 text-red-800"
               : "border-[#b7d7ce] bg-[#eef8f4] text-[#174b4f]"
           }`}
+          role={params.settings === "error" ? "alert" : "status"}
         >
           {message}
         </p>
@@ -123,7 +124,7 @@ export default async function AccountSettingsPage({
             settings for discovery details.
           </p>
           <button
-            className="w-fit rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+            className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
             type="submit"
           >
             Save settings
@@ -139,7 +140,7 @@ export default async function AccountSettingsPage({
         </p>
         <form action={resetOnboarding} className="mt-4">
           <button
-            className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-white"
+            className="w-full rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-white sm:w-fit"
             type="submit"
           >
             Re-run onboarding

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,3 +32,26 @@ body {
 a {
   color: inherit;
 }
+
+:where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+}
+
+:where(button, input, select, textarea) {
+  font: inherit;
+}
+
+:where(button, input, select, textarea) {
+  min-height: 44px;
+}
+
+:where(input[type="checkbox"], input[type="radio"]) {
+  min-height: auto;
+  min-width: 1rem;
+}
+
+::placeholder {
+  color: #6d7779;
+  opacity: 1;
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -71,7 +71,7 @@ export default async function HelpPage({ searchParams }: HelpPageProps) {
               spam and gives the project team a way to follow up.
             </p>
             <Link
-              className="mt-4 inline-flex rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+              className="mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
               href="/sign-in?next=%2Fhelp"
             >
               Sign in to send feedback

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -59,6 +59,9 @@ const goalOptions = [
   ["learning", "Learning"],
 ];
 
+const filterControlClass =
+  "mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20";
+
 function textValue(value: string | null) {
   return value ?? "";
 }
@@ -223,11 +226,14 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           </p>
         </div>
 
-        <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5">
+        <form
+          aria-label="Filter discovery map"
+          className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5"
+        >
           <label className="block">
             <span className="text-sm font-semibold">Show</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={kind}
               name="kind"
             >
@@ -241,31 +247,34 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           <label className="block">
             <span className="text-sm font-semibold">Country</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.country)}
               name="country"
+              placeholder="Australia"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Region</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.region)}
               name="region"
+              placeholder="Victoria"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Locality</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.locality)}
               name="locality"
+              placeholder="Melbourne"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Part</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.part)}
               name="part"
             >
@@ -279,7 +288,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           <label className="block">
             <span className="text-sm font-semibold">Goal</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.goal)}
               name="goal"
             >
@@ -290,21 +299,27 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
               ))}
             </select>
           </label>
-          <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-5">
+          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-5">
             <button
-              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
               type="submit"
             >
               Search
             </button>
-            <Link className="font-semibold text-[#2f6f73]" href="/map">
+            <Link
+              className="inline-flex min-h-11 items-center rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70"
+              href="/map"
+            >
               Clear
             </Link>
           </div>
         </form>
 
         {errorMessage ? (
-          <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          <p
+            className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            role="alert"
+          >
             {errorMessage}
           </p>
         ) : null}
@@ -312,10 +327,10 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
         <section className="mt-8 overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]">
           <div
             aria-label="Privacy-safe discovery map"
-            className="relative min-h-[420px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)]"
+            className="relative min-h-[520px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)] sm:min-h-[420px]"
             role="img"
           >
-            <div className="absolute inset-x-0 top-0 flex items-center justify-between bg-white/80 px-4 py-3 text-sm text-[#394548] backdrop-blur">
+            <div className="absolute inset-x-0 top-0 flex flex-col gap-1 bg-white/85 px-4 py-3 text-sm text-[#394548] backdrop-blur sm:flex-row sm:items-center sm:justify-between">
               <span>{markers.length} approximate regions</span>
               <span>
                 {mapItems.length} visible listings with public location
@@ -324,7 +339,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
 
             {markers.map((marker) => (
               <div
-                className="absolute max-w-48 -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm"
+                className="absolute max-w-[10rem] -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm [overflow-wrap:anywhere] sm:max-w-48"
                 key={marker.id}
                 style={{
                   left: `${marker.xPercent}%`,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,39 +27,39 @@ export default function Home() {
             Start as a singer looking for quartet openings, or use Find Singers
             when you are helping an incomplete quartet fill a part.
           </p>
-          <div className="mt-8 flex flex-wrap gap-3">
+          <div className="mt-8 grid gap-3 sm:flex sm:flex-wrap">
             <Link
-              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+              className="inline-flex min-h-11 items-center justify-center rounded-md bg-[#174b4f] px-4 py-2.5 text-center text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
               href="/quartets"
             >
               Find Quartet Openings
             </Link>
             <Link
-              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] px-4 py-2.5 text-center text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
               href="/singers"
             >
               Find Singers
             </Link>
             <Link
-              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] px-4 py-2.5 text-center text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
               href="/map"
             >
               View Map
             </Link>
             <Link
-              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] px-4 py-2.5 text-center text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
               href="/sign-in?next=%2Fapp%2Fprofile"
             >
               My Singer Profile
             </Link>
             <Link
-              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] px-4 py-2.5 text-center text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
               href="/sign-in?next=%2Fapp%2Flistings"
             >
               Quartet Mode
             </Link>
             <Link
-              className="rounded-md border border-[#d7cec0] px-4 py-2.5 text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] px-4 py-2.5 text-center text-sm font-semibold text-[#172023] hover:bg-[#fffaf2]"
               href="/help"
             >
               Help

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -49,6 +49,9 @@ const goalOptions = [
   ["learning", "Learning"],
 ];
 
+const filterControlClass =
+  "mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20";
+
 function textValue(value: string | null) {
   return value ?? "";
 }
@@ -166,35 +169,41 @@ export default async function QuartetSearchPage({
           </p>
         </div>
 
-        <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
+        <form
+          aria-label="Filter quartet openings"
+          className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4"
+        >
           <label className="block">
             <span className="text-sm font-semibold">Country</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.country)}
               name="country"
+              placeholder="United Kingdom"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Region</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.region)}
               name="region"
+              placeholder="Greater Manchester"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Locality</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.locality)}
               name="locality"
+              placeholder="Manchester"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Needed part</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.part)}
               name="part"
             >
@@ -208,7 +217,7 @@ export default async function QuartetSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Goal</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.goal)}
               name="goal"
             >
@@ -222,7 +231,7 @@ export default async function QuartetSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Commitment</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.experience)}
               name="experience"
             />
@@ -230,7 +239,7 @@ export default async function QuartetSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Rehearsal</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.availability)}
               name="availability"
             />
@@ -238,7 +247,7 @@ export default async function QuartetSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Travel km</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(
                 filters.travelRadiusKm == null
                   ? null
@@ -249,27 +258,36 @@ export default async function QuartetSearchPage({
               type="number"
             />
           </label>
-          <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
+          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-4">
             <button
-              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
               type="submit"
             >
               Search
             </button>
-            <Link className="font-semibold text-[#2f6f73]" href="/quartets">
+            <Link
+              className="inline-flex min-h-11 items-center rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70"
+              href="/quartets"
+            >
               Clear
             </Link>
           </div>
         </form>
 
         {contactStatus ? (
-          <p className={contactBannerClass(contactStatus.tone)}>
+          <p
+            className={contactBannerClass(contactStatus.tone)}
+            role={contactStatus.tone === "error" ? "alert" : "status"}
+          >
             {contactStatus.text}
           </p>
         ) : null}
 
         {errorMessage ? (
-          <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          <p
+            className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            role="alert"
+          >
             {errorMessage}
           </p>
         ) : null}

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -25,13 +25,19 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
         </p>
 
         {params.error ? (
-          <p className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          <p
+            className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            role="alert"
+          >
             {params.error}
           </p>
         ) : null}
 
         {params.message ? (
-          <p className="mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]">
+          <p
+            className="mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]"
+            role="status"
+          >
             {params.message}
           </p>
         ) : null}

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -47,6 +47,9 @@ const goalOptions = [
   ["learning", "Learning"],
 ];
 
+const filterControlClass =
+  "mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20";
+
 function textValue(value: string | null) {
   return value ?? "";
 }
@@ -165,35 +168,41 @@ export default async function SingerSearchPage({
           </p>
         </div>
 
-        <form className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4">
+        <form
+          aria-label="Filter singer profiles"
+          className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-4"
+        >
           <label className="block">
             <span className="text-sm font-semibold">Country</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.country)}
               name="country"
+              placeholder="Canada"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Region</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.region)}
               name="region"
+              placeholder="Ontario"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Locality</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.locality)}
               name="locality"
+              placeholder="Toronto"
             />
           </label>
           <label className="block">
             <span className="text-sm font-semibold">Part</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.part)}
               name="part"
             >
@@ -207,7 +216,7 @@ export default async function SingerSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Goal</span>
             <select
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.goal)}
               name="goal"
             >
@@ -221,7 +230,7 @@ export default async function SingerSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Experience</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.experience)}
               name="experience"
             />
@@ -229,7 +238,7 @@ export default async function SingerSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Availability</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(filters.availability)}
               name="availability"
             />
@@ -237,7 +246,7 @@ export default async function SingerSearchPage({
           <label className="block">
             <span className="text-sm font-semibold">Travel km</span>
             <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] px-3 py-2"
+              className={filterControlClass}
               defaultValue={textValue(
                 filters.travelRadiusKm == null
                   ? null
@@ -248,27 +257,36 @@ export default async function SingerSearchPage({
               type="number"
             />
           </label>
-          <div className="flex items-end gap-3 sm:col-span-2 lg:col-span-4">
+          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-4">
             <button
-              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
               type="submit"
             >
               Search
             </button>
-            <Link className="font-semibold text-[#2f6f73]" href="/singers">
+            <Link
+              className="inline-flex min-h-11 items-center rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70"
+              href="/singers"
+            >
               Clear
             </Link>
           </div>
         </form>
 
         {contactStatus ? (
-          <p className={contactBannerClass(contactStatus.tone)}>
+          <p
+            className={contactBannerClass(contactStatus.tone)}
+            role={contactStatus.tone === "error" ? "alert" : "status"}
+          >
             {contactStatus.text}
           </p>
         ) : null}
 
         {errorMessage ? (
-          <p className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          <p
+            className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            role="alert"
+          >
             {errorMessage}
           </p>
         ) : null}

--- a/components/contact/contact-request-form.tsx
+++ b/components/contact/contact-request-form.tsx
@@ -14,25 +14,28 @@ export function ContactRequestForm({
   targetKind,
   targetName,
 }: ContactRequestFormProps) {
+  const descriptionId = `contact-description-${targetKind}-${targetId}`;
+
   return (
     <form
+      aria-describedby={descriptionId}
       action={sendContactRequest}
       className="mt-5 rounded-md border border-[#d7cec0] bg-white p-4"
     >
       <input name="returnTo" type="hidden" value={returnTo} />
       <input name="targetId" type="hidden" value={targetId} />
       <input name="targetKind" type="hidden" value={targetKind} />
-      <p className="mb-3 text-sm leading-6 text-[#394548]">
+      <p className="mb-3 text-sm leading-6 text-[#394548]" id={descriptionId}>
         Contact starts through the app so personal email addresses and phone
         numbers stay private until both people choose to share them. You will be
         asked to sign in if you are not already signed in.
       </p>
       <label className="block">
-        <span className="text-sm font-semibold text-[#172023]">
+        <span className="text-sm font-semibold text-[#172023] [overflow-wrap:anywhere]">
           Contact {targetName}
         </span>
         <textarea
-          className="mt-2 min-h-24 w-full rounded-md border border-[#d7cec0] px-3 py-2 text-sm"
+          className="mt-2 min-h-28 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
           maxLength={2000}
           name="message"
           placeholder="Share a short, friendly note about the quartet opportunity."
@@ -40,7 +43,7 @@ export function ContactRequestForm({
         />
       </label>
       <button
-        className="mt-3 rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+        className="mt-3 w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
         type="submit"
       >
         Send contact request

--- a/components/feedback/help-feedback-form.tsx
+++ b/components/feedback/help-feedback-form.tsx
@@ -47,6 +47,7 @@ export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
               ? "border-[#b7d7ce] bg-[#eef8f4] text-[#174b4f]"
               : "border-red-200 bg-red-50 text-red-800"
           }`}
+          role={isSuccess ? "status" : "alert"}
         >
           {statusMessage}
         </p>
@@ -81,7 +82,7 @@ export function HelpFeedbackForm({ status }: HelpFeedbackFormProps) {
         </label>
 
         <button
-          className="w-fit rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+          className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
           type="submit"
         >
           Send feedback

--- a/components/navigation/public-site-header.tsx
+++ b/components/navigation/public-site-header.tsx
@@ -9,16 +9,19 @@ export function PublicSiteHeader({ className = "" }: PublicSiteHeaderProps) {
   return (
     <header className={`mx-auto w-full max-w-6xl px-6 pt-6 ${className}`}>
       <div className="flex flex-col gap-4 border-b border-[#d7cec0] pb-4 sm:flex-row sm:items-center sm:justify-between">
-        <Link className="text-base font-bold text-[#172023]" href="/">
+        <Link
+          className="w-fit rounded-sm text-base font-bold text-[#172023]"
+          href="/"
+        >
           Quartet Member Finder
         </Link>
         <nav
           aria-label="Public navigation"
-          className="flex flex-wrap gap-x-4 gap-y-2 text-sm"
+          className="grid grid-cols-2 gap-2 text-sm min-[420px]:flex min-[420px]:flex-wrap"
         >
           {publicNavigationLinks.map((link) => (
             <Link
-              className="font-semibold text-[#2f6f73] hover:text-[#174b4f]"
+              className="inline-flex min-h-11 items-center rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70 hover:text-[#174b4f]"
               href={link.href}
               key={link.href}
             >

--- a/docs/accessibility-mobile-audit.md
+++ b/docs/accessibility-mobile-audit.md
@@ -1,0 +1,33 @@
+# Accessibility and Mobile Audit
+
+This pre-launch audit covers the core public and signed-in flows:
+
+- public home
+- help and privacy pages
+- sign-in flow
+- signed-in dashboard
+- onboarding
+- My Singer Profile
+- Quartet Mode
+- Find Quartet Openings
+- Find Singers
+- Map
+- contact relay form
+- feedback form
+
+## Launch Checks
+
+- Public and signed-in navigation remain usable on phone-sized viewports.
+- Primary links and buttons have at least 44px tap targets.
+- Keyboard focus is visible across links, buttons, inputs, selects, textareas, and custom radio-card choices.
+- Search, contact, feedback, profile, listing, onboarding, and settings forms have visible labels.
+- Error and success messages use status or alert semantics where server-rendered feedback appears.
+- Search filters accept global country, region, locality, and long location strings without US-only assumptions.
+- Contact and feedback flows keep personal contact details private and retain app-mediated language.
+- The map remains a privacy-safe approximate regional view and includes text summaries below the visual map.
+
+## Follow-Up Issues
+
+- Add automated accessibility scanning to CI after the UI surface stabilizes.
+- Revisit the map if it becomes a real interactive map widget; keyboard panning, zoom controls, and marker popovers will need a separate accessibility pass.
+- Consider a compact mobile filter drawer if discovery filters grow beyond the current launch fields.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,3 +33,6 @@ Location, search, and distance tests should include non-US examples whenever the
 helper behavior touches geography, distance units, or public location display.
 Privacy-sensitive tests should assert that public helpers do not expose private
 postal codes, exact coordinates, email addresses, or phone numbers.
+
+Use `docs/accessibility-mobile-audit.md` for the current pre-launch
+accessibility and mobile usability audit notes.


### PR DESCRIPTION
Closes #43

## Summary
- add global visible focus and tap-target rules for keyboard and mobile usability
- improve public and signed-in navigation, search filters, map layout, contact form, feedback form, onboarding, profile, listing, and settings controls on narrow screens
- add status/alert semantics for server-rendered success and error messages
- document the pre-launch accessibility/mobile audit and follow-up items

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build
- local smoke check: /, /help, /privacy, /sign-in, /singers, /quartets, /map returned 200

## Supabase
- No schema, RLS, or data contract changes.