### PR TITLE
Unify public discovery around Find

### DIFF
--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -141,9 +141,9 @@ export default async function ManageListingsPage({
           </p>
           <Link
             className="mt-4 inline-flex font-semibold text-[#2f6f73]"
-            href="/singers"
+            href="/find?kind=singers"
           >
-            Browse Find Singers first
+            Browse singers in Find first
           </Link>
         </section>
       ) : listing.is_visible ? null : (
@@ -152,9 +152,9 @@ export default async function ManageListingsPage({
             This quartet listing is hidden
           </h2>
           <p className="mt-3 text-sm leading-6 text-[#394548]">
-            Hidden listings do not appear in Find Quartet Openings or on the
-            map, so singers cannot discover them yet. Turn on visibility below
-            when the listing is ready.
+            Hidden listings do not appear in Find, detailed quartet search, or
+            the map view, so singers cannot discover them yet. Turn on
+            visibility below when the listing is ready.
           </p>
         </section>
       )}

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -133,9 +133,9 @@ export default async function ManageProfilePage({
           </p>
           <Link
             className="mt-4 inline-flex font-semibold text-[#2f6f73]"
-            href="/quartets"
+            href="/find?kind=quartets"
           >
-            Browse Find Quartet Openings first
+            Browse quartet openings in Find first
           </Link>
         </section>
       ) : profile.is_visible ? null : (
@@ -144,9 +144,9 @@ export default async function ManageProfilePage({
             Your profile is hidden
           </h2>
           <p className="mt-3 text-sm leading-6 text-[#394548]">
-            Hidden profiles do not appear in Find Singers or on the map. Turn on
-            the visibility checkbox below when you want discovery to show your
-            public singer details.
+            Hidden profiles do not appear in Find, detailed singer search, or
+            the map view. Turn on the visibility checkbox below when you want
+            discovery to show your public singer details.
           </p>
         </section>
       )}

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -1,15 +1,15 @@
 import Link from "next/link";
-import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
 import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
 } from "@/lib/location/map-markers";
+import { approximateLocationLabel } from "@/lib/location/approximate-location";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
-type SingerMapRow = {
+type SingerFindRow = {
   country_code: string | null;
   country_name: string | null;
   display_name: string;
@@ -21,7 +21,7 @@ type SingerMapRow = {
   region: string | null;
 };
 
-type QuartetMapRow = {
+type QuartetFindRow = {
   country_code: string | null;
   country_name: string | null;
   goals: string[];
@@ -33,14 +33,19 @@ type QuartetMapRow = {
   region: string | null;
 };
 
-type MapPageProps = {
+type FindPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+type FindResult = DiscoveryMapItem & {
+  detailHref: string;
+  intentLabel: string;
 };
 
 const kindOptions = [
   ["both", "Singers and quartet openings"],
-  ["singers", "Singers"],
   ["quartets", "Quartet openings"],
+  ["singers", "Singers"],
 ];
 
 const partOptions = [
@@ -74,6 +79,40 @@ function selectedKind(value: string | string[] | undefined) {
   return rawValue === "singers" || rawValue === "quartets" ? rawValue : "both";
 }
 
+function tags(values: string[]) {
+  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+function locationLabel(item: FindResult) {
+  return approximateLocationLabel({
+    countryName: item.countryName,
+    locality: item.locality,
+    locationLabelPublic: item.locationLabelPublic,
+    region: item.region,
+  });
+}
+
+function markerSummary(marker: { names: string[] }) {
+  const previewNames = marker.names.slice(0, 3).join(", ");
+  const remainingCount = marker.names.length - 3;
+
+  return remainingCount > 0
+    ? `${previewNames}, +${remainingCount} more`
+    : previewNames;
+}
+
+function markerKindLabel(marker: { count: number; kinds: string[] }) {
+  if (marker.kinds.includes("quartet") && marker.kinds.includes("singer")) {
+    return "results";
+  }
+
+  if (marker.kinds[0] === "quartet") {
+    return marker.count === 1 ? "quartet opening" : "quartet openings";
+  }
+
+  return marker.count === 1 ? "singer" : "singers";
+}
+
 function filterAnalyticsProperties(
   filters: ReturnType<typeof parseDiscoveryFilters>,
 ) {
@@ -89,42 +128,17 @@ function filterAnalyticsProperties(
   return { filterCount, flags };
 }
 
-function tags(values: string[]) {
-  return values.map((value) => value.replaceAll("_", " ")).join(", ");
-}
-
-function markerSummary(marker: { names: string[] }) {
-  const previewNames = marker.names.slice(0, 3).join(", ");
-  const remainingCount = marker.names.length - 3;
-
-  return remainingCount > 0
-    ? `${previewNames}, +${remainingCount} more`
-    : previewNames;
-}
-
-function markerKindLabel(marker: { count: number; kinds: string[] }) {
-  if (marker.kinds.includes("quartet") && marker.kinds.includes("singer")) {
-    return "listings";
-  }
-
-  if (marker.kinds[0] === "quartet") {
-    return marker.count === 1 ? "quartet listing" : "quartet listings";
-  }
-
-  return marker.count === 1 ? "singer profile" : "singer profiles";
-}
-
-export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
+export default async function FindPage({ searchParams }: FindPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
   const kind = selectedKind(params.kind);
   const supabase = await createSupabaseServerClient();
 
-  let mapItems: DiscoveryMapItem[] = [];
+  let results: FindResult[] = [];
   let errorMessage: string | null = null;
 
   if (!supabase) {
-    errorMessage = "Supabase is not configured for discovery map search yet.";
+    errorMessage = "Supabase is not configured for discovery search yet.";
   } else {
     if (kind === "both" || kind === "singers") {
       let query = supabase
@@ -159,12 +173,14 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
       if (error) {
         errorMessage = error.message;
       } else {
-        mapItems = [
-          ...mapItems,
-          ...((data ?? []) as SingerMapRow[]).map((singer) => ({
+        results = [
+          ...results,
+          ...((data ?? []) as SingerFindRow[]).map((singer) => ({
             countryCode: singer.country_code,
             countryName: singer.country_name,
+            detailHref: "/singers",
             id: singer.id,
+            intentLabel: "Singer profile",
             kind: "singer" as const,
             locality: singer.locality,
             locationLabelPublic: singer.location_label_public,
@@ -209,12 +225,14 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
       if (error) {
         errorMessage = error.message;
       } else {
-        mapItems = [
-          ...mapItems,
-          ...((data ?? []) as QuartetMapRow[]).map((quartet) => ({
+        results = [
+          ...results,
+          ...((data ?? []) as QuartetFindRow[]).map((quartet) => ({
             countryCode: quartet.country_code,
             countryName: quartet.country_name,
+            detailHref: "/quartets",
             id: quartet.id,
+            intentLabel: "Quartet opening",
             kind: "quartet" as const,
             locality: quartet.locality,
             locationLabelPublic: quartet.location_label_public,
@@ -227,40 +245,42 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
     }
   }
 
-  const markers = buildDiscoveryMapMarkers(mapItems);
+  const markers = buildDiscoveryMapMarkers(results);
   const { filterCount, flags } = filterAnalyticsProperties(filters);
 
   await captureProductEvent("map_viewed", {
     ...flags,
     filter_count: filterCount,
     kind,
-    route: "/map",
-    result_count: mapItems.length,
-    route_area: "map",
+    route: "/find",
+    result_count: results.length,
+    route_area: "discovery",
   });
 
   return (
     <>
       <PublicSiteHeader />
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
-        <div>
-          <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-            Find map view
-          </h1>
-          <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            This compatibility map view is also available inside the main Find
-            page with a results table below it.
+        <header>
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+            Find
           </p>
-        </div>
-
-        <DiscoveryModeNav activeMode="map" />
+          <h1 className="mt-4 text-4xl font-bold text-[#172023]">
+            Search singers and quartet openings in one place.
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-[#394548]">
+            Filter by what you are looking for, scan approximate regions on the
+            map, then use the results table below for details. Exact locations
+            and private contact details stay out of public discovery.
+          </p>
+        </header>
 
         <form
-          aria-label="Filter discovery map"
+          aria-label="Filter discovery results"
           className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5"
         >
           <label className="block">
-            <span className="text-sm font-semibold">Show</span>
+            <span className="text-sm font-semibold">Looking for</span>
             <select
               className={filterControlClass}
               defaultValue={kind}
@@ -279,7 +299,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
               className={filterControlClass}
               defaultValue={textValue(filters.country)}
               name="country"
-              placeholder="Australia"
+              placeholder="Canada"
             />
           </label>
           <label className="block">
@@ -288,7 +308,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
               className={filterControlClass}
               defaultValue={textValue(filters.region)}
               name="region"
-              placeholder="Victoria"
+              placeholder="Ontario"
             />
           </label>
           <label className="block">
@@ -297,7 +317,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
               className={filterControlClass}
               defaultValue={textValue(filters.locality)}
               name="locality"
-              placeholder="Melbourne"
+              placeholder="Toronto"
             />
           </label>
           <label className="block">
@@ -328,7 +348,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
               ))}
             </select>
           </label>
-          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-5">
+          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-4">
             <button
               className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
               type="submit"
@@ -337,7 +357,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
             </button>
             <Link
               className="inline-flex min-h-11 items-center rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70"
-              href="/map"
+              href="/find"
             >
               Clear
             </Link>
@@ -361,9 +381,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           >
             <div className="absolute inset-x-0 top-0 flex flex-col gap-1 bg-white/85 px-4 py-3 text-sm text-[#394548] backdrop-blur sm:flex-row sm:items-center sm:justify-between">
               <span>{markers.length} approximate regions</span>
-              <span>
-                {mapItems.length} visible listings with public location
-              </span>
+              <span>{results.length} visible discovery results</span>
             </div>
 
             {markers.map((marker) => (
@@ -387,52 +405,103 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           </div>
         </section>
 
-        <section className="mt-8 grid gap-4 md:grid-cols-2">
-          {markers.length === 0 && !errorMessage ? (
-            <section className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548] md:col-span-2">
-              <h2 className="text-xl font-bold text-[#172023]">
-                No approximate map regions match these filters yet
+        <section className="mt-8">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-[#172023]">
+                Results table
               </h2>
-              <p className="mt-3 text-sm leading-6">
-                The map only shows visible singer profiles and quartet openings
-                with approximate public location data. Try clearing filters or
-                using the main Find page or the detailed singer and quartet
-                search pages.
+              <p className="mt-2 text-sm text-[#394548]">
+                Use the table for details after scanning the map.
               </p>
-              <div className="mt-4 flex flex-wrap gap-4">
-                <Link className="font-semibold text-[#2f6f73]" href="/map">
-                  Clear filters
-                </Link>
-                <Link className="font-semibold text-[#2f6f73]" href="/find">
-                  Open Find
-                </Link>
-                <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-                  Find quartet openings
-                </Link>
-              </div>
+            </div>
+            <div className="flex flex-wrap gap-3 text-sm font-semibold text-[#2f6f73]">
+              <Link href="/quartets">Detailed quartet search</Link>
+              <Link href="/singers">Detailed singer search</Link>
+            </div>
+          </div>
+
+          {results.length === 0 && !errorMessage ? (
+            <section className="mt-5 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+              <h3 className="text-xl font-bold text-[#172023]">
+                No public discovery results match these filters yet
+              </h3>
+              <p className="mt-3 text-sm leading-6">
+                Try clearing filters, widening the country/region/locality, or
+                switching what you are looking for.
+              </p>
             </section>
           ) : null}
 
-          {markers.map((marker) => (
-            <article
-              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
-              key={marker.id}
-            >
-              <h2 className="text-xl font-bold text-[#172023]">
-                {marker.label}
-              </h2>
-              <p className="mt-2 text-sm text-[#394548]">
-                {marker.count} visible result{marker.count === 1 ? "" : "s"}:
-                {" " + markerSummary(marker)}
-              </p>
-              {marker.parts.length > 0 ? (
-                <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
-                  {tags(marker.parts)}
-                </p>
-              ) : null}
-            </article>
-          ))}
+          {results.length > 0 ? (
+            <div className="mt-5 overflow-x-auto rounded-lg border border-[#d7cec0] bg-[#fffaf2]">
+              <table className="w-full min-w-[46rem] border-collapse text-left text-sm">
+                <thead className="bg-white/70 text-[#172023]">
+                  <tr>
+                    <th className="px-4 py-3 font-bold">Result</th>
+                    <th className="px-4 py-3 font-bold">Type</th>
+                    <th className="px-4 py-3 font-bold">Parts</th>
+                    <th className="px-4 py-3 font-bold">Approximate area</th>
+                    <th className="px-4 py-3 font-bold">Next step</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {results.map((result) => (
+                    <tr
+                      className="border-t border-[#d7cec0] align-top"
+                      key={`${result.kind}-${result.id}`}
+                    >
+                      <td className="px-4 py-3 font-semibold text-[#172023]">
+                        {result.name}
+                      </td>
+                      <td className="px-4 py-3 text-[#394548]">
+                        {result.intentLabel}
+                      </td>
+                      <td className="px-4 py-3 text-[#394548]">
+                        {result.parts.length > 0 ? tags(result.parts) : "Any"}
+                      </td>
+                      <td className="px-4 py-3 text-[#394548]">
+                        {locationLabel(result)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link
+                          className="font-semibold text-[#2f6f73]"
+                          href={result.detailHref}
+                        >
+                          Open detailed search
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
         </section>
+
+        {markers.length > 0 ? (
+          <section className="mt-8 grid gap-4 md:grid-cols-2">
+            {markers.map((marker) => (
+              <article
+                className="rounded-lg border border-[#d7cec0] bg-white/60 p-5 shadow-sm"
+                key={marker.id}
+              >
+                <h2 className="text-xl font-bold text-[#172023]">
+                  {marker.label}
+                </h2>
+                <p className="mt-2 text-sm text-[#394548]">
+                  {marker.count} visible result{marker.count === 1 ? "" : "s"}:
+                  {" " + markerSummary(marker)}
+                </p>
+                {marker.parts.length > 0 ? (
+                  <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
+                    {tags(marker.parts)}
+                  </p>
+                ) : null}
+              </article>
+            ))}
+          </section>
+        ) : null}
       </main>
     </>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,17 +10,17 @@ const audiencePaths = [
 
 const discoveryLinks = [
   {
-    href: "/quartets",
+    href: "/find?kind=quartets",
     label: "Browse quartet openings",
     description: "See incomplete quartets looking for one or more parts.",
   },
   {
-    href: "/singers",
+    href: "/find?kind=singers",
     label: "Browse singers",
     description: "Find singers who are open to quartet opportunities.",
   },
   {
-    href: "/map",
+    href: "/find",
     label: "View the map",
     description: "Explore approximate singer and quartet locations.",
   },
@@ -103,8 +103,9 @@ export default function Home() {
               Public discovery is open before you sign in.
             </h2>
             <p className="mt-4 text-base leading-7 text-[#394548]">
-              Browse public listings when you want a quick sense of activity
-              before creating your profile or quartet listing.
+              Use Find to filter public listings, scan approximate areas on the
+              map, and compare results in a table before creating your profile
+              or quartet listing.
             </p>
           </div>
 

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
 import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
@@ -193,13 +194,15 @@ export default async function QuartetSearchPage({
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-            Find Quartet Openings
+            Find quartet openings
           </h1>
           <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Search visible quartet listings from groups looking for one or more
-            missing parts. Results show approximate location only.
+            Use this detailed view when you are a singer looking for groups that
+            need your part. Results show approximate location only.
           </p>
         </div>
+
+        <DiscoveryModeNav activeMode="quartets" />
 
         <form
           aria-label="Filter quartet openings"
@@ -339,11 +342,11 @@ export default async function QuartetSearchPage({
                 <Link className="font-semibold text-[#2f6f73]" href="/quartets">
                   Clear filters
                 </Link>
-                <Link className="font-semibold text-[#2f6f73]" href="/map">
-                  View Map
+                <Link className="font-semibold text-[#2f6f73]" href="/find">
+                  Return to Find map
                 </Link>
                 <Link className="font-semibold text-[#2f6f73]" href="/singers">
-                  Find Singers
+                  Find singers
                 </Link>
               </div>
             </section>

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
 import { PublicSiteHeader } from "@/components/navigation/public-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
@@ -191,14 +192,16 @@ export default async function SingerSearchPage({
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-            Find Singers
+            Find singers
           </h1>
           <p className="mt-3 max-w-2xl text-base leading-7 text-[#394548]">
-            Search visible singer profiles for singers who may be open to
-            quartet opportunities, pickup singing, or local connections. Results
+            Use this view when you are representing a quartet that needs a part,
+            or when you are a singer looking for other singers nearby. Results
             show approximate location only.
           </p>
         </div>
+
+        <DiscoveryModeNav activeMode="singers" />
 
         <form
           aria-label="Filter singer profiles"
@@ -339,10 +342,10 @@ export default async function SingerSearchPage({
                   Clear filters
                 </Link>
                 <Link className="font-semibold text-[#2f6f73]" href="/map">
-                  View Map
+                  Switch to map view
                 </Link>
                 <Link className="font-semibold text-[#2f6f73]" href="/quartets">
-                  Find Quartet Openings
+                  Find quartet openings
                 </Link>
               </div>
             </section>

--- a/components/analytics/analytics-page-tracker.tsx
+++ b/components/analytics/analytics-page-tracker.tsx
@@ -12,7 +12,11 @@ function routeArea(pathname: string) {
     return "signed_in_app";
   }
 
-  if (pathname === "/singers" || pathname === "/quartets") {
+  if (
+    pathname === "/find" ||
+    pathname === "/singers" ||
+    pathname === "/quartets"
+  ) {
     return "discovery";
   }
 

--- a/components/discovery/discovery-mode-nav.tsx
+++ b/components/discovery/discovery-mode-nav.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+
+export const discoveryModes = [
+  {
+    description: "For singers looking for groups that need your part.",
+    href: "/quartets",
+    id: "quartets",
+    label: "Quartet openings",
+  },
+  {
+    description: "For quartet representatives and singers looking nearby.",
+    href: "/singers",
+    id: "singers",
+    label: "Singers",
+  },
+  {
+    description: "A privacy-safe regional view of public discovery results.",
+    href: "/map",
+    id: "map",
+    label: "Map view",
+  },
+] as const;
+
+type DiscoveryMode = (typeof discoveryModes)[number]["id"] | "overview";
+
+type DiscoveryModeNavProps = {
+  activeMode: DiscoveryMode;
+};
+
+export function DiscoveryModeNav({ activeMode }: DiscoveryModeNavProps) {
+  return (
+    <nav
+      aria-label="Discovery modes"
+      className="mt-8 grid gap-3 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-3 sm:grid-cols-4"
+    >
+      <Link
+        className={`rounded-md px-3 py-3 text-sm font-semibold ${
+          activeMode === "overview"
+            ? "bg-[#174b4f] text-white"
+            : "text-[#2f6f73] hover:bg-white"
+        }`}
+        href="/find"
+      >
+        Find overview
+      </Link>
+      {discoveryModes.map((mode) => (
+        <Link
+          className={`rounded-md px-3 py-3 text-sm font-semibold ${
+            activeMode === mode.id
+              ? "bg-[#174b4f] text-white"
+              : "text-[#2f6f73] hover:bg-white"
+          }`}
+          href={mode.href}
+          key={mode.href}
+        >
+          <span className="block">{mode.label}</span>
+          <span className="mt-1 block text-xs font-normal leading-5 opacity-90">
+            {mode.description}
+          </span>
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/docs/accessibility-mobile-audit.md
+++ b/docs/accessibility-mobile-audit.md
@@ -9,9 +9,10 @@ This pre-launch audit covers the core public and signed-in flows:
 - onboarding
 - My Singer Profile
 - Quartet Mode
-- Find Quartet Openings
-- Find Singers
-- Map
+- Find
+- detailed Quartet Opening search
+- detailed Singer search
+- compatibility Map view
 - contact relay form
 - feedback form
 
@@ -24,7 +25,7 @@ This pre-launch audit covers the core public and signed-in flows:
 - Error and success messages use status or alert semantics where server-rendered feedback appears.
 - Search filters accept global country, region, locality, and long location strings without US-only assumptions.
 - Contact and feedback flows keep personal contact details private and retain app-mediated language.
-- The map remains a privacy-safe approximate regional view and includes text summaries below the visual map.
+- Find keeps filters/search above the privacy-safe approximate map and includes a results table below the visual map.
 
 ## Follow-Up Issues
 

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -118,15 +118,15 @@ Record before launch:
 
 ## Core User Flows
 
-| Status   | Item                                                                                                             | Verification                                                         |
-| -------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Complete | Onboarding routes signed-in first-time users to a useful first action.                                           | Issue #41; smoke test plan.                                          |
-| Complete | Empty states provide useful next actions.                                                                        | Issue #40; smoke test plan.                                          |
-| Complete | My Singer Profile stores parts, goals, location, visibility, and private postal code separately.                 | `/app/profile`; `docs/privacy-model.md#singer-profile-management`.   |
-| Complete | Quartet Mode stores covered parts and needed parts separately.                                                   | `/app/listings`; `docs/privacy-model.md#quartet-listing-management`. |
-| Complete | Find Singers, Find Quartet Openings, and Map support country, region, locality, part, goal, and non-US examples. | `/singers`, `/quartets`, `/map`.                                     |
-| Manual   | Run the full manual smoke test plan on production before launch.                                                 | `docs/smoke-test-plan.md`.                                           |
-| Manual   | Confirm seed/demo data is not loaded into production.                                                            | `docs/seed-data.md`; Supabase production data review.                |
+| Status   | Item                                                                                                                                                     | Verification                                                         |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Complete | Onboarding routes signed-in first-time users to a useful first action.                                                                                   | Issue #41; smoke test plan.                                          |
+| Complete | Empty states provide useful next actions.                                                                                                                | Issue #40; smoke test plan.                                          |
+| Complete | My Singer Profile stores parts, goals, location, visibility, and private postal code separately.                                                         | `/app/profile`; `docs/privacy-model.md#singer-profile-management`.   |
+| Complete | Quartet Mode stores covered parts and needed parts separately.                                                                                           | `/app/listings`; `docs/privacy-model.md#quartet-listing-management`. |
+| Complete | Find consolidates public discovery into filters, privacy-safe map, and results table; detailed Singer, Quartet Opening, and Map routes remain available. | `/find`, `/singers`, `/quartets`, `/map`.                            |
+| Manual   | Run the full manual smoke test plan on production before launch.                                                                                         | `docs/smoke-test-plan.md`.                                           |
+| Manual   | Confirm seed/demo data is not loaded into production.                                                                                                    | `docs/seed-data.md`; Supabase production data review.                |
 
 ## Accessibility and Mobile
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -24,8 +24,8 @@ validation.
 1. Open `/`.
 2. Pass: the page loads without a server error and clearly names Quartet Member
    Finder.
-3. Pass: primary links to Find Quartet Openings, Find Singers, Map, Help,
-   Privacy, My Singer Profile, and Quartet Mode are present.
+3. Pass: primary links to Find, Help, Privacy, My Singer Profile, and Quartet
+   Mode are present.
 4. Fail: the page exposes private email addresses, phone numbers, exact
    coordinates, private postal codes, or raw database IDs.
 
@@ -64,8 +64,8 @@ validation.
 
 1. Sign in and open `/app`.
 2. Pass: the dashboard loads behind authentication.
-3. Pass: it distinguishes My Singer Profile, Find Quartet Openings, Find
-   Singers, Map, Quartet Mode, Account Settings, Help, and Privacy.
+3. Pass: it distinguishes My Singer Profile, Find, Quartet Mode, Account
+   Settings, Help, and Privacy.
 4. Pass: signed-out users visiting `/app` are redirected to sign in.
 5. Fail: dashboard links point to missing routes or expose another user's data.
 
@@ -119,7 +119,20 @@ validation.
 8. Fail: public UI exposes the owner user ID, private postal code, exact
    coordinates, email address, or phone number.
 
-## Find Quartet Openings
+## Find
+
+1. Open `/find`.
+2. Filter by country, region/locality, part, goal, and looking-for mode using
+   data known to exist in the environment.
+3. Pass: valid filters narrow the consolidated results without crashing.
+4. Pass: the approximate map appears above the results table.
+5. Pass: the table distinguishes singer profiles from quartet openings.
+6. Pass: empty results show helpful next actions, including clearing filters.
+7. Fail: hidden or inactive profiles/listings appear in public results.
+8. Fail: public UI exposes owner user IDs, private postal codes, exact
+   coordinates, email addresses, or phone numbers.
+
+## Detailed Quartet Opening Search
 
 1. Open `/quartets`.
 2. Filter by country, region/locality, part, goal, availability, and travel
@@ -129,7 +142,7 @@ validation.
 5. Pass: contact buttons are available for visible listings.
 6. Fail: hidden or inactive listings appear in public results.
 
-## Find Singers
+## Detailed Singer Search
 
 1. Open `/singers`.
 2. Filter by country, region/locality, part, goal, availability, experience, and
@@ -139,7 +152,7 @@ validation.
 5. Pass: contact buttons are available for visible profiles.
 6. Fail: hidden or inactive singer profiles appear in public results.
 
-## Map Discovery
+## Compatibility Map View
 
 1. Open `/map`.
 2. Test filters for United States and at least one non-US location, such as
@@ -198,8 +211,8 @@ validation.
 
 Run these at a narrow mobile viewport, around 390 px wide:
 
-1. Open `/`, `/singers`, `/quartets`, `/map`, `/help`, `/privacy`, and `/app`
-   while signed in where required.
+1. Open `/`, `/find`, `/singers`, `/quartets`, `/map`, `/help`, `/privacy`, and
+   `/app` while signed in where required.
 2. Pass: text does not overlap controls, cards, forms, or navigation.
 3. Pass: forms can be completed without horizontal scrolling.
 4. Pass: contact and feedback text areas are usable.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -82,9 +82,11 @@ displays. Singer profiles and quartet listings keep their own
 
 The public discovery routes are:
 
+- `/find`, backed by both discovery views for consolidated filters, map, and
+  results table
 - `/singers`, backed by `singer_discovery_profiles`
 - `/quartets`, backed by `quartet_discovery_listings`
-- `/map`, backed by both discovery views
+- `/map`, backed by both discovery views as a compatibility map view
 
 These routes may filter on public location fields, part, goals,
 experience/commitment, availability, and travel willingness. They should not

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -22,8 +22,10 @@ export const publicHelpSections = [
   },
   {
     body: [
-      "Find Quartet Openings shows visible quartet listings from groups looking for missing parts. Find Singers shows visible singer profiles for both individual singers and quartet representatives.",
-      "Search and map filters can use public fields like part, goal, country, region, locality, availability, and travel willingness where that data exists.",
+      "Find is the main discovery page. It combines filters, a privacy-safe regional map, and a results table for quartet openings and singer profiles.",
+      "Use the looking-for filter to focus on quartet openings when you are a singer, or singer profiles when you are representing a quartet or looking for other singers.",
+      "The map is part of Find rather than a separate first step. It helps you scan approximate activity, then the table below gives names, parts, type, and next-step links.",
+      "Detailed singer and quartet search pages remain available from Find when you need more specific filters like availability, experience, or travel willingness.",
       "Search results are useful even when a profile is incomplete, but more complete profiles are easier for others to evaluate.",
     ],
     heading: "Search",

--- a/lib/dashboard/app-dashboard.ts
+++ b/lib/dashboard/app-dashboard.ts
@@ -13,21 +13,9 @@ export const singerDashboardActions: DashboardAction[] = [
   },
   {
     description:
-      "Browse quartet openings from groups looking for one or more missing parts.",
-    href: "/quartets",
-    label: "Find Quartet Openings",
-  },
-  {
-    description:
-      "Look for other singers nearby or in a region where you are willing to sing.",
-    href: "/singers",
-    label: "Find Singers",
-  },
-  {
-    description:
-      "Scan approximate discovery locations without exposing exact home addresses or private coordinates.",
-    href: "/map",
-    label: "View Map",
+      "Search quartet openings, singer profiles, and approximate regions from one discovery page.",
+    href: "/find",
+    label: "Find",
   },
 ];
 
@@ -40,9 +28,9 @@ export const quartetModeDashboardActions: DashboardAction[] = [
   },
   {
     description:
-      "Search singer profiles when your quartet is ready to contact someone about a missing part.",
-    href: "/singers",
-    label: "Find Singers",
+      "Search singer profiles and nearby activity when your quartet is ready to contact someone about a missing part.",
+    href: "/find?kind=singers",
+    label: "Find singers",
   },
 ];
 

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -4,16 +4,8 @@ export const signedInPrimaryNavigationLinks = [
     label: "My Singer Profile",
   },
   {
-    href: "/quartets",
-    label: "Find Quartet Openings",
-  },
-  {
-    href: "/singers",
-    label: "Find Singers",
-  },
-  {
-    href: "/map",
-    label: "Map",
+    href: "/find",
+    label: "Find",
   },
 ] as const;
 

--- a/lib/navigation/site-navigation.ts
+++ b/lib/navigation/site-navigation.ts
@@ -1,15 +1,7 @@
 export const publicNavigationLinks = [
   {
-    href: "/quartets",
-    label: "Find Quartet Openings",
-  },
-  {
-    href: "/singers",
-    label: "Find Singers",
-  },
-  {
-    href: "/map",
-    label: "Map",
+    href: "/find",
+    label: "Find",
   },
   {
     href: "/sign-in",

--- a/lib/onboarding/app-onboarding.ts
+++ b/lib/onboarding/app-onboarding.ts
@@ -23,17 +23,17 @@ export const onboardingSections: OnboardingSection[] = [
       },
       {
         description:
-          "Browse quartet openings from groups looking for one or more missing parts.",
-        href: "/quartets",
+          "Search quartet openings by needed part, goal, approximate area, or map region.",
+        href: "/find?kind=quartets",
         id: "find-quartet-openings",
-        label: "Find Quartet Openings",
+        label: "Find quartet openings",
       },
       {
         description:
-          "Look for singers nearby or in another region where you are willing to sing.",
-        href: "/singers",
+          "Search for singers nearby or in another region where you are willing to sing.",
+        href: "/find?kind=singers",
         id: "find-singers-as-singer",
-        label: "Find Singers",
+        label: "Find singers",
       },
     ],
     heading: "As a singer",
@@ -52,7 +52,7 @@ export const onboardingSections: OnboardingSection[] = [
       {
         description:
           "Search singer profiles when your quartet is ready to contact someone about a missing part.",
-        href: "/singers",
+        href: "/find?kind=singers",
         id: "quartet-mode-find-singers",
         label: "Find singers for a quartet",
       },

--- a/test/app-dashboard.test.ts
+++ b/test/app-dashboard.test.ts
@@ -9,16 +9,14 @@ describe("signed-in app dashboard", () => {
   it("foregrounds the singer workflow with all primary next actions", () => {
     expect(singerDashboardActions.map((action) => action.label)).toEqual([
       "My Singer Profile",
-      "Find Quartet Openings",
-      "Find Singers",
-      "View Map",
+      "Find",
     ]);
   });
 
   it("keeps quartet mode separate from the primary singer workflow", () => {
     expect(quartetModeDashboardActions.map((action) => action.label)).toEqual([
       "Manage Quartet Listing",
-      "Find Singers",
+      "Find singers",
     ]);
   });
 
@@ -29,11 +27,9 @@ describe("signed-in app dashboard", () => {
       ...supportDashboardActions,
     ]).toEqual([
       expect.objectContaining({ href: "/app/profile" }),
-      expect.objectContaining({ href: "/quartets" }),
-      expect.objectContaining({ href: "/singers" }),
-      expect.objectContaining({ href: "/map" }),
+      expect.objectContaining({ href: "/find" }),
       expect.objectContaining({ href: "/app/listings" }),
-      expect.objectContaining({ href: "/singers" }),
+      expect.objectContaining({ href: "/find?kind=singers" }),
       expect.objectContaining({ href: "/app/settings" }),
       expect.objectContaining({ href: "/help" }),
       expect.objectContaining({ href: "/privacy" }),

--- a/test/app-onboarding.test.ts
+++ b/test/app-onboarding.test.ts
@@ -16,8 +16,8 @@ describe("first-run onboarding", () => {
     const text = JSON.stringify(onboardingSections);
 
     expect(text).toContain("My Singer Profile");
-    expect(text).toContain("Find Quartet Openings");
-    expect(text).toContain("Find Singers");
+    expect(text).toContain("Find quartet openings");
+    expect(text).toContain("Find singers");
     expect(text).toContain("Quartet Mode");
     expect(text).toContain("outside the United States");
   });
@@ -27,7 +27,7 @@ describe("first-run onboarding", () => {
       "/app/profile",
     );
     expect(destinationForOnboardingChoice("find-quartet-openings")).toBe(
-      "/quartets",
+      "/find?kind=quartets",
     );
     expect(destinationForOnboardingChoice("quartet-mode-listing")).toBe(
       "/app/listings",

--- a/test/empty-states.test.ts
+++ b/test/empty-states.test.ts
@@ -16,10 +16,10 @@ describe("empty and first-time states", () => {
 
     expect(profilePage).toContain("Create My Singer Profile");
     expect(profilePage).toContain("Your profile is hidden");
-    expect(profilePage).toContain("Find Singers");
+    expect(profilePage).toContain("Find, detailed singer search");
     expect(listingPage).toContain("Start Quartet Mode");
     expect(listingPage).toContain("This quartet listing is hidden");
-    expect(listingPage).toContain("Find Quartet Openings");
+    expect(listingPage).toContain("Find, detailed quartet search");
   });
 
   it("turns public discovery no-results states into next actions", () => {

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -21,8 +21,8 @@ describe("public discovery copy", () => {
   it("frames quartet discovery as openings for missing parts", () => {
     const quartetPage = source("app/quartets/page.tsx");
 
-    expect(quartetPage).toContain("Find Quartet Openings");
-    expect(quartetPage).toContain("groups looking for one or more");
+    expect(quartetPage).toContain("Find quartet openings");
+    expect(quartetPage).toContain("singer looking for groups");
     expect(quartetPage).toContain("No visible quartet openings");
     expect(quartetPage).not.toContain("Find quartets");
   });
@@ -30,8 +30,19 @@ describe("public discovery copy", () => {
   it("frames singer discovery as available singer profiles", () => {
     const singerPage = source("app/singers/page.tsx");
 
-    expect(singerPage).toContain("Find Singers");
-    expect(singerPage).toContain("singers who may be open");
-    expect(singerPage).not.toContain("Find singers");
+    expect(singerPage).toContain("Find singers");
+    expect(singerPage).toContain("representing a quartet");
+    expect(singerPage).toContain("looking for other singers nearby");
+  });
+
+  it("consolidates discovery around filters, map, and table", () => {
+    const findPage = source("app/find/page.tsx");
+
+    expect(findPage).toContain("Search singers and quartet openings");
+    expect(findPage).toContain("Filter discovery results");
+    expect(findPage).toContain("Privacy-safe discovery map");
+    expect(findPage).toContain("Results table");
+    expect(findPage).toContain("Detailed quartet search");
+    expect(findPage).toContain("Detailed singer search");
   });
 });

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -17,8 +17,8 @@ describe("public help and privacy content", () => {
     expect(helpText).toContain("Singer Profiles");
     expect(helpText).toContain("Quartet Listings");
     expect(helpText).toContain("Search");
-    expect(helpText).toContain("Find Quartet Openings");
-    expect(helpText).toContain("Find Singers");
+    expect(helpText).toContain("Find is the main discovery page");
+    expect(helpText).toContain("results table");
     expect(helpText).toContain("Location And Privacy");
     expect(helpText).toContain("Contact");
     expect(helpText).toContain("Signed-in users can send private feedback");

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -10,9 +10,7 @@ describe("signed-in navigation", () => {
   it("groups singer-first tasks apart from quartet mode and utility actions", () => {
     expect(signedInPrimaryNavigationLinks.map((link) => link.label)).toEqual([
       "My Singer Profile",
-      "Find Quartet Openings",
-      "Find Singers",
-      "Map",
+      "Find",
     ]);
     expect(signedInModeNavigationLinks).toEqual([
       { href: "/app/listings", label: "Quartet Mode" },
@@ -25,9 +23,7 @@ describe("signed-in navigation", () => {
   it("keeps existing route targets for the reorganized labels", () => {
     expect(signedInNavigationLinks).toEqual([
       { href: "/app/profile", label: "My Singer Profile" },
-      { href: "/quartets", label: "Find Quartet Openings" },
-      { href: "/singers", label: "Find Singers" },
-      { href: "/map", label: "Map" },
+      { href: "/find", label: "Find" },
       { href: "/app/listings", label: "Quartet Mode" },
       { href: "/app/settings", label: "Account Settings" },
     ]);

--- a/test/site-navigation.test.ts
+++ b/test/site-navigation.test.ts
@@ -7,9 +7,7 @@ import {
 describe("site navigation", () => {
   it("keeps public discovery and help links available before login", () => {
     expect(publicNavigationLinks).toEqual([
-      { href: "/quartets", label: "Find Quartet Openings" },
-      { href: "/singers", label: "Find Singers" },
-      { href: "/map", label: "Map" },
+      { href: "/find", label: "Find" },
       { href: "/sign-in", label: "Sign in" },
       { href: "/help", label: "Help" },
     ]);


### PR DESCRIPTION
Closes #70

## Summary
- Adds /find as the primary discovery experience with filters/search above a privacy-safe approximate map and a results table below.
- Updates public and signed-in navigation to point to Find while keeping /singers, /quartets, and /map available as detailed/compatibility routes.
- Updates home, Help, onboarding, dashboard, empty-state, accessibility, smoke-test, and Supabase-contract copy to match the new discovery model.
- Adds a shared discovery mode switcher to keep detailed singer/quartet/map routes connected to the unified Find model.

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build
- Local /find returned 200
- Local / returned 200