### PR TITLE
Simplify location and distance UX

### DIFF
--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -4,14 +4,16 @@ import {
   PROFILE_GOALS,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
-import { locationFieldLabelsForCountry } from "@/lib/location/country-location-defaults";
+import {
+  countryOptions,
+  kilometersToRoundedMiles,
+} from "@/lib/location/country-location-defaults";
 import { type Voicing } from "@/lib/parts/voicings";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { saveQuartetListing } from "./actions";
 
 type QuartetListingRow = {
   availability: string | null;
-  country_code: string | null;
   country_name: string | null;
   description: string | null;
   experience_level: string | null;
@@ -19,10 +21,8 @@ type QuartetListingRow = {
   id: string;
   is_visible: boolean;
   locality: string | null;
-  location_label_public: string | null;
   name: string;
   postal_code_private: string | null;
-  region: string | null;
   travel_radius_km: number | null;
 };
 
@@ -64,7 +64,7 @@ export default async function ManageListingsPage({
       ? await supabase
           .from("quartet_listings")
           .select(
-            "id, availability, country_code, country_name, description, experience_level, goals, is_visible, locality, location_label_public, name, postal_code_private, region, travel_radius_km",
+            "id, availability, country_name, description, experience_level, goals, is_visible, locality, name, postal_code_private, travel_radius_km",
           )
           .eq("owner_user_id", user.id)
           .order("created_at", { ascending: true })
@@ -90,10 +90,7 @@ export default async function ManageListingsPage({
     parts
       ?.filter((partRow) => partRow.status === "needed")
       .map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
-  const locationLabels = locationFieldLabelsForCountry(
-    listing?.country_code,
-    listing?.country_name,
-  );
+  const selectedCountry = listing?.country_name ?? "United States";
 
   return (
     <div>
@@ -198,40 +195,35 @@ export default async function ManageListingsPage({
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Location</h2>
           <p className="text-sm leading-6 text-[#394548]">
-            Start with country so the app can use sensible wording and distance
-            defaults. Public discovery shows your approximate label or
-            city/region/country area. Postal code stays private for future
-            matching; exact addresses and coordinates are not shown.
+            Used only to place this listing approximately on the map and support
+            location-based search. ZIP/postal code is not shown publicly, and
+            discovery shows an approximate area, not an exact address.
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Country name
+                Country
               </span>
-              <input
+              <select
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(listing?.country_name)}
-                maxLength={120}
+                defaultValue={selectedCountry}
                 name="countryName"
-                placeholder="Canada"
-              />
+              >
+                {countryOptions.map((country) => (
+                  <option key={country.name} value={country.name}>
+                    {country.name}
+                  </option>
+                ))}
+                {selectedCountry &&
+                !countryOptions.some(
+                  (country) => country.name === selectedCountry,
+                ) ? (
+                  <option value={selectedCountry}>{selectedCountry}</option>
+                ) : null}
+              </select>
             </label>
             <label className="block">
-              <span className="text-sm font-semibold text-[#172023]">
-                Country code
-              </span>
-              <input
-                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base uppercase text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(listing?.country_code)}
-                maxLength={2}
-                name="countryCode"
-                placeholder="CA"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-semibold text-[#172023]">
-                {locationLabels.locality}
-              </span>
+              <span className="text-sm font-semibold text-[#172023]">City</span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
                 defaultValue={fieldValue(listing?.locality)}
@@ -241,43 +233,19 @@ export default async function ManageListingsPage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                {locationLabels.region}
+                ZIP/postal code
               </span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(listing?.region)}
-                maxLength={120}
-                name="region"
+                defaultValue={fieldValue(listing?.postal_code_private)}
+                maxLength={40}
+                name="postalCodePrivate"
               />
+              <span className="mt-2 block text-sm leading-6 text-[#596466]">
+                ZIP/postal code is not shown publicly.
+              </span>
             </label>
           </div>
-          <label className="block">
-            <span className="text-sm font-semibold text-[#172023]">
-              Public approximate location
-            </span>
-            <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-              defaultValue={fieldValue(listing?.location_label_public)}
-              maxLength={160}
-              name="locationLabelPublic"
-              placeholder="Toronto, ON area"
-            />
-            <span className="mt-2 block text-sm leading-6 text-[#596466]">
-              This is the public label people see. Leave it blank to use
-              city/region/country as an approximate area.
-            </span>
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold text-[#172023]">
-              Private {locationLabels.postalCode.toLowerCase()}
-            </span>
-            <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-              defaultValue={fieldValue(listing?.postal_code_private)}
-              maxLength={40}
-              name="postalCodePrivate"
-            />
-          </label>
         </section>
 
         <section className="space-y-4">
@@ -312,13 +280,15 @@ export default async function ManageListingsPage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Travel willingness in km
+                Travel willingness in miles
               </span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(listing?.travel_radius_km)}
+                defaultValue={kilometersToRoundedMiles(
+                  listing?.travel_radius_km,
+                )}
                 min={0}
-                name="travelRadiusKm"
+                name="travelRadiusMiles"
                 type="number"
               />
             </label>

--- a/app/(protected)/app/onboarding/actions.ts
+++ b/app/(protected)/app/onboarding/actions.ts
@@ -13,7 +13,10 @@ import {
   ensureAccountProfileForOnboarding,
   type AuthUserForOnboarding,
 } from "@/lib/onboarding/account-onboarding";
-import { distanceUnitForCountry } from "@/lib/location/country-location-defaults";
+import {
+  countryCodeFromName,
+  distanceUnitForCountry,
+} from "@/lib/location/country-location-defaults";
 import {
   buildPublicLocationLabel,
   inferLocationPrecision,
@@ -58,15 +61,18 @@ export async function completeOnboarding(formData: FormData) {
     email: user.email,
     id: user.id,
   };
+  const countryName = normalizeOptionalText(formData.get("countryName"));
   const starterProfile = {
-    countryCode: normalizeCountryCode(formData.get("countryCode")),
-    countryName: normalizeOptionalText(formData.get("countryName")),
+    countryCode:
+      normalizeCountryCode(formData.get("countryCode")) ??
+      countryCodeFromName(countryName),
+    countryName,
     displayName,
     locality: normalizeOptionalText(formData.get("locality")),
     locationLabelPublic: normalizeOptionalText(
       formData.get("locationLabelPublic"),
     ),
-    postalCodePrivate: null,
+    postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
     region: null,
   };
 
@@ -96,6 +102,7 @@ export async function completeOnboarding(formData: FormData) {
       locality: starterProfile.locality,
       location_label_public: buildPublicLocationLabel(starterProfile),
       location_precision: inferLocationPrecision(starterProfile),
+      postal_code_private: starterProfile.postalCodePrivate,
       preferred_distance_unit: distanceUnitForCountry(
         starterProfile.countryCode,
         starterProfile.countryName,

--- a/app/(protected)/app/onboarding/page.tsx
+++ b/app/(protected)/app/onboarding/page.tsx
@@ -6,7 +6,7 @@ import {
   getOnboardingStatus,
   onboardingIsDone,
 } from "@/lib/onboarding/account-onboarding";
-import { locationFieldLabelsForCountry } from "@/lib/location/country-location-defaults";
+import { countryOptions } from "@/lib/location/country-location-defaults";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type OnboardingPageProps = {
@@ -20,11 +20,10 @@ type AccountProfileStarterRow = {
 };
 
 type SingerProfileStarterRow = {
-  country_code: string | null;
   country_name: string | null;
   display_name: string;
   locality: string | null;
-  location_label_public: string | null;
+  postal_code_private: string | null;
 };
 
 export default async function OnboardingPage({
@@ -64,16 +63,11 @@ export default async function OnboardingPage({
 
   const { data: singerProfile } = await supabase
     .from("singer_profiles")
-    .select(
-      "display_name, country_code, country_name, locality, location_label_public",
-    )
+    .select("display_name, country_name, locality, postal_code_private")
     .eq("user_id", user.id)
     .maybeSingle<SingerProfileStarterRow>();
 
-  const locationLabels = locationFieldLabelsForCountry(
-    singerProfile?.country_code,
-    singerProfile?.country_name,
-  );
+  const selectedCountry = singerProfile?.country_name ?? "United States";
 
   return (
     <div className="space-y-8">
@@ -141,33 +135,30 @@ export default async function OnboardingPage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Country name
+                Country
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
-              <input
+              <select
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={singerProfile?.country_name ?? ""}
-                maxLength={120}
+                defaultValue={selectedCountry}
                 name="countryName"
-                placeholder="Canada"
-              />
+              >
+                {countryOptions.map((country) => (
+                  <option key={country.name} value={country.name}>
+                    {country.name}
+                  </option>
+                ))}
+                {selectedCountry &&
+                !countryOptions.some(
+                  (country) => country.name === selectedCountry,
+                ) ? (
+                  <option value={selectedCountry}>{selectedCountry}</option>
+                ) : null}
+              </select>
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Country code
-                <span className="font-normal text-[#596466]"> Optional</span>
-              </span>
-              <input
-                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base uppercase text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={singerProfile?.country_code ?? ""}
-                maxLength={2}
-                name="countryCode"
-                placeholder="CA"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-semibold text-[#172023]">
-                {locationLabels.locality}
+                City
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
@@ -179,16 +170,19 @@ export default async function OnboardingPage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Public approximate location
+                ZIP/postal code
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={singerProfile?.location_label_public ?? ""}
-                maxLength={160}
-                name="locationLabelPublic"
-                placeholder="Toronto, ON area"
+                defaultValue={singerProfile?.postal_code_private ?? ""}
+                maxLength={40}
+                name="postalCodePrivate"
               />
+              <span className="mt-2 block text-sm leading-6 text-[#596466]">
+                Your ZIP/postal code is used for future approximate matching and
+                is not shown publicly.
+              </span>
             </label>
           </div>
         </section>

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -4,7 +4,10 @@ import {
   PROFILE_GOALS,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
-import { locationFieldLabelsForCountry } from "@/lib/location/country-location-defaults";
+import {
+  countryOptions,
+  kilometersToRoundedMiles,
+} from "@/lib/location/country-location-defaults";
 import {
   VOICINGS,
   partsByVoicing,
@@ -18,7 +21,6 @@ import { saveSingerProfile } from "./actions";
 type SingerProfileRow = {
   availability: string | null;
   bio: string | null;
-  country_code: string | null;
   country_name: string | null;
   display_name: string;
   experience_level: string | null;
@@ -26,9 +28,7 @@ type SingerProfileRow = {
   id: string;
   is_visible: boolean;
   locality: string | null;
-  location_label_public: string | null;
   postal_code_private: string | null;
-  region: string | null;
   travel_radius_km: number | null;
 };
 
@@ -78,7 +78,7 @@ export default async function ManageProfilePage({
       ? await supabase
           .from("singer_profiles")
           .select(
-            "id, availability, bio, country_code, country_name, display_name, experience_level, goals, is_visible, locality, location_label_public, postal_code_private, region, travel_radius_km",
+            "id, availability, bio, country_name, display_name, experience_level, goals, is_visible, locality, postal_code_private, travel_radius_km",
           )
           .eq("user_id", user.id)
           .maybeSingle<SingerProfileRow>()
@@ -94,10 +94,7 @@ export default async function ManageProfilePage({
 
   const selectedParts =
     parts?.map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
-  const locationLabels = locationFieldLabelsForCountry(
-    profile?.country_code,
-    profile?.country_name,
-  );
+  const selectedCountry = profile?.country_name ?? "United States";
 
   return (
     <div>
@@ -253,41 +250,38 @@ export default async function ManageProfilePage({
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Location</h2>
           <p className="text-sm leading-6 text-[#394548]">
-            Start with country so the app can use sensible wording and distance
-            defaults. Public discovery shows your approximate label or
-            city/region/country area. Postal code stays private for future
-            matching; exact addresses and coordinates are not shown.
+            Used only to place you approximately on the map and support
+            location-based search. Your ZIP/postal code is not shown publicly,
+            and public discovery shows an approximate area, not your exact
+            location.
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Country name
+                Country
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
-              <input
+              <select
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(profile?.country_name)}
-                maxLength={120}
+                defaultValue={selectedCountry}
                 name="countryName"
-                placeholder="United Kingdom"
-              />
+              >
+                {countryOptions.map((country) => (
+                  <option key={country.name} value={country.name}>
+                    {country.name}
+                  </option>
+                ))}
+                {selectedCountry &&
+                !countryOptions.some(
+                  (country) => country.name === selectedCountry,
+                ) ? (
+                  <option value={selectedCountry}>{selectedCountry}</option>
+                ) : null}
+              </select>
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Country code
-                <span className="font-normal text-[#596466]"> Optional</span>
-              </span>
-              <input
-                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base uppercase text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(profile?.country_code)}
-                maxLength={2}
-                name="countryCode"
-                placeholder="GB"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-semibold text-[#172023]">
-                {locationLabels.locality}
+                City
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
@@ -299,46 +293,20 @@ export default async function ManageProfilePage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                {locationLabels.region}
+                ZIP/postal code
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(profile?.region)}
-                maxLength={120}
-                name="region"
+                defaultValue={fieldValue(profile?.postal_code_private)}
+                maxLength={40}
+                name="postalCodePrivate"
               />
+              <FieldNote>
+                Your ZIP/postal code is never shown publicly.
+              </FieldNote>
             </label>
           </div>
-          <label className="block">
-            <span className="text-sm font-semibold text-[#172023]">
-              Public approximate location
-              <span className="font-normal text-[#596466]"> Optional</span>
-            </span>
-            <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-              defaultValue={fieldValue(profile?.location_label_public)}
-              maxLength={160}
-              name="locationLabelPublic"
-              placeholder="Manchester, UK area"
-            />
-            <FieldNote>
-              This is the public label people see. Leave it blank to use
-              city/region/country as an approximate area.
-            </FieldNote>
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold text-[#172023]">
-              Private {locationLabels.postalCode.toLowerCase()}
-              <span className="font-normal text-[#596466]"> Optional</span>
-            </span>
-            <input
-              className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-              defaultValue={fieldValue(profile?.postal_code_private)}
-              maxLength={40}
-              name="postalCodePrivate"
-            />
-          </label>
         </section>
 
         <section className="space-y-4">
@@ -386,15 +354,17 @@ export default async function ManageProfilePage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                Travel willingness in km
+                Travel willingness in miles
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
                 aria-describedby="travel-radius-help"
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
-                defaultValue={fieldValue(profile?.travel_radius_km)}
+                defaultValue={kilometersToRoundedMiles(
+                  profile?.travel_radius_km,
+                )}
                 min={0}
-                name="travelRadiusKm"
+                name="travelRadiusMiles"
                 type="number"
               />
               <FieldNote id="travel-radius-help">

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -5,7 +5,10 @@ import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
 } from "@/lib/location/map-markers";
-import { approximateLocationLabel } from "@/lib/location/approximate-location";
+import {
+  approximateLocationLabel,
+  travelRadiusLabel,
+} from "@/lib/location/approximate-location";
 import {
   groupVoicingParts,
   voicingPartOptions,
@@ -24,6 +27,7 @@ type SingerFindRow = {
   location_label_public: string | null;
   parts: string[];
   region: string | null;
+  travel_radius_km: number | null;
 };
 
 type QuartetFindRow = {
@@ -36,6 +40,7 @@ type QuartetFindRow = {
   name: string;
   parts_needed: string[];
   region: string | null;
+  travel_radius_km: number | null;
 };
 
 type FindPageProps = {
@@ -45,6 +50,7 @@ type FindPageProps = {
 type FindResult = DiscoveryMapItem & {
   detailHref: string;
   intentLabel: string;
+  travelRadiusKm: number | null;
 };
 
 const kindOptions = [
@@ -63,6 +69,11 @@ const goalOptions = [
   ["contest", "Contest"],
   ["paid_gigs", "Paid gigs"],
   ["learning", "Learning"],
+];
+
+const distanceUnitOptions = [
+  ["mi", "Miles"],
+  ["km", "Kilometers"],
 ];
 
 const filterControlClass =
@@ -143,7 +154,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
       let query = supabase
         .from("singer_discovery_profiles")
         .select(
-          "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public",
+          "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
         )
         .order("updated_at", { ascending: false });
 
@@ -188,6 +199,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             name: singer.display_name,
             parts: singer.parts,
             region: singer.region,
+            travelRadiusKm: singer.travel_radius_km,
           })),
         ];
       }
@@ -197,7 +209,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
       let query = supabase
         .from("quartet_discovery_listings")
         .select(
-          "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public",
+          "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
         )
         .order("updated_at", { ascending: false });
 
@@ -242,6 +254,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             name: quartet.name,
             parts: quartet.parts_needed,
             region: quartet.region,
+            travelRadiusKm: quartet.travel_radius_km,
           })),
         ];
       }
@@ -355,7 +368,21 @@ export default async function FindPage({ searchParams }: FindPageProps) {
               ))}
             </select>
           </label>
-          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-4">
+          <label className="block">
+            <span className="text-sm font-semibold">Distance units</span>
+            <select
+              className={filterControlClass}
+              defaultValue={filters.distanceUnit}
+              name="distanceUnit"
+            >
+              {distanceUnitOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-3">
             <button
               className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
               type="submit"
@@ -451,6 +478,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                     <th className="px-4 py-3 font-bold">Type</th>
                     <th className="px-4 py-3 font-bold">Parts</th>
                     <th className="px-4 py-3 font-bold">Approximate area</th>
+                    <th className="px-4 py-3 font-bold">Travel</th>
                     <th className="px-4 py-3 font-bold">Next step</th>
                   </tr>
                 </thead>
@@ -471,6 +499,12 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                       </td>
                       <td className="px-4 py-3 text-[#394548]">
                         {locationLabel(result)}
+                      </td>
+                      <td className="px-4 py-3 text-[#394548]">
+                        {travelRadiusLabel(
+                          result.travelRadiusKm,
+                          filters.distanceUnit,
+                        ) ?? "Not listed"}
                       </td>
                       <td className="px-4 py-3">
                         <Link

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -25,11 +25,11 @@ Public search results must not show:
 - inactive or hidden profiles/listings
 
 Public singer and quartet discovery pages must query privacy-safe discovery
-views rather than private base tables. Filters may use public country, region,
-locality, voicing-aware part, goal, experience/commitment, availability, and travel
-willingness fields where data exists. Exact coordinates, private postal codes,
-formatted private addresses, email addresses, and phone numbers are not part of
-the public result shape.
+views rather than private base tables. Filters may use public country, city,
+region when available, voicing-aware part, goal, experience/commitment,
+availability, and travel willingness fields where data exists. Exact
+coordinates, private postal codes, formatted private addresses, email addresses,
+and phone numbers are not part of the public result shape.
 
 ## Global location expectations
 
@@ -50,29 +50,30 @@ The MVP can be English-only, but location and distance handling should be global
 
 ## Location handling
 
-Users may enter a city, postal code, country, or approximate location.
+Users enter a country, city, and ZIP/postal code where useful. Forms avoid
+country-code and admin-area language.
 
 The app may store normalized location data to support distance search, but public UI should only expose approximate location.
 
 Private geocoded data should be transformed into a public location summary
-before display. Public summaries may contain only a user-provided public label,
-locality, region, and country. They must not contain exact latitude, longitude,
-private postal code, formatted private address, or other precise address
-components. If an explicit public label is present, use it as the display label;
-otherwise build an approximate label from locality, region, and country, such as
-“Dublin, Leinster, Ireland area.”
+before display. Public summaries may contain only locality/city, region when
+available, and country. They must not contain exact latitude, longitude, private
+postal code, formatted private address, or other precise address components.
+Until automatic geocoding is added, country plus city and ZIP/postal code are
+enough for the current approximate map/search approach because the map uses
+country/region anchors and public city/country labels rather than exact pins.
 
-Distance helpers may use exact coordinates internally for matching, but public
-distance display should be rounded and approximate, such as “about 15 mi / 24 km
-away.” Travel willingness and distance display should support both kilometers
-and miles without assuming a US-only default.
+Distance helpers may use exact coordinates internally for matching later, but
+public distance display should be rounded and approximate. Find defaults
+distance display to miles and offers a miles/kilometers picker. Profile and
+listing forms do not ask users to choose a unit.
 
 Acceptable user-facing examples:
 
 - “Fort Collins, CO area”
 - “Toronto, ON area”
 - “Manchester, UK area”
-- “about 15 miles / 24 km away”
+- “about 15 mi / 24 km away”
 - “Northern Colorado”
 
 Avoid exact map pins. Map interfaces should use one of the following:
@@ -107,16 +108,15 @@ The MVP profile form stores:
 - goals
 - descriptive experience level
 - availability
-- travel willingness in kilometers
+- travel willingness, entered in miles and stored internally as kilometers
 - short bio
-- public approximate location label
-- country, region, locality, and private postal code when provided
+- country, city/locality, and private ZIP/postal code when provided
 - search visibility
 
 The postal code field is stored for future matching/search work and should not
 be shown in public discovery results. The public discovery label should stay
-approximate, such as a city/region/country area. Location inputs remain globally
-tolerant and do not require US state, ZIP code, address, or phone formats.
+approximate, such as a city/country area. Location inputs remain globally
+tolerant and do not require US state, exact address, or phone formats.
 
 ## Quartet listing management
 
@@ -130,10 +130,9 @@ MVP listing form stores:
 - goals
 - experience or commitment level
 - rehearsal expectations
-- travel willingness in kilometers
+- travel willingness, entered in miles and stored internally as kilometers
 - short description
-- public approximate location label
-- country, region, locality, and private postal code when provided
+- country, city/locality, and private ZIP/postal code when provided
 - search visibility
 
 The listing form keeps covered and needed parts distinct and tied to the
@@ -217,7 +216,7 @@ information.
 ## Onboarding model
 
 First-run onboarding first asks signed-in users for basic profile context:
-display name, country, and approximate location. It then asks what they want to
+display name, country, city, and ZIP/postal code. It then asks what they want to
 do first, not what role they permanently are. A user may use the app as a singer
 and in Quartet Mode.
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -72,8 +72,8 @@ validation.
 ## First-Run Onboarding
 
 1. Sign in with a test account that has not completed onboarding.
-2. Pass: onboarding first asks for display name and optional country or
-   approximate location before asking what to do first.
+2. Pass: onboarding first asks for display name plus optional country, city, and
+   ZIP/postal code before asking what to do first.
 3. Pass: display name is clearly required and the location fields are clearly
    optional.
 4. Pass: workflow options are plain language and do not imply a permanent role.
@@ -90,11 +90,9 @@ validation.
    - parts: TTBB Lead and SATB Soprano / Mixed Tenor
    - goals: Pickup and Learning
    - country: United Kingdom
-   - region: England
-   - locality: Manchester
-   - private postal code: `M1 TEST`
-   - public location label: `Manchester, UK area`
-   - travel radius: `40`
+   - city: Manchester
+   - ZIP/postal code: `M1 TEST`
+   - travel radius: `25` miles
    - visible: on
 3. Pass: saving succeeds and the form reloads with the saved values.
 4. Pass: `/singers?country=United+Kingdom&locality=Manchester&part=TTBB%3ALead`
@@ -116,11 +114,9 @@ validation.
    - needed parts: TTBB Lead and Baritone
    - goals: Regular Rehearsal and Contest
    - country: Ireland
-   - region: Leinster
-   - locality: Dublin
-   - private postal code: `D02 TEST`
-   - public location label: `Dublin, Ireland area`
-   - travel radius: `50`
+   - city: Dublin
+   - ZIP/postal code: `D02 TEST`
+   - travel radius: `30` miles
    - visible: on
 3. Pass: saving succeeds and covered/needed parts remain distinct.
 4. Pass: `/quartets?country=Ireland&locality=Dublin&part=TTBB%3ALead` includes
@@ -138,12 +134,14 @@ validation.
 1. Open `/find`.
 2. Filter by country, region/locality, part, goal, and looking-for mode using
    data known to exist in the environment.
-3. Pass: valid filters narrow the consolidated results without crashing.
-4. Pass: the approximate map appears above the results table.
-5. Pass: the table distinguishes singer profiles from quartet openings.
-6. Pass: empty results show helpful next actions, including clearing filters.
-7. Fail: hidden or inactive profiles/listings appear in public results.
-8. Fail: public UI exposes owner user IDs, private postal codes, exact
+3. Pass: the distance-unit picker defaults to Miles and can be changed to
+   Kilometers for travel-radius display.
+4. Pass: valid filters narrow the consolidated results without crashing.
+5. Pass: the approximate map appears above the results table.
+6. Pass: the table distinguishes singer profiles from quartet openings.
+7. Pass: empty results show helpful next actions, including clearing filters.
+8. Fail: hidden or inactive profiles/listings appear in public results.
+9. Fail: public UI exposes owner user IDs, private postal codes, exact
    coordinates, email addresses, or phone numbers.
 
 ## Detailed Quartet Opening Search

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -83,8 +83,8 @@ First-run onboarding writes these `account_profiles` fields:
 The server creates the account profile row after sign-in when needed. If neither
 completion nor skipped state is present, sign-in routes the user through
 `/app/onboarding`. Current onboarding collects display name and optional
-country/approximate location before asking what workflow the user wants to open
-first. Completing onboarding also creates or updates a hidden starter
+country/city/ZIP or postal code before asking what workflow the user wants to
+open first. Completing onboarding also creates or updates a hidden starter
 `singer_profiles` row with that basic context so profile defaults are available
 without publishing the user in discovery.
 
@@ -177,7 +177,7 @@ public queries should expose only approximate location information.
 The schema should be globally tolerant. Do not require US-only fields such as state or ZIP code. Prefer fields that can support international location data, such as:
 
 - country code or country name
-- region/admin area when available
+- region/admin area when available internally or from future geocoding
 - locality/city when available
 - postal code when available
 - formatted approximate location label
@@ -189,15 +189,16 @@ Current pattern:
 - Store private normalized location fields in base tables.
 - Expose privacy-safe search fields through views or controlled RPC functions.
 - Return approximate distance/region rather than exact coordinates for public discovery.
-- Support both miles and kilometers in UI/helper logic where practical.
+- Support both miles and kilometers in Find display. Miles are the default
+  user-facing unit; stored travel radius values remain kilometers.
 
 Application location helpers should treat base-table coordinates and private
-postal/address fields as internal matching data. The reusable public
-transformation returns only `location_label_public`, `locality`, `region`, and
-`country_name` equivalents for display. Public distance strings are rounded and
-formatted in both kilometers and miles, ordered by the profile/listing
-preferred distance unit. Save actions infer that unit from country rather than
-asking for a separate account setting.
+postal/address fields as internal matching data. User-facing profile/listing
+forms ask for country, city, and ZIP/postal code; they do not expose country
+code or admin-area fields. The reusable public transformation returns only
+`location_label_public`, `locality`, `region`, and `country_name` equivalents
+for display. Find can display travel-radius values in miles or kilometers, with
+miles as the default, while storage remains in kilometers.
 
 Both singer profiles and quartet listings support these globally tolerant
 location fields:

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -64,7 +64,8 @@ export const publicHelpSections = [
   {
     body: [
       "Country is the first location cue because it helps the app use sensible labels, such as ZIP code, postcode, state, province, or region, without strict address validation.",
-      "Country also sets practical distance defaults for singer profiles and quartet listings. You can still keep public location approximate; private postal codes are not shown in discovery.",
+      "Profile and listing forms ask for country, city, and ZIP/postal code instead of country codes or admin-area fields. ZIP/postal codes are not shown in discovery.",
+      "Find defaults distance display to miles and lets you switch to kilometers when that is more useful.",
     ],
     heading: "Location Defaults",
   },
@@ -121,7 +122,7 @@ export const publicPrivacySections = [
   {
     body: [
       "Barbershop is global, and the app should be useful outside the United States and Canada. Location handling is approximate and globally tolerant by design.",
-      "The app should not require US-only fields like ZIP code or state to make basic discovery useful.",
+      "The app should not require US-only fields like state or exact street address to make basic discovery useful.",
     ],
     heading: "Global Use",
   },

--- a/lib/location/country-location-defaults.ts
+++ b/lib/location/country-location-defaults.ts
@@ -7,6 +7,7 @@ type LocationFieldLabels = {
 };
 
 const countryNameAliases: Record<string, string> = {
+  australia: "AU",
   britain: "GB",
   canada: "CA",
   england: "GB",
@@ -21,7 +22,27 @@ const countryNameAliases: Record<string, string> = {
   wales: "GB",
 };
 
-const mileCountries = new Set(["GB", "LR", "MM", "UK", "US"]);
+export const countryOptions = [
+  { code: "US", name: "United States" },
+  { code: "CA", name: "Canada" },
+  { code: "GB", name: "United Kingdom" },
+  { code: "IE", name: "Ireland" },
+  { code: "AU", name: "Australia" },
+  { code: "NZ", name: "New Zealand" },
+  { code: "DE", name: "Germany" },
+  { code: "NL", name: "Netherlands" },
+  { code: "SE", name: "Sweden" },
+  { code: "ZA", name: "South Africa" },
+  { code: "", name: "Other / not listed" },
+] as const;
+
+const countryCodesByName = Object.fromEntries(
+  countryOptions
+    .filter((country) => country.code)
+    .map((country) => [country.name.toLowerCase(), country.code]),
+);
+
+const mileCountries = new Set(["CA", "GB", "LR", "MM", "UK", "US"]);
 
 const labelOverrides: Record<string, LocationFieldLabels> = {
   AU: {
@@ -75,7 +96,9 @@ function normalizeCountryCodeValue(countryCode: string | null | undefined) {
 export function countryCodeFromName(countryName: string | null | undefined) {
   const normalized = countryName?.trim().toLowerCase();
 
-  return normalized ? (countryNameAliases[normalized] ?? null) : null;
+  return normalized
+    ? (countryCodesByName[normalized] ?? countryNameAliases[normalized] ?? null)
+    : null;
 }
 
 export function effectiveCountryCode(
@@ -93,7 +116,11 @@ export function distanceUnitForCountry(
 ): DistanceUnit {
   const effectiveCode = effectiveCountryCode(countryCode, countryName);
 
-  return effectiveCode && mileCountries.has(effectiveCode) ? "mi" : "km";
+  if (!effectiveCode) {
+    return "mi";
+  }
+
+  return mileCountries.has(effectiveCode) ? "mi" : "km";
 }
 
 export function locationFieldLabelsForCountry(
@@ -105,4 +132,18 @@ export function locationFieldLabelsForCountry(
   return effectiveCode && labelOverrides[effectiveCode]
     ? labelOverrides[effectiveCode]
     : defaultLocationFieldLabels;
+}
+
+export function kilometersToRoundedMiles(
+  kilometers: number | null | undefined,
+) {
+  if (kilometers == null) {
+    return "";
+  }
+
+  return String(Math.round(kilometers / 1.609344));
+}
+
+export function milesToRoundedKilometers(miles: number) {
+  return Math.round(miles * 1.609344);
 }

--- a/lib/profiles/singer-profile-form.ts
+++ b/lib/profiles/singer-profile-form.ts
@@ -2,6 +2,10 @@ import {
   parseVoicingPartValue,
   type VoicingPartSelection,
 } from "@/lib/parts/voicings";
+import {
+  countryCodeFromName,
+  milesToRoundedKilometers,
+} from "@/lib/location/country-location-defaults";
 
 export const PROFILE_GOALS = [
   "casual",
@@ -66,6 +70,22 @@ export function parseTravelRadiusKm(value: FormDataEntryValue | null) {
   return radius;
 }
 
+export function parseTravelRadiusMilesAsKm(value: FormDataEntryValue | null) {
+  const normalized = normalizeOptionalText(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const radius = Number(normalized);
+
+  if (!Number.isInteger(radius) || radius < 0 || radius > 10000) {
+    return null;
+  }
+
+  return milesToRoundedKilometers(radius);
+}
+
 export function parseAllowedList<T extends string>(
   values: FormDataEntryValue[],
   allowedValues: readonly T[],
@@ -88,6 +108,7 @@ export function parseSingerProfileFormData(
   formData: FormData,
 ): SingerProfileFormValues {
   const displayName = normalizeOptionalText(formData.get("displayName"));
+  const countryName = normalizeOptionalText(formData.get("countryName"));
 
   if (!displayName) {
     throw new Error("Display name is required.");
@@ -96,8 +117,10 @@ export function parseSingerProfileFormData(
   return {
     availability: normalizeOptionalText(formData.get("availability")),
     bio: normalizeOptionalText(formData.get("bio")),
-    countryCode: normalizeCountryCode(formData.get("countryCode")),
-    countryName: normalizeOptionalText(formData.get("countryName")),
+    countryCode:
+      normalizeCountryCode(formData.get("countryCode")) ??
+      countryCodeFromName(countryName),
+    countryName,
     displayName,
     experienceLevel: normalizeOptionalText(formData.get("experienceLevel")),
     goals: parseAllowedList(formData.getAll("goals"), PROFILE_GOALS),
@@ -109,7 +132,9 @@ export function parseSingerProfileFormData(
     parts: parseVoicingPartList(formData.getAll("parts")),
     postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
     region: normalizeOptionalText(formData.get("region")),
-    travelRadiusKm: parseTravelRadiusKm(formData.get("travelRadiusKm")),
+    travelRadiusKm: parseTravelRadiusMilesAsKm(
+      formData.get("travelRadiusMiles") ?? formData.get("travelRadiusKm"),
+    ),
   };
 }
 

--- a/lib/quartets/quartet-listing-form.ts
+++ b/lib/quartets/quartet-listing-form.ts
@@ -3,7 +3,7 @@ import {
   normalizeCountryCode,
   normalizeOptionalText,
   parseAllowedList,
-  parseTravelRadiusKm,
+  parseTravelRadiusMilesAsKm,
   parseVoicingPartList,
   type ProfileGoal,
 } from "@/lib/profiles/singer-profile-form";
@@ -12,6 +12,7 @@ import {
   type VoicingPartSelection,
   isVoicing,
 } from "@/lib/parts/voicings";
+import { countryCodeFromName } from "@/lib/location/country-location-defaults";
 
 export type QuartetListingFormValues = {
   availability: string | null;
@@ -54,6 +55,7 @@ export function parseQuartetListingFormData(
   formData: FormData,
 ): QuartetListingFormValues {
   const name = normalizeOptionalText(formData.get("name"));
+  const countryName = normalizeOptionalText(formData.get("countryName"));
 
   if (!name) {
     throw new Error("Listing name is required.");
@@ -72,8 +74,10 @@ export function parseQuartetListingFormData(
 
   return {
     availability: normalizeOptionalText(formData.get("availability")),
-    countryCode: normalizeCountryCode(formData.get("countryCode")),
-    countryName: normalizeOptionalText(formData.get("countryName")),
+    countryCode:
+      normalizeCountryCode(formData.get("countryCode")) ??
+      countryCodeFromName(countryName),
+    countryName,
     description: normalizeOptionalText(formData.get("description")),
     experienceLevel: normalizeOptionalText(formData.get("experienceLevel")),
     goals: parseAllowedList(formData.getAll("goals"), PROFILE_GOALS),
@@ -88,7 +92,9 @@ export function parseQuartetListingFormData(
     partsNeeded,
     postalCodePrivate: normalizeOptionalText(formData.get("postalCodePrivate")),
     region: normalizeOptionalText(formData.get("region")),
-    travelRadiusKm: parseTravelRadiusKm(formData.get("travelRadiusKm")),
+    travelRadiusKm: parseTravelRadiusMilesAsKm(
+      formData.get("travelRadiusMiles") ?? formData.get("travelRadiusKm"),
+    ),
     voicing,
   };
 }

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -6,10 +6,12 @@ import {
   parseVoicingPartValue,
   type VoicingPartSelection,
 } from "@/lib/parts/voicings";
+import type { DistanceUnit } from "@/lib/location/approximate-location";
 
 export type DiscoveryFilters = {
   availability: string | null;
   country: string | null;
+  distanceUnit: DistanceUnit;
   experience: string | null;
   goal: ProfileGoal | null;
   locality: string | null;
@@ -23,6 +25,10 @@ function normalizeSearchText(value: string | string[] | undefined) {
   const normalized = rawValue?.trim();
 
   return normalized ? normalized : null;
+}
+
+function parseDistanceUnit(value: string | string[] | undefined): DistanceUnit {
+  return normalizeSearchText(value) === "km" ? "km" : "mi";
 }
 
 function parseAllowedValue<T extends string>(
@@ -60,6 +66,7 @@ export function parseDiscoveryFilters(
   return {
     availability: normalizeSearchText(searchParams.availability),
     country: normalizeSearchText(searchParams.country),
+    distanceUnit: parseDistanceUnit(searchParams.distanceUnit),
     experience: normalizeSearchText(searchParams.experience),
     goal: parseAllowedValue(searchParams.goal, PROFILE_GOALS),
     locality: normalizeSearchText(searchParams.locality),
@@ -70,5 +77,7 @@ export function parseDiscoveryFilters(
 }
 
 export function hasDiscoveryFilters(filters: DiscoveryFilters) {
-  return Object.values(filters).some((value) => value !== null);
+  return Object.entries(filters).some(
+    ([key, value]) => key !== "distanceUnit" && value !== null,
+  );
 }

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -12,6 +12,7 @@ describe("discovery filters", () => {
       region: " Greater Manchester ",
       goal: "contest",
       part: "SATB:Soprano",
+      distanceUnit: "km",
       travelRadiusKm: "50",
     });
 
@@ -20,6 +21,7 @@ describe("discovery filters", () => {
     expect(filters.region).toBe("Greater Manchester");
     expect(filters.goal).toBe("contest");
     expect(filters.part).toEqual({ part: "Soprano", voicing: "SATB" });
+    expect(filters.distanceUnit).toBe("km");
     expect(filters.travelRadiusKm).toBe(50);
     expect(hasDiscoveryFilters(filters)).toBe(true);
   });
@@ -34,6 +36,7 @@ describe("discovery filters", () => {
     expect(filters.goal).toBeNull();
     expect(filters.part).toBeNull();
     expect(filters.travelRadiusKm).toBeNull();
+    expect(filters.distanceUnit).toBe("mi");
     expect(hasDiscoveryFilters(filters)).toBe(false);
   });
 
@@ -43,6 +46,7 @@ describe("discovery filters", () => {
       goal: ["pickup", "contest"],
       locality: ["Dublin", "Boston"],
       part: ["TTBB:Tenor", "melody"],
+      distanceUnit: ["km", "mi"],
       travelRadiusKm: ["10000", "25"],
     });
 
@@ -50,6 +54,7 @@ describe("discovery filters", () => {
     expect(filters.locality).toBe("Dublin");
     expect(filters.goal).toBe("pickup");
     expect(filters.part).toEqual({ part: "Tenor", voicing: "TTBB" });
+    expect(filters.distanceUnit).toBe("km");
     expect(filters.travelRadiusKm).toBe(10000);
   });
 

--- a/test/location-defaults.test.ts
+++ b/test/location-defaults.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  countryOptions,
   distanceUnitForCountry,
   effectiveCountryCode,
+  kilometersToRoundedMiles,
   locationFieldLabelsForCountry,
+  milesToRoundedKilometers,
 } from "@/lib/location/country-location-defaults";
 
 describe("country-aware location defaults", () => {
@@ -10,8 +13,21 @@ describe("country-aware location defaults", () => {
     expect(distanceUnitForCountry("US")).toBe("mi");
     expect(distanceUnitForCountry("gb")).toBe("mi");
     expect(distanceUnitForCountry(null, "United Kingdom")).toBe("mi");
-    expect(distanceUnitForCountry("CA")).toBe("km");
+    expect(distanceUnitForCountry("CA")).toBe("mi");
+    expect(distanceUnitForCountry(null, null)).toBe("mi");
     expect(distanceUnitForCountry(null, "Australia")).toBe("km");
+  });
+
+  it("keeps United States and Canada first in the country picklist", () => {
+    expect(countryOptions.slice(0, 2)).toEqual([
+      { code: "US", name: "United States" },
+      { code: "CA", name: "Canada" },
+    ]);
+  });
+
+  it("converts user-facing miles to internal kilometers", () => {
+    expect(milesToRoundedKilometers(50)).toBe(80);
+    expect(kilometersToRoundedMiles(80)).toBe("50");
   });
 
   it("adapts location field labels without strict address validation", () => {
@@ -34,6 +50,7 @@ describe("country-aware location defaults", () => {
   it("normalizes common country aliases", () => {
     expect(effectiveCountryCode("uk", null)).toBe("GB");
     expect(effectiveCountryCode(null, "USA")).toBe("US");
+    expect(effectiveCountryCode(null, "Canada")).toBe("CA");
     expect(effectiveCountryCode(null, "Ireland")).toBe("IE");
   });
 });

--- a/test/location-form-copy.test.ts
+++ b/test/location-form-copy.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const profilePage = readFileSync(
+  "app/(protected)/app/profile/page.tsx",
+  "utf8",
+);
+const listingPage = readFileSync(
+  "app/(protected)/app/listings/page.tsx",
+  "utf8",
+);
+const onboardingPage = readFileSync(
+  "app/(protected)/app/onboarding/page.tsx",
+  "utf8",
+);
+const findPage = readFileSync("app/find/page.tsx", "utf8");
+
+describe("location and distance form copy", () => {
+  it("uses simple country, city, and ZIP/postal code fields", () => {
+    for (const source of [profilePage, listingPage, onboardingPage]) {
+      expect(source).toContain("Country");
+      expect(source).toContain("City");
+      expect(source).toContain("ZIP/postal code");
+      expect(source).not.toContain("Country code");
+      expect(source).not.toContain("Region/admin");
+    }
+  });
+
+  it("keeps ZIP/postal code private and approximate", () => {
+    expect(profilePage).toContain("not shown publicly");
+    expect(listingPage).toContain("not shown publicly");
+    expect(onboardingPage).toContain("not shown publicly");
+    expect(profilePage).toContain("approximate area");
+    expect(listingPage).toContain("approximate area");
+  });
+
+  it("puts the miles/kilometers picker only on Find", () => {
+    expect(findPage).toContain("Distance units");
+    expect(findPage).toContain("Miles");
+    expect(profilePage).not.toContain("Distance units");
+    expect(listingPage).not.toContain("Distance units");
+    expect(onboardingPage).not.toContain("Distance units");
+  });
+});

--- a/test/onboarding-page-copy.test.ts
+++ b/test/onboarding-page-copy.test.ts
@@ -16,14 +16,16 @@ describe("onboarding page flow", () => {
       pageSource.indexOf("Step 2"),
     );
     expect(pageSource).toContain("Display name");
-    expect(pageSource).toContain("Country name");
-    expect(pageSource).toContain("Public approximate location");
+    expect(pageSource).toContain("Country");
+    expect(pageSource).toContain("ZIP/postal code");
+    expect(pageSource).not.toContain("Country code");
     expect(pageSource).toContain("Save and continue");
   });
 
   it("saves a hidden starter singer profile instead of publishing onboarding context", () => {
     expect(actionSource).toContain('.from("singer_profiles")');
     expect(actionSource).toContain("is_visible: false");
+    expect(actionSource).toContain("postal_code_private");
     expect(actionSource).toContain("Display%20name%20is%20required");
   });
 });

--- a/test/profile-guidance-copy.test.ts
+++ b/test/profile-guidance-copy.test.ts
@@ -21,7 +21,14 @@ describe("profile form guidance copy", () => {
     expect(profilePage).toContain("experienced chapter singer");
     expect(profilePage).toContain("weeknights or weekends");
     expect(profilePage).toContain("how far you would travel");
+    expect(profilePage).toContain("Travel willingness in miles");
     expect(profilePage).toContain("profile is not");
     expect(profilePage).toContain("ready for people to find");
+  });
+
+  it("uses simple location fields without exposing country code input", () => {
+    expect(profilePage).toContain("ZIP/postal code");
+    expect(profilePage).toContain("not shown publicly");
+    expect(profilePage).not.toContain("Country code");
   });
 });

--- a/test/quartet-listing-form.test.ts
+++ b/test/quartet-listing-form.test.ts
@@ -20,9 +20,7 @@ describe("quartet listing form parsing", () => {
     const values = parseQuartetListingFormData(
       formData([
         ["name", "Harbour Lights"],
-        ["countryCode", "ca"],
         ["countryName", "Canada"],
-        ["region", "Ontario"],
         ["locality", "Toronto"],
         ["postalCodePrivate", "M5V"],
         ["voicing", "TTBB"],
@@ -30,7 +28,7 @@ describe("quartet listing form parsing", () => {
         ["partsCovered", "TTBB:Bass"],
         ["partsNeeded", "TTBB:Tenor"],
         ["goals", "regular_rehearsal"],
-        ["travelRadiusKm", "75"],
+        ["travelRadiusMiles", "50"],
       ]),
     );
 
@@ -42,7 +40,7 @@ describe("quartet listing form parsing", () => {
     ]);
     expect(values.partsNeeded).toEqual([{ part: "Tenor", voicing: "TTBB" }]);
     expect(values.goals).toEqual(["regular_rehearsal"]);
-    expect(values.travelRadiusKm).toBe(75);
+    expect(values.travelRadiusKm).toBe(80);
   });
 
   it("keeps needed parts distinct from covered parts", () => {
@@ -89,14 +87,13 @@ describe("quartet listing form parsing", () => {
       formData([
         ["name", "Afterglow Four"],
         ["countryName", "Australia"],
-        ["region", "Victoria"],
         ["locality", "Melbourne"],
         ["postalCodePrivate", "3000"],
       ]),
     );
 
     expect(buildQuartetPublicLocationLabel(values)).toBe(
-      "Melbourne, Victoria, Australia area",
+      "Melbourne, Australia area",
     );
     expect(buildQuartetPublicLocationLabel(values)).not.toContain("3000");
     expect(inferQuartetLocationPrecision(values)).toBe("postal_code");

--- a/test/singer-profile-form.test.ts
+++ b/test/singer-profile-form.test.ts
@@ -34,15 +34,13 @@ describe("singer profile form parsing", () => {
     const values = parseSingerProfileFormData(
       formData([
         ["displayName", "Priya"],
-        ["countryCode", "gb"],
         ["countryName", "United Kingdom"],
-        ["region", "Greater Manchester"],
         ["locality", "Manchester"],
         ["postalCodePrivate", "M1 1AE"],
         ["parts", "TTBB:Lead"],
         ["parts", "SATB:Soprano"],
         ["goals", "pickup"],
-        ["travelRadiusKm", "40"],
+        ["travelRadiusMiles", "25"],
       ]),
     );
 
@@ -60,7 +58,7 @@ describe("singer profile form parsing", () => {
     const values = parseSingerProfileFormData(
       formData([
         ["displayName", "Jordan"],
-        ["countryCode", "usa"],
+        ["countryName", "Other / not listed"],
         ["parts", "TTBB:Lead"],
         ["parts", "melody"],
         ["goals", "contest"],
@@ -78,15 +76,12 @@ describe("singer profile form parsing", () => {
       formData([
         ["displayName", "Ari"],
         ["countryName", "Canada"],
-        ["region", "Ontario"],
         ["locality", "Toronto"],
         ["postalCodePrivate", "M5V"],
       ]),
     );
 
-    expect(buildPublicLocationLabel(values)).toBe(
-      "Toronto, Ontario, Canada area",
-    );
+    expect(buildPublicLocationLabel(values)).toBe("Toronto, Canada area");
     expect(buildPublicLocationLabel(values)).not.toContain("M5V");
     expect(inferLocationPrecision(values)).toBe("postal_code");
   });


### PR DESCRIPTION
Closes #82.
Closes #83.

## Summary
- simplify profile, Quartet Mode, and onboarding location entry to country picklist, city, and ZIP/postal code
- remove user-facing country code, region/admin-area, and public-location-label fields from those forms
- keep ZIP/postal code private and derive approximate public labels from city/country
- default distance display to miles, convert miles inputs to existing kilometer storage, and add the only miles/kilometers picker on Find
- update help/privacy/Supabase/smoke-test docs and coverage for US, Canada, and global examples

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build