### PR TITLE
Clarify account and profile settings

### DIFF
--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -97,10 +97,16 @@ export default async function ManageProfilePage({
           Manage your singer profile
         </h1>
         <p className="mt-4 text-base leading-7 text-[#394548]">
-          Create the profile that quartets and other singers can discover. Keep
-          the public location approximate; postal code stays private for future
-          matching and search.
+          Create the public singer profile that quartets and other singers can
+          discover. Account identity, distance defaults, and onboarding reset
+          live in Account Settings.
         </p>
+        <Link
+          className="mt-4 inline-flex font-semibold text-[#2f6f73]"
+          href="/app/settings"
+        >
+          Manage account settings
+        </Link>
       </div>
 
       {params.error ? (
@@ -202,8 +208,10 @@ export default async function ManageProfilePage({
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Location</h2>
           <p className="text-sm leading-6 text-[#394548]">
-            Use globally recognizable place names. Postal code is private and
-            public discovery should stay approximate.
+            Use globally recognizable place names for your public singer
+            profile. Postal code is private and public discovery should stay
+            approximate. Your default distance display preference lives in
+            Account Settings.
           </p>
           <label className="block">
             <span className="text-sm font-semibold text-[#172023]">

--- a/app/(protected)/app/settings/actions.ts
+++ b/app/(protected)/app/settings/actions.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation";
 import {
   isAccountDistanceUnit,
+  normalizeAccountDisplayName,
   normalizeAccountDistanceUnit,
 } from "@/lib/settings/account-settings";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -32,9 +33,16 @@ async function getSettingsUser() {
 }
 
 export async function saveAccountSettings(formData: FormData) {
+  const displayName = normalizeAccountDisplayName(
+    String(formData.get("displayName") ?? ""),
+  );
   const preferredDistanceUnit = normalizeAccountDistanceUnit(
     String(formData.get("preferredDistanceUnit") ?? ""),
   );
+
+  if (!displayName) {
+    redirectWithSettingsStatus("error");
+  }
 
   if (!isAccountDistanceUnit(preferredDistanceUnit)) {
     redirectWithSettingsStatus("error");
@@ -43,7 +51,10 @@ export async function saveAccountSettings(formData: FormData) {
   const { supabase, user } = await getSettingsUser();
   const { error } = await supabase
     .from("account_profiles")
-    .update({ preferred_distance_unit: preferredDistanceUnit })
+    .update({
+      display_name: displayName,
+      preferred_distance_unit: preferredDistanceUnit,
+    })
     .eq("user_id", user.id);
 
   if (error) {

--- a/app/(protected)/app/settings/page.tsx
+++ b/app/(protected)/app/settings/page.tsx
@@ -80,11 +80,49 @@ export default async function AccountSettingsPage({
           Account preferences
         </h1>
         <p className="mt-4 text-base leading-7 text-[#394548]">
-          Account Settings are for app-level preferences and account actions. My
-          Singer Profile controls how you appear in discovery; Quartet Mode
-          controls a quartet opening.
+          Account Settings are for private account identity, app defaults, and
+          first-run setup. My Singer Profile controls what other singers and
+          quartets can see in public discovery.
         </p>
       </header>
+
+      <section className="grid max-w-5xl gap-4 lg:grid-cols-3">
+        <article className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-lg font-bold text-[#172023]">Account Settings</h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Private account name, email context, distance defaults, onboarding
+            reset, and future account actions.
+          </p>
+        </article>
+        <article className="rounded-lg border border-[#d7cec0] bg-white/60 p-5">
+          <h2 className="text-lg font-bold text-[#172023]">
+            My Singer Profile
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Public singer name, parts, goals, availability, approximate
+            location, and search visibility.
+          </p>
+          <Link
+            className="mt-4 inline-flex font-semibold text-[#2f6f73]"
+            href="/app/profile"
+          >
+            Edit singer profile
+          </Link>
+        </article>
+        <article className="rounded-lg border border-[#d7cec0] bg-white/60 p-5">
+          <h2 className="text-lg font-bold text-[#172023]">Quartet Mode</h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Quartet listing details, covered parts, needed parts, approximate
+            location, and listing visibility.
+          </p>
+          <Link
+            className="mt-4 inline-flex font-semibold text-[#2f6f73]"
+            href="/app/listings"
+          >
+            Manage quartet listing
+          </Link>
+        </article>
+      </section>
 
       {message ? (
         <p
@@ -100,8 +138,30 @@ export default async function AccountSettingsPage({
       ) : null}
 
       <section className="max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
-        <h2 className="text-xl font-bold text-[#172023]">Preferences</h2>
+        <h2 className="text-xl font-bold text-[#172023]">
+          Account identity and defaults
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-[#394548]">
+          These settings are account-level. They do not change the public
+          display name, location, or visibility on your singer profile.
+        </p>
         <form action={saveAccountSettings} className="mt-4 grid gap-4">
+          <label className="block">
+            <span className="text-sm font-semibold text-[#172023]">
+              Account display name
+            </span>
+            <input
+              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+              defaultValue={accountProfile?.display_name ?? ""}
+              maxLength={120}
+              name="displayName"
+              required
+            />
+          </label>
+          <div className="rounded-md border border-[#d7cec0] bg-white/70 p-4 text-sm leading-6 text-[#394548]">
+            <span className="font-semibold text-[#172023]">Sign-in email:</span>{" "}
+            {user.email ?? "No email available"}
+          </div>
           <label className="block">
             <span className="text-sm font-semibold text-[#172023]">
               Preferred distance unit
@@ -119,9 +179,10 @@ export default async function AccountSettingsPage({
             </select>
           </label>
           <p className="text-sm leading-6 text-[#394548]">
-            This account-level preference is saved for future distance displays.
-            Singer profiles and quartet listings still keep their own distance
-            settings for discovery details.
+            Country and postal-code details belong to your singer profile or
+            quartet listing location. This account-level preference controls how
+            distance should be displayed by default; discovery records still
+            keep their own travel-distance details.
           </p>
           <button
             className="w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
@@ -133,10 +194,11 @@ export default async function AccountSettingsPage({
       </section>
 
       <section className="max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
-        <h2 className="text-xl font-bold text-[#172023]">Onboarding</h2>
+        <h2 className="text-xl font-bold text-[#172023]">First-run setup</h2>
         <p className="mt-3 text-sm leading-6 text-[#394548]">
           Current onboarding state: {onboardingState}. Reset onboarding if you
-          want to see the first-run choices again.
+          want to see the first-run choices again. This is an account action,
+          not a public profile setting.
         </p>
         <form action={resetOnboarding} className="mt-4">
           <button

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -230,13 +230,19 @@ through the app.
 ## Account settings model
 
 Account Settings are separate from My Singer Profile and Quartet Mode. They are
-for app-level preferences and account-level actions that should not change
-public discovery content by accident.
+for private account identity, app-level preferences, first-run setup, and
+account-level actions that should not change public discovery content by
+accident.
 
-The initial settings page lets a signed-in user save an account-level preferred
-distance unit and reset first-run onboarding. Future export, deactivation, and
-delete actions are shown only as placeholders until the product has clear
-privacy and data-retention behavior for them.
+The settings page lets a signed-in user save an account display name, save an
+account-level preferred distance unit, see sign-in email context, and reset
+first-run onboarding. Future export, deactivation, and delete actions are shown
+only as placeholders until the product has clear privacy and data-retention
+behavior for them.
+
+My Singer Profile remains the place for public singer discovery data: public
+display name, parts, goals, experience, availability, approximate location,
+private postal code for future matching, and search visibility.
 
 ## Abuse and safety considerations
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -191,13 +191,15 @@ validation.
 ## Account Settings
 
 1. Open `/app/settings`.
-2. Change preferred distance unit between kilometers and miles.
-3. Pass: saving succeeds and the selected account-level preference remains
+2. Pass: the page distinguishes Account Settings, My Singer Profile, and
+   Quartet Mode.
+3. Change account display name and preferred distance unit.
+4. Pass: saving succeeds and the selected account-level preferences remain
    selected.
-4. Click re-run onboarding.
-5. Pass: onboarding state is cleared and the app routes to onboarding with a
+5. Click re-run onboarding.
+6. Pass: onboarding state is cleared and the app routes to onboarding with a
    safe return path.
-6. Fail: Account Settings duplicates singer profile or quartet listing fields
+7. Fail: Account Settings duplicates singer profile or quartet listing fields
    instead of staying account-level.
 
 ## Sign-Out

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -42,8 +42,9 @@ Baritone, and Bass unless the product explicitly adds alternate naming later.
 An `account_profiles` row belongs to one authenticated user by `user_id`.
 It also stores first-run onboarding completion/skipped state so new users can be
 guided to a first action after sign-in without choosing a permanent role.
-Account-level preferences that do not belong to My Singer Profile or Quartet
-Mode also live here, including `preferred_distance_unit`.
+Account-level preferences and private account identity fields that do not belong
+to My Singer Profile or Quartet Mode also live here, including `display_name`
+and `preferred_distance_unit`.
 
 A `singer_profiles` row belongs to one authenticated user by `user_id`. The
 initial schema enforces one singer profile per user.
@@ -75,10 +76,11 @@ The server creates the account profile row after sign-in when needed. If neither
 completion nor skipped state is present, sign-in routes the user through
 `/app/onboarding` before continuing to the requested app destination.
 
-Account Settings at `/app/settings` writes `preferred_distance_unit` on
-`account_profiles`. This is an app/account preference for future distance
-displays. Singer profiles and quartet listings keep their own
-`preferred_distance_unit` values for discovery rows.
+Account Settings at `/app/settings` writes `display_name` and
+`preferred_distance_unit` on `account_profiles`. These are private account-level
+settings for app identity and distance display. Singer profiles and quartet
+listings keep their own public display/location/travel details for discovery
+rows.
 
 The public discovery routes are:
 

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -53,6 +53,13 @@ export const publicHelpSections = [
   },
   {
     body: [
+      "Account Settings are for private account identity, preferred distance display, onboarding reset, and account-level actions.",
+      "My Singer Profile is for public singer details like display name, parts, goals, approximate location, and discovery visibility. Changing Account Settings does not publish your private email address or change what public discovery shows.",
+    ],
+    heading: "Account Settings Vs Singer Profile",
+  },
+  {
+    body: [
       "Use the same judgment you would use when meeting someone through a singing community. Start with app-mediated messages, meet in public or group settings when possible, and do not share private contact details until you are comfortable.",
       "The app helps reduce public exposure of personal data, but it does not replace personal judgment or formal moderation.",
     ],

--- a/lib/dashboard/app-dashboard.ts
+++ b/lib/dashboard/app-dashboard.ts
@@ -37,7 +37,7 @@ export const quartetModeDashboardActions: DashboardAction[] = [
 export const supportDashboardActions: DashboardAction[] = [
   {
     description:
-      "Review account-level preferences, re-run onboarding, and find future account-management placeholders.",
+      "Review private account identity, preferred distance units, first-run setup, and future account-management placeholders.",
     href: "/app/settings",
     label: "Account Settings",
   },

--- a/lib/settings/account-settings.ts
+++ b/lib/settings/account-settings.ts
@@ -12,6 +12,12 @@ export const accountDistanceUnitOptions = [
 export type AccountDistanceUnit =
   (typeof accountDistanceUnitOptions)[number]["value"];
 
+export function normalizeAccountDisplayName(value: string | null) {
+  const trimmed = value?.trim();
+
+  return trimmed ? trimmed.slice(0, 120) : null;
+}
+
 export function isAccountDistanceUnit(
   value: string,
 ): value is AccountDistanceUnit {

--- a/test/account-settings.test.ts
+++ b/test/account-settings.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   accountDistanceUnitOptions,
+  normalizeAccountDisplayName,
   normalizeAccountDistanceUnit,
 } from "@/lib/settings/account-settings";
 
@@ -17,15 +18,22 @@ describe("account settings", () => {
     ]);
     expect(normalizeAccountDistanceUnit("mi")).toBe("mi");
     expect(normalizeAccountDistanceUnit("yards")).toBe("km");
+    expect(normalizeAccountDisplayName("  Tim  ")).toBe("Tim");
+    expect(normalizeAccountDisplayName("   ")).toBeNull();
+    expect(normalizeAccountDisplayName("a".repeat(140))).toHaveLength(120);
   });
 
   it("keeps settings distinct from singer profile and Quartet Mode", () => {
     const page = source("app/(protected)/app/settings/page.tsx");
 
     expect(page).toContain("Account Settings");
+    expect(page).toContain("Account identity and defaults");
+    expect(page).toContain("Account display name");
+    expect(page).toContain("Sign-in email");
     expect(page).toMatch(/My\s+Singer Profile/);
-    expect(page).toContain("controls how you appear in discovery");
+    expect(page).toContain("Public singer name");
     expect(page).toContain("Quartet Mode");
+    expect(page).toContain("First-run setup");
     expect(page).toContain("Re-run onboarding");
     expect(page).toContain("not available yet");
   });

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -20,6 +20,7 @@ describe("public help and privacy content", () => {
     expect(helpText).toContain("Find is the main discovery page");
     expect(helpText).toContain("results table");
     expect(helpText).toContain("Location And Privacy");
+    expect(helpText).toContain("Account Settings Vs Singer Profile");
     expect(helpText).toContain("Contact");
     expect(helpText).toContain("Signed-in users can send private feedback");
     expect(helpText).toContain("does not replace personal judgment");


### PR DESCRIPTION
Closes #66

## Summary
- Keeps Account Settings separate from My Singer Profile, but adds clear side-by-side explanations of account settings, public singer profile data, and Quartet Mode.
- Adds account display-name editing to Account Settings using the existing account_profiles.display_name field, alongside preferred distance unit.
- Makes My Singer Profile explicitly about public discovery data and links back to Account Settings for account identity/defaults.
- Updates Help, privacy model, Supabase contract, smoke test plan, dashboard copy, and tests to match the clarified information architecture.

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build
- Local /app/settings returns protected redirect when signed out
- Local /app/profile returns protected redirect when signed out