### PR TITLE
Update footer copyright/link pattern

### DIFF
--- a/components/navigation/site-footer.tsx
+++ b/components/navigation/site-footer.tsx
@@ -4,26 +4,33 @@ import { siteFooterLinks } from "@/lib/navigation/site-navigation";
 export function SiteFooter() {
   return (
     <footer className="border-t border-[#d7cec0] bg-[#fffaf2]/70">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-[#596466]">
-          Quartet Member Finder helps singers and quartets connect with privacy
-          in mind.
-        </p>
+      <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-center gap-3 px-6 py-5 text-center sm:flex-row sm:gap-4">
+        <p className="text-sm text-[#596466]">© 2026 Quartet Member Finder</p>
         <nav
           aria-label="Site resources"
-          className="flex flex-wrap gap-x-4 gap-y-2 text-sm"
+          className="flex flex-wrap items-center justify-center gap-y-2 text-sm"
         >
-          {siteFooterLinks.map((link) => (
-            <Link
-              className="font-semibold text-[#2f6f73] hover:text-[#174b4f]"
-              href={link.href}
-              key={link.href}
-              rel={link.href.startsWith("https://") ? "noreferrer" : undefined}
-              target={link.href.startsWith("https://") ? "_blank" : undefined}
-            >
-              {link.label}
-            </Link>
-          ))}
+          <ul className="flex flex-wrap items-center justify-center gap-y-2">
+            {siteFooterLinks.map((link) => (
+              <li
+                className="border-[#d7cec0] px-3 sm:border-l sm:first:border-l-0"
+                key={link.href}
+              >
+                <Link
+                  className="font-semibold text-[#2f6f73] hover:text-[#174b4f]"
+                  href={link.href}
+                  rel={
+                    link.href.startsWith("https://") ? "noreferrer" : undefined
+                  }
+                  target={
+                    link.href.startsWith("https://") ? "_blank" : undefined
+                  }
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
         </nav>
       </div>
     </footer>

--- a/test/site-footer.test.ts
+++ b/test/site-footer.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { siteFooterLinks } from "@/lib/navigation/site-navigation";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("site footer", () => {
+  it("uses the compact copyright and resource-link pattern", () => {
+    const footer = source("components/navigation/site-footer.tsx");
+
+    expect(footer).toContain("© 2026 Quartet Member Finder");
+    expect(footer).not.toContain(
+      "Quartet Member Finder helps singers and quartets connect with privacy",
+    );
+    expect(siteFooterLinks.map((link) => link.label)).toEqual([
+      "Help",
+      "Privacy",
+      "GitHub",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #88

## Summary
- Replace the footer marketing sentence with the compact © 2026 Quartet Member Finder copyright line
- Keep Help, Privacy, and GitHub resource links in a compact wrapped layout
- Add a focused footer regression test for the copyright/link pattern

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build