### PR TITLE
Add privacy-safe PostHog analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,15 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
+# Optional privacy-safe product analytics. Leave blank to disable analytics.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Local admin-only PostHog dashboard setup. Never deploy or commit a personal API key.
+POSTHOG_ENVIRONMENT_ID=404599
+POSTHOG_HOST=https://us.posthog.com
+POSTHOG_PERSONAL_API_KEY=
+
 # Server-only secrets. Never expose these in client components or browser bundles.
 SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Manual launch and deployment validation steps are documented in
 The final production-readiness and privacy launch checklist is documented in
 `docs/launch-readiness.md`.
 
+Privacy-safe PostHog event capture and launch dashboard setup are documented in
+`docs/posthog-analytics.md`.
+
 Vercel, Supabase, Resend, Namecheap DNS, and `quartetmemberfinder.org`
 deployment steps are documented in `docs/deployment.md`.
 

--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -1,0 +1,237 @@
+{
+  "version": 1,
+  "tags": ["quartet-member-finder", "managed-in-repo"],
+  "dashboards": [
+    {
+      "key": "product-health",
+      "name": "Quartet Member Finder - Product Health",
+      "description": "Core usage, analytics readiness, feedback, and route health.",
+      "insights": [
+        {
+          "key": "daily-active-users",
+          "name": "Daily active users",
+          "description": "Distinct signed-in users seen each day.",
+          "type": "trend",
+          "display": "ActionsLineGraph",
+          "dateFrom": "-30d",
+          "series": [{ "event": "user_logged_in", "math": "dau" }]
+        },
+        {
+          "key": "analytics-client-ready",
+          "name": "Analytics client ready",
+          "description": "Browser sessions where the configured analytics client accepted its first app event.",
+          "type": "trend",
+          "display": "BoldNumber",
+          "dateFrom": "-30d",
+          "series": [{ "event": "analytics_client_ready" }]
+        },
+        {
+          "key": "weekly-active-users",
+          "name": "Weekly active users",
+          "description": "Distinct signed-in users seen each week.",
+          "type": "trend",
+          "display": "ActionsLineGraph",
+          "dateFrom": "-12w",
+          "interval": "week",
+          "series": [{ "event": "user_logged_in", "math": "weekly_active" }]
+        },
+        {
+          "key": "top-routes",
+          "name": "Top routes",
+          "description": "Route visits grouped by normalized app route.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "route",
+          "series": [{ "event": "app_route_viewed" }]
+        },
+        {
+          "key": "feedback-submissions",
+          "name": "Feedback submissions",
+          "description": "Feedback sent successfully by type.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "feedback_type",
+          "series": [{ "event": "feedback_submitted" }]
+        }
+      ]
+    },
+    {
+      "key": "launch-funnel",
+      "name": "Quartet Member Finder - Launch Funnel",
+      "description": "From visiting the app to useful singer and quartet listing creation.",
+      "insights": [
+        {
+          "key": "singer-activation-funnel",
+          "name": "Singer activation funnel",
+          "description": "Visit, authenticate, complete onboarding, and save a singer profile.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "onboarding_completed" },
+            { "event": "singer_profile_saved" }
+          ]
+        },
+        {
+          "key": "quartet-activation-funnel",
+          "name": "Quartet activation funnel",
+          "description": "Visit, authenticate, complete onboarding, and save a quartet listing.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "onboarding_completed" },
+            { "event": "quartet_listing_saved" }
+          ]
+        },
+        {
+          "key": "launch-funnel-browser",
+          "name": "Launch funnel by browser",
+          "description": "Core launch funnel broken down by browser.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "breakdown": "$browser",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "onboarding_completed" },
+            { "event": "singer_profile_saved" }
+          ]
+        },
+        {
+          "key": "launch-funnel-device",
+          "name": "Launch funnel by device",
+          "description": "Core launch funnel broken down by device type.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "breakdown": "$device_type",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "onboarding_completed" },
+            { "event": "singer_profile_saved" }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "discovery-contact",
+      "name": "Quartet Member Finder - Discovery & Contact",
+      "description": "Whether users find relevant singers/quartets and turn discovery into app-mediated contact.",
+      "insights": [
+        {
+          "key": "discovery-searches-by-kind",
+          "name": "Discovery searches by kind",
+          "description": "Singer search vs quartet opening search, excluding private query values.",
+          "type": "trend",
+          "display": "ActionsLineGraph",
+          "dateFrom": "-30d",
+          "breakdown": "kind",
+          "series": [{ "event": "discovery_search_submitted" }]
+        },
+        {
+          "key": "map-views-by-kind",
+          "name": "Map views by result type",
+          "description": "Whether the privacy-safe map is used for singers, quartet openings, or both.",
+          "type": "trend",
+          "display": "ActionsLineGraph",
+          "dateFrom": "-30d",
+          "breakdown": "kind",
+          "series": [{ "event": "map_viewed" }]
+        },
+        {
+          "key": "discovery-to-contact-funnel",
+          "name": "Discovery to contact funnel",
+          "description": "Search or map discovery leading to app-mediated contact request submission.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "discovery_search_submitted" },
+            { "event": "contact_request_submitted" }
+          ]
+        },
+        {
+          "key": "contact-requests-by-target",
+          "name": "Contact requests by target",
+          "description": "App-mediated contact volume by singer/quartet target.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "target_kind",
+          "series": [{ "event": "contact_request_submitted" }]
+        },
+        {
+          "key": "contact-requests-by-status",
+          "name": "Contact requests by status",
+          "description": "Contact request delivery outcomes such as sent or stored.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "status",
+          "series": [{ "event": "contact_request_submitted" }]
+        }
+      ]
+    },
+    {
+      "key": "operations-privacy",
+      "name": "Quartet Member Finder - Operations & Privacy",
+      "description": "Launch density, visibility, privacy-safe feedback, and mobile/browser compatibility.",
+      "insights": [
+        {
+          "key": "visible-singer-profiles",
+          "name": "Visible singer profiles saved",
+          "description": "Profiles saved with visibility enabled; useful for launch density.",
+          "type": "trend",
+          "display": "BoldNumber",
+          "dateFrom": "-30d",
+          "properties": [{ "key": "visibility_enabled", "value": true }],
+          "series": [{ "event": "singer_profile_saved" }]
+        },
+        {
+          "key": "visible-quartet-listings",
+          "name": "Visible quartet listings saved",
+          "description": "Quartet listings saved with visibility enabled; useful for launch density.",
+          "type": "trend",
+          "display": "BoldNumber",
+          "dateFrom": "-30d",
+          "properties": [{ "key": "visibility_enabled", "value": true }],
+          "series": [{ "event": "quartet_listing_saved" }]
+        },
+        {
+          "key": "key-actions-by-browser",
+          "name": "Key actions by browser",
+          "description": "Profile, listing, search, and contact activity grouped by browser.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "$browser",
+          "series": [
+            { "event": "singer_profile_saved" },
+            { "event": "quartet_listing_saved" },
+            { "event": "discovery_search_submitted" },
+            { "event": "contact_request_submitted" }
+          ]
+        },
+        {
+          "key": "key-actions-by-device",
+          "name": "Key actions by device",
+          "description": "Profile, listing, search, and contact activity grouped by device type.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "$device_type",
+          "series": [
+            { "event": "singer_profile_saved" },
+            { "event": "quartet_listing_saved" },
+            { "event": "discovery_search_submitted" },
+            { "event": "contact_request_submitted" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -3,6 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
+import {
   buildQuartetPublicLocationLabel,
   inferQuartetLocationPrecision,
   parseQuartetListingFormData,
@@ -120,5 +124,15 @@ export async function saveQuartetListing(formData: FormData) {
   }
 
   revalidatePath("/app/listings");
+  await captureProductEvent(
+    "quartet_listing_saved",
+    {
+      is_visible: values.isVisible,
+      route: "/app/listings",
+      route_area: "signed_in_app",
+      visibility_enabled: values.isVisible,
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
   redirectWithListingMessage("message", "Quartet listing saved.");
 }

--- a/app/(protected)/app/onboarding/actions.ts
+++ b/app/(protected)/app/onboarding/actions.ts
@@ -7,6 +7,10 @@ import {
   normalizePostOnboardingPath,
 } from "@/lib/onboarding/app-onboarding";
 import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
+import {
   ensureAccountProfileForOnboarding,
   type AuthUserForOnboarding,
 } from "@/lib/onboarding/account-onboarding";
@@ -59,6 +63,16 @@ export async function completeOnboarding(formData: FormData) {
     redirect("/app/onboarding?error=Unable%20to%20save%20onboarding.");
   }
 
+  await captureProductEvent(
+    "onboarding_completed",
+    {
+      onboarding_choice: choiceId,
+      route: "/app/onboarding",
+      route_area: "signed_in_app",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
+
   redirect(destinationForOnboardingChoice(choiceId));
 }
 
@@ -83,6 +97,15 @@ export async function skipOnboarding(formData: FormData) {
   if (error) {
     redirect("/app/onboarding?error=Unable%20to%20skip%20onboarding.");
   }
+
+  await captureProductEvent(
+    "onboarding_skipped",
+    {
+      route: "/app/onboarding",
+      route_area: "signed_in_app",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
 
   redirect(next);
 }

--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -3,6 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
+import {
   buildPublicLocationLabel,
   inferLocationPrecision,
   parseSingerProfileFormData,
@@ -107,5 +111,15 @@ export async function saveSingerProfile(formData: FormData) {
   }
 
   revalidatePath("/app/profile");
+  await captureProductEvent(
+    "singer_profile_saved",
+    {
+      is_visible: values.isVisible,
+      route: "/app/profile",
+      route_area: "signed_in_app",
+      visibility_enabled: values.isVisible,
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
   redirectWithProfileMessage("message", "Singer profile saved.");
 }

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import {
+  captureProductEvent,
+  isProductAnalyticsEvent,
+  type ProductAnalyticsProperties,
+} from "@/lib/analytics/product-analytics";
+
+type AnalyticsRequestBody = {
+  distinctId?: unknown;
+  event?: unknown;
+  properties?: unknown;
+};
+
+function safeProperties(value: unknown): ProductAnalyticsProperties {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as ProductAnalyticsProperties;
+}
+
+export async function POST(request: Request) {
+  let body: AnalyticsRequestBody;
+
+  try {
+    body = (await request.json()) as AnalyticsRequestBody;
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  if (typeof body.event !== "string" || !isProductAnalyticsEvent(body.event)) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const distinctId =
+    typeof body.distinctId === "string" && body.distinctId.startsWith("anon_")
+      ? body.distinctId.slice(0, 80)
+      : undefined;
+
+  await captureProductEvent(body.event, safeProperties(body.properties), {
+    distinctId,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/analytics/status/route.ts
+++ b/app/api/analytics/status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getProductAnalyticsConfig } from "@/lib/analytics/product-analytics";
+
+export function GET() {
+  const config = getProductAnalyticsConfig();
+
+  return NextResponse.json({
+    posthogConfigured: Boolean(config),
+    posthogHost: config?.host ?? null,
+    posthogHostConfigured: Boolean(process.env.NEXT_PUBLIC_POSTHOG_HOST),
+    posthogKeyPresent: Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY),
+    vercelEnvironment: process.env.VERCEL_ENV ?? null,
+    vercelGitCommitSha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+  });
+}

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,17 +1,21 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
 import { firstSignInDestination } from "@/lib/onboarding/account-onboarding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function redirectWithMessage(
-  path: string,
+  route: string,
   key: "error" | "message",
   value: string,
 ): never {
-  const separator = path.includes("?") ? "&" : "?";
+  const separator = route.includes("?") ? "&" : "?";
 
-  redirect(`${path}${separator}${key}=${encodeURIComponent(value)}`);
+  redirect(`${route}${separator}${key}=${encodeURIComponent(value)}`);
 }
 
 export async function signInWithEmail(formData: FormData) {
@@ -103,6 +107,15 @@ export async function verifyEmailOtp(formData: FormData) {
   if (!user) {
     redirect(safeNext);
   }
+
+  await captureProductEvent(
+    "user_logged_in",
+    {
+      route: "/sign-in",
+      route_area: "auth",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
 
   redirect(await firstSignInDestination(supabase, user, safeNext));
 }

--- a/app/contact/actions.ts
+++ b/app/contact/actions.ts
@@ -3,6 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
+import {
   CONTACT_RATE_LIMIT_COUNT,
   contactRateLimitWindowStart,
   getContactRelayConfig,
@@ -136,6 +140,16 @@ export async function sendContactRequest(formData: FormData) {
 
   if (!admin || !relayConfig) {
     revalidatePath(values.returnTo);
+    await captureProductEvent(
+      "contact_request_submitted",
+      {
+        route: values.returnTo.split("?")[0] || values.returnTo,
+        route_area: "discovery",
+        status: "stored",
+        target_kind: values.targetKind,
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
     redirectWithContactStatus(values.returnTo, "stored");
   }
 
@@ -144,6 +158,16 @@ export async function sendContactRequest(formData: FormData) {
 
   if (recipientError || !recipient.user?.email) {
     revalidatePath(values.returnTo);
+    await captureProductEvent(
+      "contact_request_submitted",
+      {
+        route: values.returnTo.split("?")[0] || values.returnTo,
+        route_area: "discovery",
+        status: "stored",
+        target_kind: values.targetKind,
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
     redirectWithContactStatus(values.returnTo, "stored");
   }
 
@@ -161,9 +185,29 @@ export async function sendContactRequest(formData: FormData) {
       .eq("id", contactRequest.id);
   } catch {
     revalidatePath(values.returnTo);
+    await captureProductEvent(
+      "contact_request_submitted",
+      {
+        route: values.returnTo.split("?")[0] || values.returnTo,
+        route_area: "discovery",
+        status: "stored",
+        target_kind: values.targetKind,
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
     redirectWithContactStatus(values.returnTo, "stored");
   }
 
   revalidatePath(values.returnTo);
+  await captureProductEvent(
+    "contact_request_submitted",
+    {
+      route: values.returnTo.split("?")[0] || values.returnTo,
+      route_area: "discovery",
+      status: "sent",
+      target_kind: values.targetKind,
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
   redirectWithContactStatus(values.returnTo, "sent");
 }

--- a/app/help/actions.ts
+++ b/app/help/actions.ts
@@ -4,6 +4,10 @@ import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
+import {
   FEEDBACK_RATE_LIMIT_COUNT,
   feedbackRateLimitWindowStart,
   parseFeedbackFormData,
@@ -71,7 +75,7 @@ export async function submitHelpFeedback(formData: FormData) {
   const { data: feedbackSubmission, error: insertError } = await feedbackClient
     .from("feedback_submissions")
     .insert({
-      context_path: values.contextPath,
+      context_route: values.contextPath,
       feedback_type: values.feedbackType,
       message_body: values.message,
       submitter_email_private: user.email ?? null,
@@ -112,5 +116,15 @@ export async function submitHelpFeedback(formData: FormData) {
   }
 
   revalidatePath("/help");
+  await captureProductEvent(
+    "feedback_submitted",
+    {
+      feedback_type: values.feedbackType,
+      route: "/help",
+      route_area: "support",
+      status: "sent",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
   redirectWithFeedbackStatus("sent");
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AnalyticsPageTracker } from "@/components/analytics/analytics-page-tracker";
 import { SiteFooter } from "@/components/navigation/site-footer";
 import "./globals.css";
 
@@ -16,6 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <AnalyticsPageTracker />
         <div className="flex min-h-screen flex-col">
           <div className="flex-1">{children}</div>
           <SiteFooter />

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
@@ -70,6 +71,21 @@ function selectedKind(value: string | string[] | undefined) {
   const rawValue = Array.isArray(value) ? value[0] : value;
 
   return rawValue === "singers" || rawValue === "quartets" ? rawValue : "both";
+}
+
+function filterAnalyticsProperties(
+  filters: ReturnType<typeof parseDiscoveryFilters>,
+) {
+  const flags = {
+    has_country_filter: Boolean(filters.country),
+    has_goal_filter: Boolean(filters.goal),
+    has_locality_filter: Boolean(filters.locality),
+    has_part_filter: Boolean(filters.part),
+    has_region_filter: Boolean(filters.region),
+  };
+  const filterCount = Object.values(flags).filter(Boolean).length;
+
+  return { filterCount, flags };
 }
 
 function tags(values: string[]) {
@@ -211,6 +227,16 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
   }
 
   const markers = buildDiscoveryMapMarkers(mapItems);
+  const { filterCount, flags } = filterAnalyticsProperties(filters);
+
+  await captureProductEvent("map_viewed", {
+    ...flags,
+    filter_count: filterCount,
+    kind,
+    route: "/map",
+    result_count: mapItems.length,
+    route_area: "map",
+  });
 
   return (
     <>

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
 import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
@@ -80,6 +81,24 @@ function returnToPath(params: Record<string, string | string[] | undefined>) {
   return queryString ? `/quartets?${queryString}` : "/quartets";
 }
 
+function filterAnalyticsProperties(
+  filters: ReturnType<typeof parseDiscoveryFilters>,
+) {
+  const flags = {
+    has_availability_filter: Boolean(filters.availability),
+    has_country_filter: Boolean(filters.country),
+    has_experience_filter: Boolean(filters.experience),
+    has_goal_filter: Boolean(filters.goal),
+    has_locality_filter: Boolean(filters.locality),
+    has_part_filter: Boolean(filters.part),
+    has_region_filter: Boolean(filters.region),
+    has_travel_filter: filters.travelRadiusKm != null,
+  };
+  const filterCount = Object.values(flags).filter(Boolean).length;
+
+  return { filterCount, flags };
+}
+
 function contactBannerClass(tone: "error" | "notice" | "success") {
   if (tone === "error") {
     return "mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800";
@@ -153,6 +172,19 @@ export default async function QuartetSearchPage({
     } else {
       quartets = (data ?? []) as QuartetDiscoveryRow[];
     }
+  }
+
+  const { filterCount, flags } = filterAnalyticsProperties(filters);
+
+  if (filterCount > 0) {
+    await captureProductEvent("discovery_search_submitted", {
+      ...flags,
+      filter_count: filterCount,
+      kind: "quartet",
+      route: "/quartets",
+      result_count: quartets.length,
+      route_area: "discovery",
+    });
   }
 
   return (

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
 import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
@@ -78,6 +79,24 @@ function returnToPath(params: Record<string, string | string[] | undefined>) {
   return queryString ? `/singers?${queryString}` : "/singers";
 }
 
+function filterAnalyticsProperties(
+  filters: ReturnType<typeof parseDiscoveryFilters>,
+) {
+  const flags = {
+    has_availability_filter: Boolean(filters.availability),
+    has_country_filter: Boolean(filters.country),
+    has_experience_filter: Boolean(filters.experience),
+    has_goal_filter: Boolean(filters.goal),
+    has_locality_filter: Boolean(filters.locality),
+    has_part_filter: Boolean(filters.part),
+    has_region_filter: Boolean(filters.region),
+    has_travel_filter: filters.travelRadiusKm != null,
+  };
+  const filterCount = Object.values(flags).filter(Boolean).length;
+
+  return { filterCount, flags };
+}
+
 function contactBannerClass(tone: "error" | "notice" | "success") {
   if (tone === "error") {
     return "mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800";
@@ -151,6 +170,19 @@ export default async function SingerSearchPage({
     } else {
       singers = (data ?? []) as SingerDiscoveryRow[];
     }
+  }
+
+  const { filterCount, flags } = filterAnalyticsProperties(filters);
+
+  if (filterCount > 0) {
+    await captureProductEvent("discovery_search_submitted", {
+      ...flags,
+      filter_count: filterCount,
+      kind: "singer",
+      route: "/singers",
+      result_count: singers.length,
+      route_area: "discovery",
+    });
   }
 
   return (

--- a/components/analytics/analytics-page-tracker.tsx
+++ b/components/analytics/analytics-page-tracker.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import {
+  trackAnalyticsClientReady,
+  trackClientProductEvent,
+} from "@/lib/analytics/client-analytics";
+
+function routeArea(pathname: string) {
+  if (pathname.startsWith("/app")) {
+    return "signed_in_app";
+  }
+
+  if (pathname === "/singers" || pathname === "/quartets") {
+    return "discovery";
+  }
+
+  if (pathname === "/map") {
+    return "map";
+  }
+
+  if (pathname === "/help" || pathname === "/privacy") {
+    return "support";
+  }
+
+  if (pathname === "/sign-in") {
+    return "auth";
+  }
+
+  return "public";
+}
+
+export function AnalyticsPageTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackAnalyticsClientReady();
+  }, []);
+
+  useEffect(() => {
+    trackClientProductEvent("app_route_viewed", {
+      route: pathname,
+      route_area: routeArea(pathname),
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,8 @@ Expected variables will likely include:
 
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_POSTHOG_KEY` optional product analytics key
+- `NEXT_PUBLIC_POSTHOG_HOST` optional PostHog ingest host
 - `SUPABASE_SERVICE_ROLE_KEY` for server-only administrative scripts, never browser code
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
@@ -339,6 +341,12 @@ environment variables:
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
 
+Optional product analytics values may also live in Vercel Production
+environment variables:
+
+- `NEXT_PUBLIC_POSTHOG_KEY`
+- `NEXT_PUBLIC_POSTHOG_HOST`
+
 Those values are pulled by `vercel pull --environment=production` before the
 Vercel production build. They should not be added to GitHub Actions unless a
 future workflow step explicitly needs them.
@@ -445,6 +453,17 @@ Geocoding provider secrets, if any, must be server-only. Browser-rendered map
 props should contain approximate public labels, regional anchors, rounded
 distances, or jittered/blurred marker positions, never exact private
 latitude/longitude or private address fields.
+
+## Product analytics
+
+PostHog product analytics is optional. Set `NEXT_PUBLIC_POSTHOG_KEY` in Vercel
+Production to enable it, and set `NEXT_PUBLIC_POSTHOG_HOST` if the project uses
+a non-default PostHog region.
+
+The app sends only allowlisted privacy-safe product events through
+`/api/analytics` or trusted server actions. Do not configure session replay,
+autocapture of form fields, advertising pixels, or direct user identification
+without a separate privacy review and documentation update.
 
 ## Production readiness checklist
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -7,6 +7,7 @@ The app will need environment variables for:
 - app base URL
 - Supabase project URL
 - Supabase public browser client value
+- optional PostHog product analytics configuration
 - server-only Supabase administrative value, if needed for scripts or trusted server tasks
 - Resend API access
 - Resend sender email
@@ -17,6 +18,8 @@ The current scaffold includes `.env.example` with safe placeholder keys:
 - `NEXT_PUBLIC_APP_URL`
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_POSTHOG_KEY` optional privacy-safe product analytics project key
+- `NEXT_PUBLIC_POSTHOG_HOST` optional PostHog host, defaulting to the US ingest host
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
@@ -112,3 +115,21 @@ The MVP discovery map does not require a map provider. Optional public map
 values are reserved for a future MapLibre/OpenStreetMap-compatible tile setup.
 Geocoding secrets, if later needed, should be server-only and must not use the
 `NEXT_PUBLIC_` prefix.
+
+## Product Analytics
+
+PostHog analytics is optional and disabled when `NEXT_PUBLIC_POSTHOG_KEY` is
+blank.
+
+When enabled, analytics uses an internal app endpoint that accepts only
+allowlisted product events and safe properties. The app may track route views and
+high-level funnel events such as onboarding completion, profile/listing saves,
+discovery searches, map views, contact request submission, and feedback
+submission.
+
+Do not send email addresses, display names, profile/listing text, contact or
+feedback message text, postal codes, exact coordinates, phone numbers, or raw
+private ownership identifiers to PostHog.
+
+Set `NEXT_PUBLIC_POSTHOG_HOST` if the project uses a non-default PostHog region,
+for example `https://eu.i.posthog.com`.

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -59,14 +59,15 @@ Record before launch:
 
 ## Environment Variables and Secrets
 
-| Status   | Item                                                                          | Verification                                                                      |
-| -------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Complete | Required GitHub deployment secrets are documented.                            | `docs/deployment.md#github-production-deployment-secrets`; `docs/environment.md`. |
-| Complete | Runtime-only server secrets stay in Vercel Production, not browser code.      | `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`.               |
-| Complete | Browser-exposed values are limited to public `NEXT_PUBLIC_*` configuration.   | `.env.example`; `docs/environment.md`.                                            |
-| Manual   | Confirm GitHub has production workflow secrets for deployment.                | GitHub repository or `production` environment secrets.                            |
-| Manual   | Confirm Vercel Production has runtime secrets for contact and feedback email. | Vercel project environment variables.                                             |
-| Manual   | Confirm no real `.env` file or secret value is tracked by git.                | CI guardrails and local `git status`.                                             |
+| Status   | Item                                                                                                                                    | Verification                                                                      |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Complete | Required GitHub deployment secrets are documented.                                                                                      | `docs/deployment.md#github-production-deployment-secrets`; `docs/environment.md`. |
+| Complete | Runtime-only server secrets stay in Vercel Production, not browser code.                                                                | `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`.               |
+| Complete | Browser-exposed values are limited to public `NEXT_PUBLIC_*` configuration.                                                             | `.env.example`; `docs/environment.md`.                                            |
+| Manual   | Confirm GitHub has production workflow secrets for deployment.                                                                          | GitHub repository or `production` environment secrets.                            |
+| Manual   | Confirm Vercel Production has runtime secrets for contact and feedback email.                                                           | Vercel project environment variables.                                             |
+| Manual   | If analytics is desired for launch, confirm Vercel Production has `NEXT_PUBLIC_POSTHOG_KEY` and the correct `NEXT_PUBLIC_POSTHOG_HOST`. | Vercel project environment variables and PostHog project settings.                |
+| Manual   | Confirm no real `.env` file or secret value is tracked by git.                                                                          | CI guardrails and local `git status`.                                             |
 
 ## Supabase Database, RLS, and Auth
 
@@ -104,6 +105,16 @@ Record before launch:
 | Complete | Hidden singer profiles and quartet listings are excluded from public discovery.                                             | Discovery views and smoke tests.                     |
 | Manual   | Run the final privacy sweep against public pages and page source.                                                           | `docs/smoke-test-plan.md#final-privacy-sweep`.       |
 | Manual   | Confirm public pages do not imply real-time chat, formal moderation, or public direct contact details.                      | `/help` and `/privacy` copy review.                  |
+
+## Product Analytics
+
+| Status    | Item                                                                                                                           | Verification                                          |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| Complete  | Product analytics is disabled when PostHog configuration is missing.                                                           | `lib/analytics/product-analytics.ts`; `.env.example`. |
+| Complete  | Analytics events use an allowlist and sanitize properties before forwarding to PostHog.                                        | `lib/analytics/product-analytics.ts`; tests.          |
+| Complete  | Analytics avoids email addresses, names, message text, postal codes, exact coordinates, and raw private ownership identifiers. | `docs/privacy-model.md#product-analytics-model`.      |
+| Manual    | Confirm PostHog receives page-view and funnel events in production if analytics is enabled.                                    | PostHog dashboard after smoke test.                   |
+| Follow-up | Add richer analytics dashboards or funnels after launch behavior clarifies what matters.                                       | PostHog product analysis, not app code.               |
 
 ## Core User Flows
 

--- a/docs/posthog-analytics.md
+++ b/docs/posthog-analytics.md
@@ -1,0 +1,146 @@
+# PostHog Analytics
+
+Quartet Member Finder uses optional, privacy-safe PostHog product analytics to
+understand whether early users can reach the useful parts of the app.
+
+Analytics must answer product questions without collecting personal content.
+
+## Configuration
+
+Production event capture uses Vercel environment variables:
+
+```text
+NEXT_PUBLIC_POSTHOG_KEY=<PostHog project token>
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+Leave `NEXT_PUBLIC_POSTHOG_KEY` blank to disable analytics.
+
+Dashboard creation is a local/admin operation and uses a PostHog personal API
+key, not the project token:
+
+```text
+POSTHOG_ENVIRONMENT_ID=404599
+POSTHOG_HOST=https://us.posthog.com
+POSTHOG_PERSONAL_API_KEY=<personal API key>
+```
+
+Do not add `POSTHOG_PERSONAL_API_KEY` to Vercel or commit it to the repository.
+`POSTHOG_PROJECT_ID` is accepted as a fallback name for older PostHog docs, but
+`POSTHOG_ENVIRONMENT_ID` matches the current PostHog dashboard and insight API
+paths.
+
+## Event Model
+
+Allowed events are defined in `lib/analytics/product-analytics.ts`.
+
+Current events:
+
+- `analytics_client_ready`
+- `app_route_viewed`
+- `user_logged_in`
+- `onboarding_completed`
+- `onboarding_skipped`
+- `singer_profile_saved`
+- `quartet_listing_saved`
+- `discovery_search_submitted`
+- `map_viewed`
+- `contact_request_submitted`
+- `feedback_submitted`
+
+Allowed properties are intentionally narrow. They include route area, public
+route path, filter-presence booleans, result counts, target kind, visibility
+enabled flags, feedback type, generic status, and onboarding choice.
+
+Never send:
+
+- email addresses
+- display names
+- profile bio or listing description text
+- contact request or feedback message text
+- postal codes
+- exact latitude or longitude
+- phone numbers
+- raw private ownership or recipient identifiers
+
+Signed-in server events may use a pseudonymous hash of the authenticated user ID
+so funnel steps can be understood without identifying users by direct personal
+information.
+
+## Dashboards
+
+Dashboard definitions live in `analytics/posthog/dashboards.json`.
+
+Validate the dashboard spec locally with:
+
+```bash
+npm run posthog:dashboards:check
+```
+
+Sync the dashboards to PostHog with:
+
+```bash
+POSTHOG_PERSONAL_API_KEY=<personal-api-key> npm run posthog:dashboards:sync
+```
+
+For a narrow test loop, sync selected cards to the sandbox dashboard:
+
+```bash
+POSTHOG_PERSONAL_API_KEY=<personal-api-key> \
+npm run posthog:dashboards:sync -- --sandbox --only top-routes,analytics-client-ready
+```
+
+Inspect or compare saved PostHog cards without editing them:
+
+```bash
+POSTHOG_PERSONAL_API_KEY=<personal-api-key> \
+npm run posthog:dashboards:inspect -- --dashboard "Quartet Member Finder - Product Health"
+
+POSTHOG_PERSONAL_API_KEY=<personal-api-key> \
+npm run posthog:dashboards:inspect -- --insight "Top routes"
+
+POSTHOG_PERSONAL_API_KEY=<personal-api-key> \
+npm run posthog:dashboards:compare -- --left "Top routes" --right "Manual working Top routes"
+```
+
+The script targets environment `404599` by default and creates four dashboard
+groups:
+
+- `Quartet Member Finder - Product Health`: client readiness, active users,
+  route health, and feedback.
+- `Quartet Member Finder - Launch Funnel`: sign-in, onboarding, singer profile,
+  and quartet listing activation.
+- `Quartet Member Finder - Discovery & Contact`: discovery search, map usage,
+  and contact request
+  conversion.
+- `Quartet Member Finder - Operations & Privacy`: visible listing/listing
+  density, browser/device compatibility, and privacy-safe feedback signals.
+
+The sync script is intentionally idempotent by dashboard and insight name:
+
+- existing dashboards are patched by exact name
+- existing insights are patched by exact name
+- missing dashboards and insights are created
+- `--only insight-key-1,insight-key-2` limits sync to selected insight keys
+- `--sandbox` writes selected cards to the dashboard sync sandbox and prefixes
+  insight names with `Sandbox -`
+- insights use PostHog query objects wrapped as visualization nodes, not legacy
+  filters
+- event-property breakdowns are generated with PostHog query breakdown entries
+
+## Launch Review
+
+After analytics is deployed and the dashboard script has run:
+
+1. Run the production smoke test plan.
+2. Confirm PostHog receives page-view events.
+3. Confirm at least one funnel event reaches each launch dashboard where the
+   smoke test exercises that flow.
+4. Confirm no event properties contain private contact, exact location, profile,
+   listing, contact-message, or feedback-message content.
+
+Use `/api/analytics/status` on the deployed app to verify that the production
+build has the public PostHog configuration baked in. The route reports only
+safe values: whether a key is present, whether a host is configured, the host
+name, and Vercel environment/commit metadata when available. It never returns
+the project token or personal API key.

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -182,6 +182,36 @@ views, search results, maps, or public profile/listing UI. Regular authenticated
 users cannot read other users' feedback. Admin/service-role access is required
 for cross-user review or triage.
 
+## Product analytics model
+
+The app may use PostHog for privacy-safe product analytics so the project can
+understand launch usage, onboarding completion, discovery activity, contact
+requests, and feedback submission without reading private user content.
+
+Analytics is optional and disabled when PostHog environment variables are not
+configured. When enabled, browser tracking sends route-view events through an
+internal app endpoint, and server actions send high-level funnel events after
+successful actions.
+
+Allowed analytics properties are intentionally narrow, such as route area,
+public route path, result counts, filter-presence booleans, target kind,
+visibility enabled flags, generic status, feedback type, and onboarding choice.
+
+Analytics must not send:
+
+- email addresses
+- display names
+- profile bio or quartet listing descriptions
+- contact request or feedback message text
+- postal codes
+- exact latitude or longitude
+- phone numbers
+- raw private ownership or recipient identifiers
+
+Signed-in server events may use a pseudonymous hash of the authenticated user ID
+so funnel steps can be understood without identifying users by direct personal
+information.
+
 ## Onboarding model
 
 First-run onboarding asks signed-in users what they want to do first, not what

--- a/lib/analytics/client-analytics.ts
+++ b/lib/analytics/client-analytics.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import type {
+  ProductAnalyticsEvent,
+  ProductAnalyticsProperties,
+} from "@/lib/analytics/product-analytics";
+
+const ANALYTICS_ID_STORAGE_KEY = "qmf_analytics_id";
+const ANALYTICS_READY_STORAGE_KEY = "qmf_analytics_ready";
+
+function browserAnalyticsId() {
+  if (typeof window === "undefined") {
+    return "browser";
+  }
+
+  const existing = window.localStorage.getItem(ANALYTICS_ID_STORAGE_KEY);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created = `anon_${window.crypto.randomUUID()}`;
+  window.localStorage.setItem(ANALYTICS_ID_STORAGE_KEY, created);
+
+  return created;
+}
+
+export function trackClientProductEvent(
+  event: ProductAnalyticsEvent,
+  properties: ProductAnalyticsProperties = {},
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const payload = JSON.stringify({
+    distinctId: browserAnalyticsId(),
+    event,
+    properties,
+  });
+
+  if (navigator.sendBeacon) {
+    const blob = new Blob([payload], { type: "application/json" });
+    navigator.sendBeacon("/api/analytics", blob);
+    return;
+  }
+
+  void fetch("/api/analytics", {
+    body: payload,
+    headers: {
+      "content-type": "application/json",
+    },
+    keepalive: true,
+    method: "POST",
+  });
+}
+
+export function trackAnalyticsClientReady() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (window.sessionStorage.getItem(ANALYTICS_READY_STORAGE_KEY)) {
+    return;
+  }
+
+  window.sessionStorage.setItem(ANALYTICS_READY_STORAGE_KEY, "1");
+  trackClientProductEvent("analytics_client_ready");
+}

--- a/lib/analytics/product-analytics.ts
+++ b/lib/analytics/product-analytics.ts
@@ -1,0 +1,146 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export const PRODUCT_ANALYTICS_EVENTS = [
+  "analytics_client_ready",
+  "app_route_viewed",
+  "user_logged_in",
+  "onboarding_completed",
+  "onboarding_skipped",
+  "singer_profile_saved",
+  "quartet_listing_saved",
+  "discovery_search_submitted",
+  "map_viewed",
+  "contact_request_submitted",
+  "feedback_submitted",
+] as const;
+
+export type ProductAnalyticsEvent = (typeof PRODUCT_ANALYTICS_EVENTS)[number];
+
+export type ProductAnalyticsProperties = Record<
+  string,
+  boolean | number | string | null | undefined
+>;
+
+type AnalyticsConfig = {
+  host: string;
+  key: string;
+};
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const SAFE_PROPERTY_KEYS = new Set([
+  "feedback_type",
+  "filter_count",
+  "has_availability_filter",
+  "has_country_filter",
+  "has_experience_filter",
+  "has_goal_filter",
+  "has_locality_filter",
+  "has_part_filter",
+  "has_region_filter",
+  "has_travel_filter",
+  "is_visible",
+  "kind",
+  "onboarding_choice",
+  "route",
+  "result_count",
+  "route_area",
+  "status",
+  "target_kind",
+  "visibility_enabled",
+]);
+
+export function productAnalyticsIsConfigured() {
+  return Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
+}
+
+export function getProductAnalyticsConfig(): AnalyticsConfig | null {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+
+  if (!key) {
+    return null;
+  }
+
+  return {
+    host:
+      process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim().replace(/\/$/, "") ||
+      DEFAULT_POSTHOG_HOST,
+    key,
+  };
+}
+
+export function isProductAnalyticsEvent(
+  event: string,
+): event is ProductAnalyticsEvent {
+  return PRODUCT_ANALYTICS_EVENTS.includes(event as ProductAnalyticsEvent);
+}
+
+export function sanitizeAnalyticsProperties(
+  properties: ProductAnalyticsProperties = {},
+) {
+  const sanitized: Record<string, boolean | number | string | null> = {};
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (!SAFE_PROPERTY_KEYS.has(key) || value === undefined) {
+      continue;
+    }
+
+    if (
+      typeof value === "boolean" ||
+      typeof value === "number" ||
+      typeof value === "string" ||
+      value === null
+    ) {
+      sanitized[key] = typeof value === "string" ? value.slice(0, 160) : value;
+    }
+  }
+
+  return sanitized;
+}
+
+export function pseudonymousAnalyticsUserId(userId: string) {
+  return createHash("sha256")
+    .update(`qmf-analytics:${userId}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function createAnonymousAnalyticsId() {
+  return `anon_${randomUUID()}`;
+}
+
+export async function captureProductEvent(
+  event: ProductAnalyticsEvent,
+  properties: ProductAnalyticsProperties = {},
+  options: { distinctId?: string } = {},
+) {
+  const config = getProductAnalyticsConfig();
+
+  if (!config) {
+    return { ok: false, skipped: true };
+  }
+
+  const distinctId = options.distinctId ?? createAnonymousAnalyticsId();
+
+  try {
+    const response = await fetch(`${config.host}/capture/`, {
+      body: JSON.stringify({
+        api_key: config.key,
+        distinct_id: distinctId,
+        event,
+        properties: {
+          ...sanitizeAnalyticsProperties(properties),
+          app: "quartet_member_finder",
+        },
+      }),
+      cache: "no-store",
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    return { ok: response.ok, skipped: false };
+  } catch {
+    return { ok: false, skipped: false };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "posthog:dashboards:check": "node scripts/posthog/check-dashboards.mjs",
+    "posthog:dashboards:compare": "node scripts/posthog/compare-dashboards.mjs",
+    "posthog:dashboards:inspect": "node scripts/posthog/inspect-dashboards.mjs",
+    "posthog:dashboards:sync": "node scripts/posthog/sync-dashboards.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run"

--- a/scripts/posthog/check-dashboards.mjs
+++ b/scripts/posthog/check-dashboards.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import {
+  dashboardSpecPath,
+  readDashboardSpec,
+  validateDashboardSpec,
+} from "./dashboard-utils.mjs";
+
+const spec = await readDashboardSpec();
+const errors = validateDashboardSpec(spec);
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Dashboard spec OK: ${dashboardSpecPath} (${spec.dashboards.length} dashboards)`,
+);

--- a/scripts/posthog/compare-dashboards.mjs
+++ b/scripts/posthog/compare-dashboards.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { findInsightByName, parseArgs } from "./dashboard-utils.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.left || !args.right) {
+  console.error('Pass --left "Insight name" --right "Insight name".');
+  process.exit(1);
+}
+
+const left = await findInsightByName(args.left);
+const right = await findInsightByName(args.right);
+
+console.log(
+  JSON.stringify(
+    {
+      left: {
+        filters: left?.filters,
+        name: left?.name,
+        query: left?.query,
+      },
+      right: {
+        filters: right?.filters,
+        name: right?.name,
+        query: right?.query,
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/posthog/dashboard-utils.mjs
+++ b/scripts/posthog/dashboard-utils.mjs
@@ -1,0 +1,266 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+export const dashboardSpecPath = join(
+  repoRoot,
+  "analytics/posthog/dashboards.json",
+);
+
+export async function readDashboardSpec() {
+  return JSON.parse(await readFile(dashboardSpecPath, "utf8"));
+}
+
+export function posthogConfig() {
+  const environmentId =
+    process.env.POSTHOG_ENVIRONMENT_ID ||
+    process.env.POSTHOG_PROJECT_ID ||
+    "404599";
+  const personalApiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+
+  return { environmentId, host, personalApiKey };
+}
+
+export function requirePosthogConfig() {
+  const config = posthogConfig();
+
+  if (!config.personalApiKey) {
+    console.error(
+      "Missing POSTHOG_PERSONAL_API_KEY. Create a PostHog personal API key with dashboard/insight read-write access, then rerun.",
+    );
+    process.exit(1);
+  }
+
+  return config;
+}
+
+export async function posthogApi(path, { body, method = "GET" } = {}) {
+  const { environmentId, host, personalApiKey } = requirePosthogConfig();
+  const response = await fetch(`${host}/api/projects/${environmentId}${path}`, {
+    body: body ? JSON.stringify(body) : undefined,
+    headers: {
+      authorization: `Bearer ${personalApiKey}`,
+      "content-type": "application/json",
+    },
+    method,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `PostHog API ${method} ${path} failed with ${response.status}: ${text}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+export function parseArgs(args) {
+  const parsed = {
+    only: null,
+    sandbox: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--sandbox") {
+      parsed.sandbox = true;
+    } else if (arg === "--only") {
+      parsed.only = (args[index + 1] || "")
+        .split(",")
+        .map((key) => key.trim())
+        .filter(Boolean);
+      index += 1;
+    } else if (arg.startsWith("--only=")) {
+      parsed.only = arg
+        .slice("--only=".length)
+        .split(",")
+        .map((key) => key.trim())
+        .filter(Boolean);
+    } else if (arg === "--dashboard") {
+      parsed.dashboard = args[index + 1];
+      index += 1;
+    } else if (arg === "--insight") {
+      parsed.insight = args[index + 1];
+      index += 1;
+    } else if (arg === "--left") {
+      parsed.left = args[index + 1];
+      index += 1;
+    } else if (arg === "--right") {
+      parsed.right = args[index + 1];
+      index += 1;
+    }
+  }
+
+  return parsed;
+}
+
+export function dashboardIdsForInsight(insight) {
+  if (!Array.isArray(insight.dashboards)) {
+    return [];
+  }
+
+  return insight.dashboards
+    .map((dashboard) =>
+      typeof dashboard === "number" ? dashboard : dashboard?.id,
+    )
+    .filter(Boolean);
+}
+
+export async function findDashboardByName(name) {
+  const response = await posthogApi(
+    `/dashboards/?search=${encodeURIComponent(name)}`,
+  );
+  const dashboards = response.results || response;
+
+  return dashboards.find((dashboard) => dashboard.name === name) || null;
+}
+
+export async function findInsightByName(name) {
+  const response = await posthogApi(
+    `/insights/?saved=true&search=${encodeURIComponent(name)}`,
+  );
+  const insights = response.results || response;
+
+  return insights.find((insight) => insight.name === name) || null;
+}
+
+function seriesMath(series) {
+  if (series.math === "dau") {
+    return "dau";
+  }
+
+  if (series.math === "weekly_active") {
+    return "weekly_active";
+  }
+
+  return series.math || "total";
+}
+
+export function seriesToEventsNode(series) {
+  return {
+    event: series.event,
+    kind: "EventsNode",
+    math: seriesMath(series),
+    math_property: series.mathProperty,
+    name: series.event,
+  };
+}
+
+function breakdownFilter(insight) {
+  if (!insight.breakdown) {
+    return undefined;
+  }
+
+  return {
+    breakdowns: [
+      {
+        property: insight.breakdown,
+        type: insight.breakdown.startsWith("$") ? "person" : "event",
+      },
+    ],
+  };
+}
+
+function insightProperties(insight) {
+  if (!Array.isArray(insight.properties)) {
+    return undefined;
+  }
+
+  return insight.properties.map((property) => ({
+    key: property.key,
+    operator: property.operator || "exact",
+    type: property.type || "event",
+    value: property.value,
+  }));
+}
+
+function sourceQuery(insight) {
+  if (insight.type === "funnel") {
+    return {
+      breakdownFilter: breakdownFilter(insight),
+      dateRange: {
+        date_from: insight.dateFrom,
+      },
+      funnelsFilter: {
+        funnelOrderType: "ordered",
+        layout: "horizontal",
+      },
+      kind: "FunnelsQuery",
+      series: insight.series.map(seriesToEventsNode),
+    };
+  }
+
+  return {
+    breakdownFilter: breakdownFilter(insight),
+    dateRange: {
+      date_from: insight.dateFrom,
+    },
+    kind: "TrendsQuery",
+    properties: insightProperties(insight),
+    series: insight.series.map(seriesToEventsNode),
+    trendsFilter: {
+      display: insight.display || "ActionsLineGraph",
+    },
+  };
+}
+
+export function insightQuery(insight) {
+  return {
+    kind: "InsightVizNode",
+    source: sourceQuery(insight),
+  };
+}
+
+export function validateDashboardSpec(spec) {
+  const errors = [];
+  const dashboardKeys = new Set();
+  const insightKeys = new Set();
+
+  if (spec.version !== 1) {
+    errors.push("Expected dashboard spec version 1.");
+  }
+
+  for (const dashboard of spec.dashboards || []) {
+    if (!dashboard.key || dashboardKeys.has(dashboard.key)) {
+      errors.push(`Dashboard has missing or duplicate key: ${dashboard.key}`);
+    }
+    dashboardKeys.add(dashboard.key);
+
+    if (!dashboard.name) {
+      errors.push(`Dashboard ${dashboard.key} is missing a name.`);
+    }
+
+    for (const insight of dashboard.insights || []) {
+      if (!insight.key || insightKeys.has(insight.key)) {
+        errors.push(`Insight has missing or duplicate key: ${insight.key}`);
+      }
+      insightKeys.add(insight.key);
+
+      if (!["funnel", "trend"].includes(insight.type)) {
+        errors.push(
+          `Insight ${insight.key} has unsupported type ${insight.type}.`,
+        );
+      }
+
+      if (!Array.isArray(insight.series) || insight.series.length === 0) {
+        errors.push(
+          `Insight ${insight.key} must define at least one event series.`,
+        );
+      }
+    }
+  }
+
+  return errors;
+}

--- a/scripts/posthog/inspect-dashboards.mjs
+++ b/scripts/posthog/inspect-dashboards.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import {
+  findDashboardByName,
+  findInsightByName,
+  parseArgs,
+} from "./dashboard-utils.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.dashboard && !args.insight) {
+  console.error(
+    'Pass --dashboard "Dashboard name" or --insight "Insight name".',
+  );
+  process.exit(1);
+}
+
+if (args.dashboard) {
+  const dashboard = await findDashboardByName(args.dashboard);
+  console.log(JSON.stringify(dashboard, null, 2));
+}
+
+if (args.insight) {
+  const insight = await findInsightByName(args.insight);
+  console.log(JSON.stringify(insight, null, 2));
+}

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import {
+  dashboardIdsForInsight,
+  findDashboardByName,
+  findInsightByName,
+  insightQuery,
+  parseArgs,
+  posthogApi,
+  posthogConfig,
+  readDashboardSpec,
+  validateDashboardSpec,
+} from "./dashboard-utils.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const spec = await readDashboardSpec();
+const errors = validateDashboardSpec(spec);
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+const only = args.only ? new Set(args.only) : null;
+const dashboardName = args.sandbox
+  ? "Quartet Member Finder - Dashboard Sync Sandbox"
+  : null;
+
+for (const dashboardSpec of spec.dashboards) {
+  const selectedInsights = dashboardSpec.insights.filter(
+    (insight) => !only || only.has(insight.key),
+  );
+
+  if (selectedInsights.length === 0) {
+    continue;
+  }
+
+  const name = dashboardName || dashboardSpec.name;
+  const existingDashboard = await findDashboardByName(name);
+  const dashboard =
+    existingDashboard ||
+    (await posthogApi("/dashboards/", {
+      body: {
+        description: args.sandbox
+          ? "Sandbox dashboard for testing repo-managed QMF dashboard cards."
+          : dashboardSpec.description,
+        name,
+        pinned: true,
+        tags: spec.tags,
+      },
+      method: "POST",
+    }));
+
+  if (existingDashboard) {
+    await posthogApi(`/dashboards/${dashboard.id}/`, {
+      body: {
+        description: args.sandbox
+          ? "Sandbox dashboard for testing repo-managed QMF dashboard cards."
+          : dashboardSpec.description,
+        name,
+        pinned: true,
+        tags: spec.tags,
+      },
+      method: "PATCH",
+    });
+  }
+
+  console.log(
+    `${existingDashboard ? "Using" : "Created"} dashboard: ${dashboard.name} (${dashboard.id})`,
+  );
+
+  for (const insightSpec of selectedInsights) {
+    const insightName = args.sandbox
+      ? `Sandbox - ${insightSpec.name}`
+      : insightSpec.name;
+    const existingInsight = await findInsightByName(insightName);
+    const payload = {
+      dashboards: [dashboard.id],
+      description: insightSpec.description,
+      name: insightName,
+      query: insightQuery(insightSpec),
+      saved: true,
+      tags: spec.tags,
+    };
+
+    if (existingInsight) {
+      const dashboardIds = dashboardIdsForInsight(existingInsight);
+      await posthogApi(`/insights/${existingInsight.id}/`, {
+        body: {
+          ...payload,
+          dashboards: Array.from(new Set([...dashboardIds, dashboard.id])),
+        },
+        method: "PATCH",
+      });
+      console.log(`  Updated insight: ${insightName} (${existingInsight.id})`);
+      continue;
+    }
+
+    const insight = await posthogApi("/insights/", {
+      body: payload,
+      method: "POST",
+    });
+
+    console.log(`  Created insight: ${insight.name} (${insight.id})`);
+  }
+}
+
+const { environmentId, host } = posthogConfig();
+console.log(
+  `Dashboard sync complete for PostHog environment ${environmentId} at ${host}.`,
+);

--- a/test/product-analytics.test.ts
+++ b/test/product-analytics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getProductAnalyticsConfig,
+  isProductAnalyticsEvent,
+  productAnalyticsIsConfigured,
+  pseudonymousAnalyticsUserId,
+  sanitizeAnalyticsProperties,
+} from "@/lib/analytics/product-analytics";
+
+describe("product analytics helpers", () => {
+  it("only accepts allowlisted analytics events", () => {
+    expect(isProductAnalyticsEvent("analytics_client_ready")).toBe(true);
+    expect(isProductAnalyticsEvent("app_route_viewed")).toBe(true);
+    expect(isProductAnalyticsEvent("user_logged_in")).toBe(true);
+    expect(isProductAnalyticsEvent("contact_request_submitted")).toBe(true);
+    expect(isProductAnalyticsEvent("profile_bio_changed")).toBe(false);
+  });
+
+  it("drops private or unknown event properties", () => {
+    expect(
+      sanitizeAnalyticsProperties({
+        email: "singer@example.com",
+        feedback_type: "bug",
+        latitude_private: 40.5,
+        message_body: "private message",
+        route: "/help",
+        postal_code_private: "M1 TEST",
+        result_count: 2,
+      }),
+    ).toEqual({
+      feedback_type: "bug",
+      route: "/help",
+      result_count: 2,
+    });
+  });
+
+  it("uses PostHog configuration only when a project key is present", () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "");
+
+    expect(productAnalyticsIsConfigured()).toBe(false);
+    expect(getProductAnalyticsConfig()).toBeNull();
+
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "ph_project_key");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com/");
+
+    expect(productAnalyticsIsConfigured()).toBe(true);
+    expect(getProductAnalyticsConfig()).toEqual({
+      host: "https://eu.i.posthog.com",
+      key: "ph_project_key",
+    });
+
+    vi.unstubAllEnvs();
+  });
+
+  it("creates a stable pseudonymous user id without exposing the source id", () => {
+    const userId = "123e4567-e89b-12d3-a456-426614174000";
+
+    expect(pseudonymousAnalyticsUserId(userId)).toBe(
+      pseudonymousAnalyticsUserId(userId),
+    );
+    expect(pseudonymousAnalyticsUserId(userId)).not.toContain(userId);
+    expect(pseudonymousAnalyticsUserId(userId)).toHaveLength(32);
+  });
+});


### PR DESCRIPTION
Closes #62

## Summary
- add optional privacy-safe PostHog event capture through an allowlisted analytics endpoint
- track route views, analytics client readiness, login, onboarding, profile/listing saves, discovery searches, map views, contact requests, and feedback submissions without personal content
- add /api/analytics/status for production configuration verification
- add repo-managed PostHog dashboard definitions using the WCWS-style versioned dashboards.json pattern
- add dashboard check/sync/inspect/compare scripts with sandbox sync support
- document analytics privacy, setup, dashboard sync, and launch verification

## PostHog dashboards
- Synced sandbox dashboard first with top-routes and analytics-client-ready cards
- Synced full managed dashboards in PostHog environment 404599:
  - Quartet Member Finder - Product Health
  - Quartet Member Finder - Launch Funnel
  - Quartet Member Finder - Discovery & Contact
  - Quartet Member Finder - Operations & Privacy
- Verified Product Health exists, is pinned, tagged managed-in-repo/quartet-member-finder, and belongs to team 404599

## Verification
- npm run posthog:dashboards:check
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build

## Supabase
- No schema, RLS, or data contract changes.