### PR TITLE
Add voicing-aware part model

### DIFF
--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -106,14 +106,16 @@ export async function saveQuartetListing(formData: FormData) {
 
   const partRows = [
     ...values.partsCovered.map((part) => ({
-      part,
+      part: part.part,
       quartet_listing_id: listingId,
       status: "covered",
+      voicing: part.voicing,
     })),
     ...values.partsNeeded.map((part) => ({
-      part,
+      part: part.part,
       quartet_listing_id: listingId,
       status: "needed",
+      voicing: part.voicing,
     })),
   ];
 

--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
+import { QuartetListingPartsFieldset } from "@/components/quartet-listing-parts-fieldset";
 import {
-  BARBERSHOP_PARTS,
   PROFILE_GOALS,
-  type BarbershopPart,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
 import { locationFieldLabelsForCountry } from "@/lib/location/country-location-defaults";
+import { type Voicing } from "@/lib/parts/voicings";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { saveQuartetListing } from "./actions";
 
@@ -31,13 +31,6 @@ type ManageListingsPageProps = {
     error?: string;
     message?: string;
   }>;
-};
-
-const partLabels: Record<BarbershopPart, string> = {
-  baritone: "Baritone",
-  bass: "Bass",
-  lead: "Lead",
-  tenor: "Tenor",
 };
 
 const goalLabels: Record<ProfileGoal, string> = {
@@ -83,18 +76,20 @@ export default async function ManageListingsPage({
     supabase && listing
       ? await supabase
           .from("quartet_listing_parts")
-          .select("part, status")
+          .select("part, status, voicing")
           .eq("quartet_listing_id", listing.id)
       : { data: [] };
 
+  const selectedVoicing =
+    (parts?.[0]?.voicing as Voicing | undefined) ?? "TTBB";
   const partsCovered =
     parts
       ?.filter((partRow) => partRow.status === "covered")
-      .map((partRow) => partRow.part as BarbershopPart) ?? [];
+      .map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
   const partsNeeded =
     parts
       ?.filter((partRow) => partRow.status === "needed")
-      .map((partRow) => partRow.part as BarbershopPart) ?? [];
+      .map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
   const locationLabels = locationFieldLabelsForCountry(
     listing?.country_code,
     listing?.country_name,
@@ -194,49 +189,11 @@ export default async function ManageListingsPage({
           </label>
         </section>
 
-        <section className="space-y-4">
-          <h2 className="text-xl font-bold text-[#172023]">Parts</h2>
-          <div className="grid gap-6 sm:grid-cols-2">
-            <fieldset className="space-y-3">
-              <legend className="text-sm font-semibold text-[#172023]">
-                Currently covered
-              </legend>
-              {BARBERSHOP_PARTS.map((part) => (
-                <label
-                  className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
-                  key={part}
-                >
-                  <input
-                    defaultChecked={checked(part, partsCovered)}
-                    name="partsCovered"
-                    type="checkbox"
-                    value={part}
-                  />
-                  <span className="font-semibold">{partLabels[part]}</span>
-                </label>
-              ))}
-            </fieldset>
-            <fieldset className="space-y-3">
-              <legend className="text-sm font-semibold text-[#172023]">
-                Needed
-              </legend>
-              {BARBERSHOP_PARTS.map((part) => (
-                <label
-                  className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
-                  key={part}
-                >
-                  <input
-                    defaultChecked={checked(part, partsNeeded)}
-                    name="partsNeeded"
-                    type="checkbox"
-                    value={part}
-                  />
-                  <span className="font-semibold">{partLabels[part]}</span>
-                </label>
-              ))}
-            </fieldset>
-          </div>
-        </section>
+        <QuartetListingPartsFieldset
+          initialCoveredParts={partsCovered}
+          initialNeededParts={partsNeeded}
+          initialVoicing={selectedVoicing}
+        />
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Location</h2>

--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -105,8 +105,9 @@ export async function saveSingerProfile(formData: FormData) {
       .from("singer_profile_parts")
       .insert(
         values.parts.map((part) => ({
-          part,
+          part: part.part,
           singer_profile_id: profile.id,
+          voicing: part.voicing,
         })),
       );
 

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link";
 import {
-  BARBERSHOP_PARTS,
   PROFILE_GOALS,
-  type BarbershopPart,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
 import { locationFieldLabelsForCountry } from "@/lib/location/country-location-defaults";
+import {
+  VOICINGS,
+  partsByVoicing,
+  partLabel,
+  voicingLabels,
+  voicingPartValue,
+} from "@/lib/parts/voicings";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { saveSingerProfile } from "./actions";
 
@@ -31,13 +36,6 @@ type ManageProfilePageProps = {
     error?: string;
     message?: string;
   }>;
-};
-
-const partLabels: Record<BarbershopPart, string> = {
-  baritone: "Baritone",
-  bass: "Bass",
-  lead: "Lead",
-  tenor: "Tenor",
 };
 
 const goalLabels: Record<ProfileGoal, string> = {
@@ -81,12 +79,12 @@ export default async function ManageProfilePage({
     supabase && profile
       ? await supabase
           .from("singer_profile_parts")
-          .select("part")
+          .select("part, voicing")
           .eq("singer_profile_id", profile.id)
       : { data: [] };
 
   const selectedParts =
-    parts?.map((partRow) => partRow.part as BarbershopPart) ?? [];
+    parts?.map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
   const locationLabels = locationFieldLabelsForCountry(
     profile?.country_code,
     profile?.country_name,
@@ -186,20 +184,42 @@ export default async function ManageProfilePage({
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Parts Sung</h2>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {BARBERSHOP_PARTS.map((part) => (
-              <label
-                className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
-                key={part}
+          <p className="text-sm leading-6 text-[#394548]">
+            Select every part you sing, grouped by voicing. TTBB Tenor and SATB
+            Tenor are different discovery contexts.
+          </p>
+          <div className="grid gap-4">
+            {VOICINGS.map((voicing) => (
+              <fieldset
+                className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4"
+                key={voicing}
               >
-                <input
-                  defaultChecked={checked(part, selectedParts)}
-                  name="parts"
-                  type="checkbox"
-                  value={part}
-                />
-                <span className="font-semibold">{partLabels[part]}</span>
-              </label>
+                <legend className="font-bold text-[#172023]">
+                  {voicingLabels[voicing]}
+                </legend>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  {partsByVoicing[voicing].map((part) => {
+                    const value = voicingPartValue(voicing, part);
+
+                    return (
+                      <label
+                        className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-white px-3 py-2"
+                        key={value}
+                      >
+                        <input
+                          defaultChecked={checked(value, selectedParts)}
+                          name="parts"
+                          type="checkbox"
+                          value={value}
+                        />
+                        <span className="font-semibold">
+                          {partLabel(voicing, part)}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </fieldset>
             ))}
           </div>
         </section>

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -6,6 +6,11 @@ import {
   type DiscoveryMapItem,
 } from "@/lib/location/map-markers";
 import { approximateLocationLabel } from "@/lib/location/approximate-location";
+import {
+  groupVoicingParts,
+  voicingPartOptions,
+  voicingPartValue,
+} from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -48,13 +53,7 @@ const kindOptions = [
   ["singers", "Singers"],
 ];
 
-const partOptions = [
-  ["", "Any part"],
-  ["tenor", "Tenor"],
-  ["lead", "Lead"],
-  ["baritone", "Baritone"],
-  ["bass", "Bass"],
-];
+const partOptions = voicingPartOptions("Any voicing / part");
 
 const goalOptions = [
   ["", "Any goal"],
@@ -79,8 +78,8 @@ function selectedKind(value: string | string[] | undefined) {
   return rawValue === "singers" || rawValue === "quartets" ? rawValue : "both";
 }
 
-function tags(values: string[]) {
-  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+function partsLabel(values: string[]) {
+  return groupVoicingParts(values) || "Any";
 }
 
 function locationLabel(item: FindResult) {
@@ -161,7 +160,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
       }
 
       if (filters.part) {
-        query = query.contains("parts", [filters.part]);
+        query = query.contains("parts", [
+          voicingPartValue(filters.part.voicing, filters.part.part),
+        ]);
       }
 
       if (filters.goal) {
@@ -213,7 +214,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
       }
 
       if (filters.part) {
-        query = query.contains("parts_needed", [filters.part]);
+        query = query.contains("parts_needed", [
+          voicingPartValue(filters.part.voicing, filters.part.part),
+        ]);
       }
 
       if (filters.goal) {
@@ -324,7 +327,11 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             <span className="text-sm font-semibold">Part</span>
             <select
               className={filterControlClass}
-              defaultValue={textValue(filters.part)}
+              defaultValue={
+                filters.part
+                  ? voicingPartValue(filters.part.voicing, filters.part.part)
+                  : ""
+              }
               name="part"
             >
               {partOptions.map(([value, label]) => (
@@ -398,7 +405,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                   {marker.count} {markerKindLabel(marker)}
                 </p>
                 {marker.parts.length > 0 ? (
-                  <p className="mt-1 text-[#596466]">{tags(marker.parts)}</p>
+                  <p className="mt-1 text-[#596466]">
+                    {partsLabel(marker.parts)}
+                  </p>
                 ) : null}
               </div>
             ))}
@@ -458,7 +467,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                         {result.intentLabel}
                       </td>
                       <td className="px-4 py-3 text-[#394548]">
-                        {result.parts.length > 0 ? tags(result.parts) : "Any"}
+                        {partsLabel(result.parts)}
                       </td>
                       <td className="px-4 py-3 text-[#394548]">
                         {locationLabel(result)}
@@ -495,7 +504,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                 </p>
                 {marker.parts.length > 0 ? (
                   <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
-                    {tags(marker.parts)}
+                    {partsLabel(marker.parts)}
                   </p>
                 ) : null}
               </article>

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -6,6 +6,11 @@ import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
 } from "@/lib/location/map-markers";
+import {
+  groupVoicingParts,
+  voicingPartOptions,
+  voicingPartValue,
+} from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -43,13 +48,7 @@ const kindOptions = [
   ["quartets", "Quartet openings"],
 ];
 
-const partOptions = [
-  ["", "Any part"],
-  ["tenor", "Tenor"],
-  ["lead", "Lead"],
-  ["baritone", "Baritone"],
-  ["bass", "Bass"],
-];
+const partOptions = voicingPartOptions("Any voicing / part");
 
 const goalOptions = [
   ["", "Any goal"],
@@ -89,8 +88,8 @@ function filterAnalyticsProperties(
   return { filterCount, flags };
 }
 
-function tags(values: string[]) {
-  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+function partsLabel(values: string[]) {
+  return groupVoicingParts(values) || "No parts listed";
 }
 
 function markerSummary(marker: { names: string[] }) {
@@ -147,7 +146,9 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
       }
 
       if (filters.part) {
-        query = query.contains("parts", [filters.part]);
+        query = query.contains("parts", [
+          voicingPartValue(filters.part.voicing, filters.part.part),
+        ]);
       }
 
       if (filters.goal) {
@@ -197,7 +198,9 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
       }
 
       if (filters.part) {
-        query = query.contains("parts_needed", [filters.part]);
+        query = query.contains("parts_needed", [
+          voicingPartValue(filters.part.voicing, filters.part.part),
+        ]);
       }
 
       if (filters.goal) {
@@ -304,7 +307,11 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
             <span className="text-sm font-semibold">Part</span>
             <select
               className={filterControlClass}
-              defaultValue={textValue(filters.part)}
+              defaultValue={
+                filters.part
+                  ? voicingPartValue(filters.part.voicing, filters.part.part)
+                  : ""
+              }
               name="part"
             >
               {partOptions.map(([value, label]) => (
@@ -380,7 +387,9 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
                   {marker.count} {markerKindLabel(marker)}
                 </p>
                 {marker.parts.length > 0 ? (
-                  <p className="mt-1 text-[#596466]">{tags(marker.parts)}</p>
+                  <p className="mt-1 text-[#596466]">
+                    {partsLabel(marker.parts)}
+                  </p>
                 ) : null}
               </div>
             ))}
@@ -427,7 +436,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
               </p>
               {marker.parts.length > 0 ? (
                 <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
-                  {tags(marker.parts)}
+                  {partsLabel(marker.parts)}
                 </p>
               ) : null}
             </article>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ const discoveryLinks = [
   {
     href: "/find?kind=quartets",
     label: "Browse quartet openings",
-    description: "See incomplete quartets looking for one or more parts.",
+    description: "See incomplete quartets looking for voicing-specific parts.",
   },
   {
     href: "/find?kind=singers",
@@ -45,8 +45,8 @@ export default function Home() {
             </p>
             <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
               {PRODUCT_NAME} is for practical introductions: create a singer
-              profile, list an incomplete quartet, or look around before you
-              decide what to share.
+              profile with the parts you sing by voicing, list an incomplete
+              quartet, or look around before you decide what to share.
             </p>
             <div className="mt-8 grid gap-3 sm:flex sm:flex-wrap">
               <Link

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -9,6 +9,11 @@ import {
   toPublicLocationSummary,
   travelRadiusLabel,
 } from "@/lib/location/approximate-location";
+import {
+  groupVoicingParts,
+  voicingPartOptions,
+  voicingPartValue,
+} from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -33,13 +38,7 @@ type SearchPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-const partOptions = [
-  ["", "Any needed part"],
-  ["tenor", "Tenor"],
-  ["lead", "Lead"],
-  ["baritone", "Baritone"],
-  ["bass", "Bass"],
-];
+const partOptions = voicingPartOptions("Any needed voicing / part");
 
 const goalOptions = [
   ["", "Any goal"],
@@ -60,6 +59,10 @@ function textValue(value: string | null) {
 
 function tags(values: string[]) {
   return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+function partsLabel(values: string[]) {
+  return groupVoicingParts(values) || "No parts listed";
 }
 
 function returnToPath(params: Record<string, string | string[] | undefined>) {
@@ -147,7 +150,9 @@ export default async function QuartetSearchPage({
     }
 
     if (filters.part) {
-      query = query.contains("parts_needed", [filters.part]);
+      query = query.contains("parts_needed", [
+        voicingPartValue(filters.part.voicing, filters.part.part),
+      ]);
     }
 
     if (filters.goal) {
@@ -239,7 +244,11 @@ export default async function QuartetSearchPage({
             <span className="text-sm font-semibold">Needed part</span>
             <select
               className={filterControlClass}
-              defaultValue={textValue(filters.part)}
+              defaultValue={
+                filters.part
+                  ? voicingPartValue(filters.part.voicing, filters.part.part)
+                  : ""
+              }
               name="part"
             >
               {partOptions.map(([value, label]) => (
@@ -374,7 +383,7 @@ export default async function QuartetSearchPage({
                   </p>
                 </div>
                 <p className="text-sm font-semibold text-[#2f6f73]">
-                  Seeking {tags(quartet.parts_needed)}
+                  Seeking {partsLabel(quartet.parts_needed)}
                 </p>
               </div>
               {quartet.description ? (
@@ -386,7 +395,7 @@ export default async function QuartetSearchPage({
                 {quartet.parts_covered.length > 0 ? (
                   <div>
                     <dt className="font-semibold text-[#172023]">Covered</dt>
-                    <dd>{tags(quartet.parts_covered)}</dd>
+                    <dd>{partsLabel(quartet.parts_covered)}</dd>
                   </div>
                 ) : null}
                 {quartet.goals.length > 0 ? (

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -9,6 +9,11 @@ import {
   toPublicLocationSummary,
   travelRadiusLabel,
 } from "@/lib/location/approximate-location";
+import {
+  groupVoicingParts,
+  voicingPartOptions,
+  voicingPartValue,
+} from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -31,13 +36,7 @@ type SearchPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-const partOptions = [
-  ["", "Any part"],
-  ["tenor", "Tenor"],
-  ["lead", "Lead"],
-  ["baritone", "Baritone"],
-  ["bass", "Bass"],
-];
+const partOptions = voicingPartOptions("Any voicing / part");
 
 const goalOptions = [
   ["", "Any goal"],
@@ -58,6 +57,10 @@ function textValue(value: string | null) {
 
 function tags(values: string[]) {
   return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+function partsLabel(values: string[]) {
+  return groupVoicingParts(values) || "No parts listed";
 }
 
 function returnToPath(params: Record<string, string | string[] | undefined>) {
@@ -145,7 +148,9 @@ export default async function SingerSearchPage({
     }
 
     if (filters.part) {
-      query = query.contains("parts", [filters.part]);
+      query = query.contains("parts", [
+        voicingPartValue(filters.part.voicing, filters.part.part),
+      ]);
     }
 
     if (filters.goal) {
@@ -238,7 +243,11 @@ export default async function SingerSearchPage({
             <span className="text-sm font-semibold">Part</span>
             <select
               className={filterControlClass}
-              defaultValue={textValue(filters.part)}
+              defaultValue={
+                filters.part
+                  ? voicingPartValue(filters.part.voicing, filters.part.part)
+                  : ""
+              }
               name="part"
             >
               {partOptions.map(([value, label]) => (
@@ -373,7 +382,7 @@ export default async function SingerSearchPage({
                   </p>
                 </div>
                 <p className="text-sm font-semibold text-[#2f6f73]">
-                  {tags(singer.parts)}
+                  {partsLabel(singer.parts)}
                 </p>
               </div>
               <dl className="mt-4 grid gap-3 text-sm text-[#394548] sm:grid-cols-2">

--- a/components/quartet-listing-parts-fieldset.tsx
+++ b/components/quartet-listing-parts-fieldset.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import {
+  VOICINGS,
+  partsByVoicing,
+  partLabel,
+  voicingLabels,
+  voicingPartValue,
+  type Voicing,
+} from "@/lib/parts/voicings";
+
+type QuartetListingPartsFieldsetProps = {
+  initialCoveredParts: string[];
+  initialNeededParts: string[];
+  initialVoicing: Voicing;
+};
+
+function checked(value: string, values: readonly string[]) {
+  return values.includes(value);
+}
+
+export function QuartetListingPartsFieldset({
+  initialCoveredParts,
+  initialNeededParts,
+  initialVoicing,
+}: QuartetListingPartsFieldsetProps) {
+  const [voicing, setVoicing] = useState<Voicing>(initialVoicing);
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-bold text-[#172023]">Parts</h2>
+      <label className="block">
+        <span className="text-sm font-semibold text-[#172023]">
+          Quartet voicing
+        </span>
+        <select
+          className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+          name="voicing"
+          onChange={(event) => setVoicing(event.target.value as Voicing)}
+          value={voicing}
+        >
+          {VOICINGS.map((option) => (
+            <option key={option} value={option}>
+              {voicingLabels[option]}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="text-sm leading-6 text-[#394548]">
+        Choose one primary voicing for this listing. SATB labels include the
+        mixed-barbershop equivalent while storing canonical SATB parts.
+      </p>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold text-[#172023]">
+            Currently covered
+          </legend>
+          {partsByVoicing[voicing].map((part) => {
+            const value = voicingPartValue(voicing, part);
+
+            return (
+              <label
+                className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                key={value}
+              >
+                <input
+                  defaultChecked={checked(value, initialCoveredParts)}
+                  name="partsCovered"
+                  type="checkbox"
+                  value={value}
+                />
+                <span className="font-semibold">
+                  {partLabel(voicing, part)}
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold text-[#172023]">
+            Needed
+          </legend>
+          {partsByVoicing[voicing].map((part) => {
+            const value = voicingPartValue(voicing, part);
+
+            return (
+              <label
+                className="flex items-center gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] px-3 py-2"
+                key={value}
+              >
+                <input
+                  defaultChecked={checked(value, initialNeededParts)}
+                  name="partsNeeded"
+                  type="checkbox"
+                  value={value}
+                />
+                <span className="font-semibold">
+                  {partLabel(voicing, part)}
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+      </div>
+    </section>
+  );
+}

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -11,7 +11,7 @@ Public search results may show:
 - display name
 - approximate city/region/country
 - approximate distance from the searcher
-- voice parts sung or needed
+- voice parts sung or needed, with voicing context
 - quartet goals and experience information
 - availability and travel preferences when the user chooses to provide them
 
@@ -26,7 +26,7 @@ Public search results must not show:
 
 Public singer and quartet discovery pages must query privacy-safe discovery
 views rather than private base tables. Filters may use public country, region,
-locality, part, goal, experience/commitment, availability, and travel
+locality, voicing-aware part, goal, experience/commitment, availability, and travel
 willingness fields where data exists. Exact coordinates, private postal codes,
 formatted private addresses, email addresses, and phone numbers are not part of
 the public result shape.
@@ -103,7 +103,7 @@ Signed-in users can manage their own singer profile from the protected app area.
 The MVP profile form stores:
 
 - display name
-- barbershop parts sung
+- barbershop parts sung, grouped by voicing
 - goals
 - descriptive experience level
 - availability
@@ -124,6 +124,7 @@ Signed-in users can manage a quartet listing from the protected app area. The
 MVP listing form stores:
 
 - listing or quartet name
+- quartet voicing
 - parts currently covered
 - parts needed
 - goals
@@ -135,9 +136,10 @@ MVP listing form stores:
 - country, region, locality, and private postal code when provided
 - search visibility
 
-The listing form keeps covered and needed parts distinct so public discovery can
-clearly show what the quartet has and what it is seeking. Postal code remains
-private listing data and should not be shown in public listing discovery.
+The listing form keeps covered and needed parts distinct and tied to the
+listing's primary voicing so public discovery can clearly show what the quartet
+has and what it is seeking. Postal code remains private listing data and should
+not be shown in public listing discovery.
 
 ## Contact model
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -74,7 +74,7 @@ validation.
 1. Open `/app/profile`.
 2. Create or edit a singer profile with:
    - display name: `Smoke Test Singer`
-   - parts: Lead and Baritone
+   - parts: TTBB Lead and SATB Soprano / Mixed Tenor
    - goals: Pickup and Learning
    - country: United Kingdom
    - region: England
@@ -84,7 +84,7 @@ validation.
    - travel radius: `40`
    - visible: on
 3. Pass: saving succeeds and the form reloads with the saved values.
-4. Pass: `/singers?country=United+Kingdom&locality=Manchester&part=lead`
+4. Pass: `/singers?country=United+Kingdom&locality=Manchester&part=TTBB%3ALead`
    includes the profile when visible.
 5. Pass: public singer results show approximate location only, such as
    `Manchester, UK area`, and do not show `M1 TEST`.
@@ -98,8 +98,9 @@ validation.
 1. Open `/app/listings`.
 2. Create or edit a quartet listing with:
    - name: `Smoke Test Quartet`
-   - covered parts: Tenor and Bass
-   - needed parts: Lead and Baritone
+   - voicing: TTBB
+   - covered parts: TTBB Tenor and Bass
+   - needed parts: TTBB Lead and Baritone
    - goals: Regular Rehearsal and Contest
    - country: Ireland
    - region: Leinster
@@ -109,8 +110,8 @@ validation.
    - travel radius: `50`
    - visible: on
 3. Pass: saving succeeds and covered/needed parts remain distinct.
-4. Pass: `/quartets?country=Ireland&locality=Dublin&part=lead` includes the
-   listing when visible.
+4. Pass: `/quartets?country=Ireland&locality=Dublin&part=TTBB%3ALead` includes
+   the listing when visible.
 5. Pass: public quartet results show parts covered, parts needed, goals, and
    approximate location only.
 6. Set visibility off and save.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -13,29 +13,36 @@ It includes these data areas:
 
 - `account_profiles`: authenticated-user display metadata.
 - `singer_profiles`: one singer profile per authenticated owner.
-- `singer_profile_parts`: one or more barbershop parts for a singer.
+- `singer_profile_parts`: one or more voicing-aware barbershop parts for a singer.
 - `quartet_listings`: incomplete quartet listings owned by one authenticated user.
-- `quartet_listing_parts`: parts currently covered or needed by a quartet.
+- `quartet_listing_parts`: voicing-aware parts currently covered or needed by a quartet.
 - `contact_requests`: app-mediated first-contact messages.
 - `feedback_submissions`: private authenticated-user feedback from the help page.
 - `singer_discovery_profiles`: privacy-safe singer discovery view.
 - `quartet_discovery_listings`: privacy-safe quartet discovery view.
 
-The schema also defines enums for barbershop parts, distance units, location
-precision, quartet part status, and contact request status.
+The schema also defines enums for distance units, location precision, quartet
+part status, and contact request status. Earlier migrations created a
+barbershop part enum; current part storage uses text plus voicing constraints so
+TTBB, SATB, and SSAA part names can stay distinct.
 
 ## Part model
 
-Barbershop parts are represented as:
+Barbershop parts are represented with explicit voicing context. The app stores
+the canonical `voicing` and `part` together in `singer_profile_parts` and
+`quartet_listing_parts`.
 
-- `tenor`
-- `lead`
-- `baritone`
-- `bass`
+Supported MVP voicings and parts are:
 
-Display code may title-case those values, but the database intentionally uses
-stable lowercase enum values. SSAA barbershop listings still use Tenor, Lead,
-Baritone, and Bass unless the product explicitly adds alternate naming later.
+- TTBB: `Tenor`, `Lead`, `Baritone`, `Bass`
+- SATB: `Soprano`, `Alto`, `Tenor`, `Bass`
+- SSAA: `Soprano 1`, `Soprano 2`, `Alto 1`, `Alto 2`
+
+Voicing context is meaningful. `TTBB` `Tenor` and `SATB` `Tenor` are not treated
+as interchangeable discovery values. SATB UI may show mixed-barbershop helper
+labels, such as “Soprano / Mixed Tenor,” while storing the canonical SATB part.
+Discovery views expose searchable public arrays as `Voicing:Part` strings, for
+example `TTBB:Lead` or `SATB:Soprano`.
 
 ## Ownership model
 
@@ -91,7 +98,7 @@ The public discovery routes are:
 - `/quartets`, backed by `quartet_discovery_listings`
 - `/map`, backed by both discovery views as a compatibility map view
 
-These routes may filter on public location fields, part, goals,
+These routes may filter on public location fields, voicing-aware part, goals,
 experience/commitment, availability, and travel willingness. They should not
 read private base-table location or contact fields.
 

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -9,6 +9,7 @@ export const publicHelpSections = [
   {
     body: [
       "A singer profile describes who you are as a singer: your name, parts, goals, experience, availability, travel willingness, and approximate location.",
+      "Parts are grouped by voicing, so TTBB Tenor, SATB Tenor, and SSAA part labels stay distinct in discovery.",
       "You choose whether the profile appears in public discovery. Hidden profiles stay out of singer search and the map.",
     ],
     heading: "Singer Profiles",
@@ -16,7 +17,7 @@ export const publicHelpSections = [
   {
     body: [
       "A quartet listing is for a quartet or prospective quartet that has some parts covered and is looking for one or more singers.",
-      "Listings keep covered parts and needed parts separate so searchers can quickly understand what the group needs.",
+      "Listings keep covered parts and needed parts separate within the quartet's voicing so searchers can quickly understand what the group needs.",
     ],
     heading: "Quartet Listings",
   },
@@ -24,6 +25,7 @@ export const publicHelpSections = [
     body: [
       "Find is the main discovery page. It combines filters, a privacy-safe regional map, and a results table for quartet openings and singer profiles.",
       "Use the looking-for filter to focus on quartet openings when you are a singer, or singer profiles when you are representing a quartet or looking for other singers.",
+      "Part filters include voicing context, including TTBB, SSAA, and SATB / mixed labels.",
       "The map is part of Find rather than a separate first step. It helps you scan approximate activity, then the table below gives names, parts, type, and next-step links.",
       "Detailed singer and quartet search pages remain available from Find when you need more specific filters like availability, experience, or travel willingness.",
       "Search results are useful even when a profile is incomplete, but more complete profiles are easier for others to evaluate.",

--- a/lib/parts/voicings.ts
+++ b/lib/parts/voicings.ts
@@ -1,0 +1,104 @@
+export const VOICINGS = ["TTBB", "SSAA", "SATB"] as const;
+
+export type Voicing = (typeof VOICINGS)[number];
+
+export const partsByVoicing = {
+  TTBB: ["Tenor", "Lead", "Baritone", "Bass"],
+  SATB: ["Soprano", "Alto", "Tenor", "Bass"],
+  SSAA: ["Soprano 1", "Soprano 2", "Alto 1", "Alto 2"],
+} as const;
+
+export type VoicingPart = (typeof partsByVoicing)[Voicing][number];
+
+export type VoicingPartSelection = {
+  part: VoicingPart;
+  voicing: Voicing;
+};
+
+export const satbDisplayLabels = {
+  Alto: "Alto / Mixed Lead",
+  Bass: "Bass / Mixed Bass",
+  Soprano: "Soprano / Mixed Tenor",
+  Tenor: "Tenor / Mixed Baritone",
+} as const;
+
+export const voicingLabels: Record<Voicing, string> = {
+  SATB: "SATB / mixed",
+  SSAA: "SSAA",
+  TTBB: "TTBB",
+};
+
+export function partLabel(voicing: Voicing, part: VoicingPart) {
+  return voicing === "SATB" && part in satbDisplayLabels
+    ? satbDisplayLabels[part as keyof typeof satbDisplayLabels]
+    : part;
+}
+
+export function voicingPartValue(voicing: Voicing, part: VoicingPart) {
+  return `${voicing}:${part}`;
+}
+
+export function voicingPartOptions(anyLabel: string) {
+  return [
+    ["", anyLabel],
+    ...VOICINGS.flatMap((voicing) =>
+      partsByVoicing[voicing].map((part) => [
+        voicingPartValue(voicing, part),
+        `${voicingLabels[voicing]} ${partLabel(voicing, part)}`,
+      ]),
+    ),
+  ] as const;
+}
+
+export function parseVoicingPartValue(value: string) {
+  const [voicing, part] = value.split(":");
+
+  if (!isVoicing(voicing)) {
+    return null;
+  }
+
+  return isPartForVoicing(voicing, part)
+    ? ({ part, voicing } as VoicingPartSelection)
+    : null;
+}
+
+export function isVoicing(value: unknown): value is Voicing {
+  return typeof value === "string" && VOICINGS.includes(value as Voicing);
+}
+
+export function isPartForVoicing(
+  voicing: Voicing,
+  value: unknown,
+): value is VoicingPart {
+  return (
+    typeof value === "string" &&
+    (partsByVoicing[voicing] as readonly string[]).includes(value)
+  );
+}
+
+export function groupVoicingParts(parts: readonly string[]) {
+  const groups = new Map<Voicing, VoicingPart[]>();
+
+  for (const value of parts) {
+    const parsed = parseVoicingPartValue(value);
+
+    if (!parsed) {
+      continue;
+    }
+
+    groups.set(parsed.voicing, [
+      ...(groups.get(parsed.voicing) ?? []),
+      parsed.part,
+    ]);
+  }
+
+  return VOICINGS.flatMap((voicing) => {
+    const selectedParts = groups.get(voicing) ?? [];
+
+    return selectedParts.length > 0
+      ? [
+          `${voicingLabels[voicing]}: ${selectedParts.map((part) => partLabel(voicing, part)).join(", ")}`,
+        ]
+      : [];
+  }).join("; ");
+}

--- a/lib/profiles/singer-profile-form.ts
+++ b/lib/profiles/singer-profile-form.ts
@@ -1,4 +1,7 @@
-export const BARBERSHOP_PARTS = ["tenor", "lead", "baritone", "bass"] as const;
+import {
+  parseVoicingPartValue,
+  type VoicingPartSelection,
+} from "@/lib/parts/voicings";
 
 export const PROFILE_GOALS = [
   "casual",
@@ -9,7 +12,6 @@ export const PROFILE_GOALS = [
   "learning",
 ] as const;
 
-export type BarbershopPart = (typeof BARBERSHOP_PARTS)[number];
 export type ProfileGoal = (typeof PROFILE_GOALS)[number];
 
 export type SingerProfileFormValues = {
@@ -23,7 +25,7 @@ export type SingerProfileFormValues = {
   isVisible: boolean;
   locality: string | null;
   locationLabelPublic: string | null;
-  parts: BarbershopPart[];
+  parts: VoicingPartSelection[];
   postalCodePrivate: string | null;
   region: string | null;
   travelRadiusKm: number | null;
@@ -64,7 +66,7 @@ export function parseTravelRadiusKm(value: FormDataEntryValue | null) {
   return radius;
 }
 
-function parseAllowedList<T extends string>(
+export function parseAllowedList<T extends string>(
   values: FormDataEntryValue[],
   allowedValues: readonly T[],
 ) {
@@ -73,6 +75,13 @@ function parseAllowedList<T extends string>(
   return values
     .filter((value): value is string => typeof value === "string")
     .filter((value): value is T => allowed.has(value));
+}
+
+export function parseVoicingPartList(values: FormDataEntryValue[]) {
+  return values
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => parseVoicingPartValue(value))
+    .filter((value): value is VoicingPartSelection => value != null);
 }
 
 export function parseSingerProfileFormData(
@@ -97,7 +106,7 @@ export function parseSingerProfileFormData(
     locationLabelPublic: normalizeOptionalText(
       formData.get("locationLabelPublic"),
     ),
-    parts: parseAllowedList(formData.getAll("parts"), BARBERSHOP_PARTS),
+    parts: parseVoicingPartList(formData.getAll("parts")),
     postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
     region: normalizeOptionalText(formData.get("region")),
     travelRadiusKm: parseTravelRadiusKm(formData.get("travelRadiusKm")),

--- a/lib/quartets/quartet-listing-form.ts
+++ b/lib/quartets/quartet-listing-form.ts
@@ -1,12 +1,17 @@
 import {
-  BARBERSHOP_PARTS,
   PROFILE_GOALS,
   normalizeCountryCode,
   normalizeOptionalText,
+  parseAllowedList,
   parseTravelRadiusKm,
-  type BarbershopPart,
+  parseVoicingPartList,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
+import {
+  type Voicing,
+  type VoicingPartSelection,
+  isVoicing,
+} from "@/lib/parts/voicings";
 
 export type QuartetListingFormValues = {
   availability: string | null;
@@ -20,31 +25,29 @@ export type QuartetListingFormValues = {
   locality: string | null;
   locationLabelPublic: string | null;
   name: string;
-  partsCovered: BarbershopPart[];
-  partsNeeded: BarbershopPart[];
+  partsCovered: VoicingPartSelection[];
+  partsNeeded: VoicingPartSelection[];
   postalCodePrivate: string | null;
   region: string | null;
   travelRadiusKm: number | null;
+  voicing: Voicing;
 };
 
-function parseAllowedList<T extends string>(
-  values: FormDataEntryValue[],
-  allowedValues: readonly T[],
+function removePartsAlreadyNeeded(
+  covered: VoicingPartSelection[],
+  needed: VoicingPartSelection[],
 ) {
-  const allowed = new Set<string>(allowedValues);
+  const neededParts = new Set(
+    needed.map((part) => `${part.voicing}:${part.part}`),
+  );
 
-  return values
-    .filter((value): value is string => typeof value === "string")
-    .filter((value): value is T => allowed.has(value));
+  return covered.filter(
+    (part) => !neededParts.has(`${part.voicing}:${part.part}`),
+  );
 }
 
-function removePartsAlreadyNeeded(
-  covered: BarbershopPart[],
-  needed: BarbershopPart[],
-) {
-  const neededParts = new Set(needed);
-
-  return covered.filter((part) => !neededParts.has(part));
+function selectedVoicing(value: FormDataEntryValue | null) {
+  return typeof value === "string" && isVoicing(value) ? value : "TTBB";
 }
 
 export function parseQuartetListingFormData(
@@ -56,12 +59,14 @@ export function parseQuartetListingFormData(
     throw new Error("Listing name is required.");
   }
 
-  const partsNeeded = parseAllowedList(
+  const voicing = selectedVoicing(formData.get("voicing"));
+  const partsNeeded = parseVoicingPartList(
     formData.getAll("partsNeeded"),
-    BARBERSHOP_PARTS,
-  );
+  ).filter((part) => part.voicing === voicing);
   const partsCovered = removePartsAlreadyNeeded(
-    parseAllowedList(formData.getAll("partsCovered"), BARBERSHOP_PARTS),
+    parseVoicingPartList(formData.getAll("partsCovered")).filter(
+      (part) => part.voicing === voicing,
+    ),
     partsNeeded,
   );
 
@@ -84,6 +89,7 @@ export function parseQuartetListingFormData(
     postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
     region: normalizeOptionalText(formData.get("region")),
     travelRadiusKm: parseTravelRadiusKm(formData.get("travelRadiusKm")),
+    voicing,
   };
 }
 

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -1,9 +1,11 @@
 import {
-  BARBERSHOP_PARTS,
   PROFILE_GOALS,
-  type BarbershopPart,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
+import {
+  parseVoicingPartValue,
+  type VoicingPartSelection,
+} from "@/lib/parts/voicings";
 
 export type DiscoveryFilters = {
   availability: string | null;
@@ -11,7 +13,7 @@ export type DiscoveryFilters = {
   experience: string | null;
   goal: ProfileGoal | null;
   locality: string | null;
-  part: BarbershopPart | null;
+  part: VoicingPartSelection | null;
   region: string | null;
   travelRadiusKm: number | null;
 };
@@ -61,7 +63,7 @@ export function parseDiscoveryFilters(
     experience: normalizeSearchText(searchParams.experience),
     goal: parseAllowedValue(searchParams.goal, PROFILE_GOALS),
     locality: normalizeSearchText(searchParams.locality),
-    part: parseAllowedValue(searchParams.part, BARBERSHOP_PARTS),
+    part: parseVoicingPartValue(normalizeSearchText(searchParams.part) ?? ""),
     region: normalizeSearchText(searchParams.region),
     travelRadiusKm: parseTravelRadiusKm(searchParams.travelRadiusKm),
   };

--- a/supabase/migrations/20260430220600_voicing_aware_parts.sql
+++ b/supabase/migrations/20260430220600_voicing_aware_parts.sql
@@ -1,0 +1,130 @@
+drop view if exists public.quartet_discovery_listings;
+drop view if exists public.singer_discovery_profiles;
+
+alter table public.singer_profile_parts
+  drop constraint singer_profile_parts_pkey;
+
+alter table public.quartet_listing_parts
+  drop constraint quartet_listing_parts_pkey;
+
+alter table public.singer_profile_parts
+  add column voicing text not null default 'TTBB';
+
+alter table public.quartet_listing_parts
+  add column voicing text not null default 'TTBB';
+
+alter table public.singer_profile_parts
+  alter column part type text
+  using case part::text
+    when 'tenor' then 'Tenor'
+    when 'lead' then 'Lead'
+    when 'baritone' then 'Baritone'
+    when 'bass' then 'Bass'
+    else part::text
+  end;
+
+alter table public.quartet_listing_parts
+  alter column part type text
+  using case part::text
+    when 'tenor' then 'Tenor'
+    when 'lead' then 'Lead'
+    when 'baritone' then 'Baritone'
+    when 'bass' then 'Bass'
+    else part::text
+  end;
+
+alter table public.singer_profile_parts
+  add constraint singer_profile_parts_voicing_part_check
+  check (
+    (voicing = 'TTBB' and part in ('Tenor', 'Lead', 'Baritone', 'Bass'))
+    or (voicing = 'SATB' and part in ('Soprano', 'Alto', 'Tenor', 'Bass'))
+    or (voicing = 'SSAA' and part in ('Soprano 1', 'Soprano 2', 'Alto 1', 'Alto 2'))
+  ),
+  add primary key (singer_profile_id, voicing, part);
+
+alter table public.quartet_listing_parts
+  add constraint quartet_listing_parts_voicing_part_check
+  check (
+    (voicing = 'TTBB' and part in ('Tenor', 'Lead', 'Baritone', 'Bass'))
+    or (voicing = 'SATB' and part in ('Soprano', 'Alto', 'Tenor', 'Bass'))
+    or (voicing = 'SSAA' and part in ('Soprano 1', 'Soprano 2', 'Alto 1', 'Alto 2'))
+  ),
+  add primary key (quartet_listing_id, voicing, part);
+
+create view public.singer_discovery_profiles
+as
+select
+  singer_profiles.id,
+  singer_profiles.display_name,
+  coalesce(
+    array_agg(
+      singer_profile_parts.voicing || ':' || singer_profile_parts.part
+      order by singer_profile_parts.voicing, singer_profile_parts.part
+    )
+      filter (where singer_profile_parts.part is not null),
+    '{}'
+  ) as parts,
+  singer_profiles.goals,
+  singer_profiles.experience_level,
+  singer_profiles.availability,
+  singer_profiles.travel_radius_km,
+  singer_profiles.preferred_distance_unit,
+  singer_profiles.country_code,
+  singer_profiles.country_name,
+  singer_profiles.region,
+  singer_profiles.locality,
+  singer_profiles.location_label_public,
+  singer_profiles.updated_at
+from public.singer_profiles
+left join public.singer_profile_parts
+  on singer_profile_parts.singer_profile_id = singer_profiles.id
+where singer_profiles.is_visible = true
+  and singer_profiles.is_active = true
+group by singer_profiles.id;
+
+create view public.quartet_discovery_listings
+as
+select
+  quartet_listings.id,
+  quartet_listings.name,
+  quartet_listings.description,
+  coalesce(
+    array_agg(
+      quartet_listing_parts.voicing || ':' || quartet_listing_parts.part
+      order by quartet_listing_parts.voicing, quartet_listing_parts.part
+    )
+      filter (
+        where quartet_listing_parts.status = 'covered'
+      ),
+    '{}'
+  ) as parts_covered,
+  coalesce(
+    array_agg(
+      quartet_listing_parts.voicing || ':' || quartet_listing_parts.part
+      order by quartet_listing_parts.voicing, quartet_listing_parts.part
+    )
+      filter (
+        where quartet_listing_parts.status = 'needed'
+      ),
+    '{}'
+  ) as parts_needed,
+  quartet_listings.goals,
+  quartet_listings.experience_level,
+  quartet_listings.availability,
+  quartet_listings.travel_radius_km,
+  quartet_listings.preferred_distance_unit,
+  quartet_listings.country_code,
+  quartet_listings.country_name,
+  quartet_listings.region,
+  quartet_listings.locality,
+  quartet_listings.location_label_public,
+  quartet_listings.updated_at
+from public.quartet_listings
+left join public.quartet_listing_parts
+  on quartet_listing_parts.quartet_listing_id = quartet_listings.id
+where quartet_listings.is_visible = true
+  and quartet_listings.is_active = true
+group by quartet_listings.id;
+
+grant select on table public.singer_discovery_profiles to anon, authenticated;
+grant select on table public.quartet_discovery_listings to anon, authenticated;

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -11,7 +11,7 @@ describe("discovery filters", () => {
       locality: " Manchester ",
       region: " Greater Manchester ",
       goal: "contest",
-      part: "lead",
+      part: "SATB:Soprano",
       travelRadiusKm: "50",
     });
 
@@ -19,7 +19,7 @@ describe("discovery filters", () => {
     expect(filters.locality).toBe("Manchester");
     expect(filters.region).toBe("Greater Manchester");
     expect(filters.goal).toBe("contest");
-    expect(filters.part).toBe("lead");
+    expect(filters.part).toEqual({ part: "Soprano", voicing: "SATB" });
     expect(filters.travelRadiusKm).toBe(50);
     expect(hasDiscoveryFilters(filters)).toBe(true);
   });
@@ -42,14 +42,14 @@ describe("discovery filters", () => {
       country: ["Ireland", "United States"],
       goal: ["pickup", "contest"],
       locality: ["Dublin", "Boston"],
-      part: ["tenor", "melody"],
+      part: ["TTBB:Tenor", "melody"],
       travelRadiusKm: ["10000", "25"],
     });
 
     expect(filters.country).toBe("Ireland");
     expect(filters.locality).toBe("Dublin");
     expect(filters.goal).toBe("pickup");
-    expect(filters.part).toBe("tenor");
+    expect(filters.part).toEqual({ part: "Tenor", voicing: "TTBB" });
     expect(filters.travelRadiusKm).toBe(10000);
   });
 

--- a/test/map-markers.test.ts
+++ b/test/map-markers.test.ts
@@ -12,7 +12,7 @@ describe("privacy-safe discovery map markers", () => {
         locality: "Fort Collins",
         locationLabelPublic: null,
         name: "Avery",
-        parts: ["lead"],
+        parts: ["TTBB:Lead"],
         region: "CO",
       },
       {
@@ -23,7 +23,7 @@ describe("privacy-safe discovery map markers", () => {
         locality: "Manchester",
         locationLabelPublic: "Manchester, UK area",
         name: "Northern Ring",
-        parts: ["bass"],
+        parts: ["SATB:Bass"],
         region: "England",
       },
     ]);
@@ -54,7 +54,7 @@ describe("privacy-safe discovery map markers", () => {
         locality: "Dublin",
         locationLabelPublic: null,
         name: "Casey",
-        parts: ["tenor"],
+        parts: ["TTBB:Tenor"],
         region: "Leinster",
       },
       {
@@ -65,7 +65,7 @@ describe("privacy-safe discovery map markers", () => {
         locality: "Dublin",
         locationLabelPublic: null,
         name: "River City Four",
-        parts: ["lead"],
+        parts: ["SSAA:Soprano 2"],
         region: "Leinster",
       },
     ]);
@@ -76,7 +76,7 @@ describe("privacy-safe discovery map markers", () => {
       kinds: ["quartet", "singer"],
       label: "Dublin, Leinster, Ireland area",
       names: ["Casey", "River City Four"],
-      parts: ["lead", "tenor"],
+      parts: ["SSAA:Soprano 2", "TTBB:Tenor"],
     });
   });
 
@@ -91,7 +91,7 @@ describe("privacy-safe discovery map markers", () => {
           locality: null,
           locationLabelPublic: null,
           name: "Hidden Location",
-          parts: ["bass"],
+          parts: ["SATB:Bass"],
           region: null,
         },
       ]),

--- a/test/quartet-listing-form.test.ts
+++ b/test/quartet-listing-form.test.ts
@@ -25,9 +25,10 @@ describe("quartet listing form parsing", () => {
         ["region", "Ontario"],
         ["locality", "Toronto"],
         ["postalCodePrivate", "M5V"],
-        ["partsCovered", "lead"],
-        ["partsCovered", "bass"],
-        ["partsNeeded", "tenor"],
+        ["voicing", "TTBB"],
+        ["partsCovered", "TTBB:Lead"],
+        ["partsCovered", "TTBB:Bass"],
+        ["partsNeeded", "TTBB:Tenor"],
         ["goals", "regular_rehearsal"],
         ["travelRadiusKm", "75"],
       ]),
@@ -35,8 +36,11 @@ describe("quartet listing form parsing", () => {
 
     expect(values.countryCode).toBe("CA");
     expect(values.postalCodePrivate).toBe("M5V");
-    expect(values.partsCovered).toEqual(["lead", "bass"]);
-    expect(values.partsNeeded).toEqual(["tenor"]);
+    expect(values.partsCovered).toEqual([
+      { part: "Lead", voicing: "TTBB" },
+      { part: "Bass", voicing: "TTBB" },
+    ]);
+    expect(values.partsNeeded).toEqual([{ part: "Tenor", voicing: "TTBB" }]);
     expect(values.goals).toEqual(["regular_rehearsal"]);
     expect(values.travelRadiusKm).toBe(75);
   });
@@ -45,30 +49,39 @@ describe("quartet listing form parsing", () => {
     const values = parseQuartetListingFormData(
       formData([
         ["name", "Chord Project"],
-        ["partsCovered", "lead"],
-        ["partsCovered", "bass"],
-        ["partsNeeded", "lead"],
-        ["partsNeeded", "baritone"],
+        ["voicing", "SATB"],
+        ["partsCovered", "SATB:Alto"],
+        ["partsCovered", "SATB:Bass"],
+        ["partsNeeded", "SATB:Alto"],
+        ["partsNeeded", "SATB:Tenor"],
       ]),
     );
 
-    expect(values.partsCovered).toEqual(["bass"]);
-    expect(values.partsNeeded).toEqual(["lead", "baritone"]);
+    expect(values.partsCovered).toEqual([{ part: "Bass", voicing: "SATB" }]);
+    expect(values.partsNeeded).toEqual([
+      { part: "Alto", voicing: "SATB" },
+      { part: "Tenor", voicing: "SATB" },
+    ]);
   });
 
   it("preserves every valid needed part for an incomplete quartet", () => {
     const values = parseQuartetListingFormData(
       formData([
         ["name", "Festival Pickup Quartet"],
-        ["partsCovered", "lead"],
-        ["partsNeeded", "tenor"],
-        ["partsNeeded", "baritone"],
-        ["partsNeeded", "bass"],
+        ["voicing", "SSAA"],
+        ["partsCovered", "SSAA:Alto 1"],
+        ["partsNeeded", "SSAA:Soprano 1"],
+        ["partsNeeded", "SSAA:Soprano 2"],
+        ["partsNeeded", "SSAA:Alto 2"],
       ]),
     );
 
-    expect(values.partsCovered).toEqual(["lead"]);
-    expect(values.partsNeeded).toEqual(["tenor", "baritone", "bass"]);
+    expect(values.partsCovered).toEqual([{ part: "Alto 1", voicing: "SSAA" }]);
+    expect(values.partsNeeded).toEqual([
+      { part: "Soprano 1", voicing: "SSAA" },
+      { part: "Soprano 2", voicing: "SSAA" },
+      { part: "Alto 2", voicing: "SSAA" },
+    ]);
   });
 
   it("builds an approximate public location without postal code", () => {

--- a/test/singer-profile-form.test.ts
+++ b/test/singer-profile-form.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  BARBERSHOP_PARTS,
   buildPublicLocationLabel,
   inferLocationPrecision,
   parseSingerProfileFormData,
 } from "@/lib/profiles/singer-profile-form";
+import { partsByVoicing, satbDisplayLabels } from "@/lib/parts/voicings";
 
 function formData(entries: Array<[string, string]>) {
   const data = new FormData();
@@ -18,9 +18,16 @@ function formData(entries: Array<[string, string]>) {
 
 describe("singer profile form parsing", () => {
   it("keeps barbershop part constants explicit and does not rename Lead", () => {
-    expect(BARBERSHOP_PARTS).toEqual(["tenor", "lead", "baritone", "bass"]);
-    expect(BARBERSHOP_PARTS).toContain("lead");
-    expect(BARBERSHOP_PARTS).not.toContain("melody");
+    expect(partsByVoicing.TTBB).toEqual(["Tenor", "Lead", "Baritone", "Bass"]);
+    expect(partsByVoicing.TTBB).toContain("Lead");
+    expect(partsByVoicing.TTBB).not.toContain("Melody");
+    expect(partsByVoicing.SSAA).toEqual([
+      "Soprano 1",
+      "Soprano 2",
+      "Alto 1",
+      "Alto 2",
+    ]);
+    expect(satbDisplayLabels.Soprano).toBe("Soprano / Mixed Tenor");
   });
 
   it("accepts globally tolerant location fields without US-only requirements", () => {
@@ -32,8 +39,8 @@ describe("singer profile form parsing", () => {
         ["region", "Greater Manchester"],
         ["locality", "Manchester"],
         ["postalCodePrivate", "M1 1AE"],
-        ["parts", "lead"],
-        ["parts", "bass"],
+        ["parts", "TTBB:Lead"],
+        ["parts", "SATB:Soprano"],
         ["goals", "pickup"],
         ["travelRadiusKm", "40"],
       ]),
@@ -41,7 +48,10 @@ describe("singer profile form parsing", () => {
 
     expect(values.countryCode).toBe("GB");
     expect(values.postalCodePrivate).toBe("M1 1AE");
-    expect(values.parts).toEqual(["lead", "bass"]);
+    expect(values.parts).toEqual([
+      { part: "Lead", voicing: "TTBB" },
+      { part: "Soprano", voicing: "SATB" },
+    ]);
     expect(values.goals).toEqual(["pickup"]);
     expect(values.travelRadiusKm).toBe(40);
   });
@@ -51,7 +61,7 @@ describe("singer profile form parsing", () => {
       formData([
         ["displayName", "Jordan"],
         ["countryCode", "usa"],
-        ["parts", "lead"],
+        ["parts", "TTBB:Lead"],
         ["parts", "melody"],
         ["goals", "contest"],
         ["goals", "viral_video"],
@@ -59,7 +69,7 @@ describe("singer profile form parsing", () => {
     );
 
     expect(values.countryCode).toBeNull();
-    expect(values.parts).toEqual(["lead"]);
+    expect(values.parts).toEqual([{ part: "Lead", voicing: "TTBB" }]);
     expect(values.goals).toEqual(["contest"]);
   });
 

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -68,4 +68,22 @@ describe("initial Supabase schema migration", () => {
       privateFieldPattern,
     );
   });
+
+  it("stores and exposes parts with explicit voicing context", () => {
+    expect(migration).toContain(
+      "add column voicing text not null default 'TTBB'",
+    );
+    expect(migration).toContain(
+      "add constraint singer_profile_parts_voicing_part_check",
+    );
+    expect(migration).toContain(
+      "add constraint quartet_listing_parts_voicing_part_check",
+    );
+    expect(migration).toContain(
+      "singer_profile_parts.voicing || ':' || singer_profile_parts.part",
+    );
+    expect(migration).toContain(
+      "quartet_listing_parts.voicing || ':' || quartet_listing_parts.part",
+    );
+  });
 });

--- a/test/voicings.test.ts
+++ b/test/voicings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupVoicingParts,
+  parseVoicingPartValue,
+  partLabel,
+  partsByVoicing,
+  satbDisplayLabels,
+} from "@/lib/parts/voicings";
+
+describe("voicing-aware parts", () => {
+  it("keeps canonical part labels distinct by voicing", () => {
+    expect(partsByVoicing.TTBB).toEqual(["Tenor", "Lead", "Baritone", "Bass"]);
+    expect(partsByVoicing.SATB).toEqual(["Soprano", "Alto", "Tenor", "Bass"]);
+    expect(partsByVoicing.SSAA).toEqual([
+      "Soprano 1",
+      "Soprano 2",
+      "Alto 1",
+      "Alto 2",
+    ]);
+  });
+
+  it("accepts only valid part and voicing combinations", () => {
+    expect(parseVoicingPartValue("TTBB:Tenor")).toEqual({
+      part: "Tenor",
+      voicing: "TTBB",
+    });
+    expect(parseVoicingPartValue("SATB:Tenor")).toEqual({
+      part: "Tenor",
+      voicing: "SATB",
+    });
+    expect(parseVoicingPartValue("SATB:Lead")).toBeNull();
+    expect(parseVoicingPartValue("SSAA:Lead")).toBeNull();
+  });
+
+  it("shows SATB mixed equivalents without changing stored parts", () => {
+    expect(satbDisplayLabels.Soprano).toBe("Soprano / Mixed Tenor");
+    expect(partLabel("SATB", "Alto")).toBe("Alto / Mixed Lead");
+    expect(partLabel("TTBB", "Lead")).toBe("Lead");
+  });
+
+  it("groups stored values by voicing for discovery display", () => {
+    expect(
+      groupVoicingParts(["TTBB:Lead", "SATB:Soprano", "SSAA:Alto 2"]),
+    ).toBe("TTBB: Lead; SSAA: Alto 2; SATB / mixed: Soprano / Mixed Tenor");
+  });
+});


### PR DESCRIPTION
Closes #67.

## Summary
- add TTBB, SSAA, and SATB canonical voicing/part helpers with SATB mixed-barbershop labels
- update singer profile, Quartet Mode, and discovery filters/results to store and display voicing-aware parts
- add Supabase migration for voicing-aware part storage and discovery view arrays
- update help/home/privacy/smoke-test/Supabase docs and tests

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build

## Deployment notes
- Includes a Supabase migration; the production deploy workflow should apply it before Vercel deploy.