### PR TITLE
Implement intent-based optional profile model

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { signOut } from "@/app/auth/actions";
 import {
-  signedInModeNavigationLinks,
   signedInPrimaryNavigationLinks,
   signedInUtilityNavigationLinks,
 } from "@/lib/navigation/signed-in-nav";
@@ -79,25 +78,11 @@ export default async function ProtectedAppLayout({
           >
             <div
               className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap"
-              aria-label="Singer tasks"
+              aria-label="App tasks"
             >
               {signedInPrimaryNavigationLinks.map((link) => (
                 <Link
                   className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] bg-white/60 px-3 py-2 text-center text-sm font-semibold text-[#394548] hover:border-[#2f6f73] hover:text-[#174b4f]"
-                  href={link.href}
-                  key={link.href}
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-            <div
-              className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap lg:justify-end"
-              aria-label="Quartet mode"
-            >
-              {signedInModeNavigationLinks.map((link) => (
-                <Link
-                  className="inline-flex min-h-11 items-center justify-center rounded-md bg-[#174b4f] px-3 py-2 text-center text-sm font-semibold text-white hover:bg-[#10393c]"
                   href={link.href}
                   key={link.href}
                 >

--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -96,15 +96,15 @@ export default async function ManageListingsPage({
     <div>
       <div className="max-w-3xl">
         <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-          Quartet listings
+          Quartet profile
         </p>
         <h1 className="mt-4 text-3xl font-bold text-[#172023]">
-          Manage quartet listing
+          Manage My Quartet Profile
         </h1>
         <p className="mt-4 text-base leading-7 text-[#394548]">
-          Create the listing that tells singers which parts are covered, which
-          parts are needed, and what kind of quartet you are building. Keep the
-          public location approximate.
+          This profile is for a quartet or prospective quartet you represent.
+          Make it discoverable when you are looking for one or more singers;
+          hide it any time without affecting your singer profile.
         </p>
       </div>
 
@@ -129,12 +129,13 @@ export default async function ManageListingsPage({
       {!listing ? (
         <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
           <h2 className="text-xl font-bold text-[#172023]">
-            Start Quartet Mode
+            Create My Quartet Profile
           </h2>
           <p className="mt-3 text-sm leading-6 text-[#394548]">
-            Quartet Mode is for a quartet or prospective quartet looking for
-            singers. Create a listing with covered parts, missing parts, and an
-            approximate location so singers can judge whether it might fit.
+            My Quartet Profile is for a quartet or prospective quartet looking
+            for singers. Create a profile with covered parts, missing parts, and
+            an approximate location so singers can judge whether it might fit.
+            You can keep it hidden until the opening is active.
           </p>
           <Link
             className="mt-4 inline-flex font-semibold text-[#2f6f73]"
@@ -146,12 +147,13 @@ export default async function ManageListingsPage({
       ) : listing.is_visible ? null : (
         <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
           <h2 className="text-xl font-bold text-[#172023]">
-            This quartet listing is hidden
+            My Quartet Profile is hidden
           </h2>
           <p className="mt-3 text-sm leading-6 text-[#394548]">
             Hidden listings do not appear in Find, detailed quartet search, or
             the map view, so singers cannot discover them yet. Turn on
-            visibility below when the listing is ready.
+            visibility below when the opening is active. This does not change
+            your singer profile visibility.
           </p>
         </section>
       )}
@@ -308,6 +310,10 @@ export default async function ManageListingsPage({
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Visibility</h2>
+          <p className="text-sm leading-6 text-[#394548]">
+            Discoverable means this profile can appear in Find results and
+            approximate map discovery. Hidden means it stays out of discovery.
+          </p>
           <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
             <input
               className="mt-1"
@@ -317,7 +323,7 @@ export default async function ManageListingsPage({
             />
             <span>
               <span className="block font-semibold text-[#172023]">
-                Show this quartet listing in discovery
+                Show My Quartet Profile in discovery
               </span>
               <span className="mt-1 block text-sm leading-6 text-[#596466]">
                 Discovery views include the name, parts covered and needed,

--- a/app/(protected)/app/onboarding/page.tsx
+++ b/app/(protected)/app/onboarding/page.tsx
@@ -83,8 +83,8 @@ export default async function OnboardingPage({
           distance defaults before asking what you want to do first.
         </p>
         <p className="mt-3 max-w-3xl text-base leading-7 text-[#394548]">
-          You can use the app as a singer, in Quartet Mode, or both. The choice
-          below is only your next step, not a permanent role.
+          You can use My Singer Profile, My Quartet Profile, or both. The choice
+          below is only your first task, not a permanent role.
         </p>
       </header>
 
@@ -193,11 +193,11 @@ export default async function OnboardingPage({
               Step 2
             </p>
             <h2 className="mt-2 text-2xl font-bold text-[#172023]">
-              What do you want to do first?
+              What are you here to do first?
             </h2>
             <p className="mt-2 text-base leading-7 text-[#394548]">
-              Pick the next page to open after setup. You can use every workflow
-              later.
+              Pick the next page to open after setup. You can use both optional
+              profiles later, and each profile has its own visibility setting.
             </p>
           </div>
           <div className="mt-4 grid gap-4 md:grid-cols-2">

--- a/app/(protected)/app/page.tsx
+++ b/app/(protected)/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import {
-  quartetModeDashboardActions,
+  quartetDashboardActions,
   singerDashboardActions,
   supportDashboardActions,
   type DashboardAction,
@@ -45,14 +45,13 @@ export default async function AppHomePage() {
           {user?.email ? `, ${user.email}` : ""}?
         </h1>
         <p className="mt-4 max-w-3xl text-base leading-7 text-[#394548]">
-          Use the app as a singer, as someone helping an incomplete quartet, or
-          both. Singer profiles help others find you, quartet openings help you
-          find groups looking for missing parts, and first contact starts
-          through the app.
+          You can maintain a singer profile, a quartet profile, or both. Each
+          has its own visibility setting, so you control what appears in
+          discovery without choosing a permanent role.
         </p>
         <p className="mt-3 max-w-3xl text-base leading-7 text-[#394548]">
-          Discovery uses approximate locations so singers and quartets can judge
-          practical distance without exposing exact home-location details.
+          Discoverable means a profile can appear in Find results and
+          approximate map discovery. Hidden means it stays out of discovery.
         </p>
       </header>
 
@@ -65,38 +64,38 @@ export default async function AppHomePage() {
             className="mt-3 text-2xl font-bold text-[#172023]"
             id="singer-dashboard-heading"
           >
-            Start with your singer workflow
+            My Singer Profile
           </h2>
           <p className="mt-3 text-base leading-7 text-[#394548]">
-            Build a useful profile, look for quartet openings, connect with
-            other singers, and use the map for privacy-minded regional
-            discovery.
+            This profile represents you personally as a singer. Make it
+            discoverable if you want quartets or other singers to find you; hide
+            it any time without affecting your quartet profile.
           </p>
         </div>
         <DashboardActionList actions={singerDashboardActions} />
       </section>
 
       <section
-        aria-labelledby="quartet-mode-dashboard-heading"
+        aria-labelledby="quartet-profile-dashboard-heading"
         className="border-t border-[#d7cec0] pt-8"
       >
         <div className="max-w-3xl">
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-            Quartet Mode
+            As a quartet representative
           </p>
           <h2
             className="mt-3 text-2xl font-bold text-[#172023]"
-            id="quartet-mode-dashboard-heading"
+            id="quartet-profile-dashboard-heading"
           >
-            Represent an incomplete quartet
+            My Quartet Profile
           </h2>
           <p className="mt-3 text-base leading-7 text-[#394548]">
-            Quartet Mode is for managing a quartet listing and finding singers
-            who may fit the missing part. You can use it alongside your own
-            singer profile.
+            This profile represents a quartet or prospective quartet you
+            represent. Make it discoverable when you are looking for one or more
+            singers; hide it any time without affecting your singer profile.
           </p>
         </div>
-        <DashboardActionList actions={quartetModeDashboardActions} />
+        <DashboardActionList actions={quartetDashboardActions} />
       </section>
 
       <section

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -106,9 +106,9 @@ export default async function ManageProfilePage({
           Manage your singer profile
         </h1>
         <p className="mt-4 text-base leading-7 text-[#394548]">
-          Create the public singer profile that quartets and other singers can
-          discover. Location and country also set sensible distance defaults, so
-          you do not need a separate account settings step.
+          This profile is for you as an individual singer. Make it discoverable
+          if you want quartets or other singers to find you; hide it any time
+          without affecting your quartet profile.
         </p>
         <p className="mt-3 text-sm leading-6 text-[#596466]">
           Only display name is required. Everything else is optional, but parts,
@@ -143,7 +143,8 @@ export default async function ManageProfilePage({
           <p className="mt-3 text-sm leading-6 text-[#394548]">
             A singer profile helps quartet openings and other singers find you.
             Start with your parts, goals, and approximate location; you can keep
-            it hidden until you are ready.
+            it hidden until you are ready. Filling it out does not require
+            making it discoverable.
           </p>
           <Link
             className="mt-4 inline-flex font-semibold text-[#2f6f73]"
@@ -160,7 +161,8 @@ export default async function ManageProfilePage({
           <p className="mt-3 text-sm leading-6 text-[#394548]">
             Hidden profiles do not appear in Find, detailed singer search, or
             the map view. Turn on the visibility checkbox below when you want
-            discovery to show your public singer details.
+            discovery to show your public singer details. This does not change
+            your quartet profile visibility.
           </p>
         </section>
       )}
@@ -395,6 +397,10 @@ export default async function ManageProfilePage({
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Visibility</h2>
+          <p className="text-sm leading-6 text-[#394548]">
+            Discoverable means this profile can appear in Find results and
+            approximate map discovery. Hidden means it stays out of discovery.
+          </p>
           <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
             <input
               className="mt-1"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,21 +8,24 @@ const audiencePaths = [
   "Quartet representatives looking for missing parts",
 ];
 
-const discoveryLinks = [
+const profilePaths = [
   {
-    href: "/find?kind=quartets",
-    label: "Browse quartet openings",
-    description: "See incomplete quartets looking for voicing-specific parts.",
+    href: "/sign-in?next=%2Fapp%2Fprofile",
+    label: "My Singer Profile",
+    description:
+      "Use this if you want to be found personally as a singer. You decide when it becomes discoverable.",
   },
   {
-    href: "/find?kind=singers",
-    label: "Browse singers",
-    description: "Find singers who are open to quartet opportunities.",
+    href: "/sign-in?next=%2Fapp%2Flistings",
+    label: "My Quartet Profile",
+    description:
+      "Use this if you represent a quartet or prospective quartet looking for one or more singers.",
   },
   {
-    href: "/find",
-    label: "View the map",
-    description: "Explore approximate singer and quartet locations.",
+    href: "/help",
+    label: "Get oriented",
+    description:
+      "Read how optional profiles, independent visibility, and app-mediated contact work before signing in.",
   },
 ];
 
@@ -45,8 +48,9 @@ export default function Home() {
             </p>
             <p className="mt-4 max-w-2xl text-base leading-7 text-[#394548]">
               {PRODUCT_NAME} is for practical introductions: create a singer
-              profile with the parts you sing by voicing, list an incomplete
-              quartet, or look around before you decide what to share.
+              profile with the parts you sing by voicing, create a quartet
+              profile for an incomplete group, or use both without choosing a
+              permanent role.
             </p>
             <div className="mt-8 grid gap-3 sm:flex sm:flex-wrap">
               <Link
@@ -92,25 +96,26 @@ export default function Home() {
         </section>
 
         <section
-          aria-label="Public discovery links"
+          aria-label="Profile paths"
           className="mt-12 border-t border-[#d7cec0] pt-8"
         >
           <div className="max-w-3xl">
             <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
-              Want to look around first?
+              Two optional profiles
             </p>
             <h2 className="mt-3 text-2xl font-bold text-[#172023]">
-              Public discovery is open before you sign in.
+              Use either profile, or both.
             </h2>
             <p className="mt-4 text-base leading-7 text-[#394548]">
-              Use Find to filter public listings, scan approximate areas on the
-              map, and compare results in a table before creating your profile
-              or quartet listing.
+              Use My Singer Profile if you want to be found as a singer. Use My
+              Quartet Profile if you represent a quartet looking for a missing
+              part. Each profile has its own visibility setting, so filling one
+              out does not force it into discovery.
             </p>
           </div>
 
           <div className="mt-6 grid gap-4 sm:grid-cols-3">
-            {discoveryLinks.map((link) => (
+            {profilePaths.map((link) => (
               <Link
                 className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm hover:bg-white"
                 href={link.href}

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -345,7 +345,7 @@ export default async function QuartetSearchPage({
               <p className="mt-3 text-sm leading-6">
                 Try clearing filters, widening the country/region/locality, or
                 checking the map. Some quartets may not have turned on discovery
-                for their Quartet Mode listing yet.
+                for My Quartet Profile yet.
               </p>
               <div className="mt-4 flex flex-wrap gap-4">
                 <Link className="font-semibold text-[#2f6f73]" href="/quartets">

--- a/docs/accessibility-mobile-audit.md
+++ b/docs/accessibility-mobile-audit.md
@@ -8,7 +8,7 @@ This pre-launch audit covers the core public and signed-in flows:
 - signed-in dashboard
 - onboarding
 - My Singer Profile
-- Quartet Mode
+- My Quartet Profile
 - Find
 - detailed Quartet Opening search
 - detailed Singer search

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -123,7 +123,7 @@ Record before launch:
 | Complete | Onboarding routes signed-in first-time users to a useful first action.                                                                                   | Issue #41; smoke test plan.                                          |
 | Complete | Empty states provide useful next actions.                                                                                                                | Issue #40; smoke test plan.                                          |
 | Complete | My Singer Profile stores parts, goals, location, visibility, and private postal code separately.                                                         | `/app/profile`; `docs/privacy-model.md#singer-profile-management`.   |
-| Complete | Quartet Mode stores covered parts and needed parts separately.                                                                                           | `/app/listings`; `docs/privacy-model.md#quartet-listing-management`. |
+| Complete | My Quartet Profile stores covered parts and needed parts separately.                                                                                     | `/app/listings`; `docs/privacy-model.md#quartet-listing-management`. |
 | Complete | Find consolidates public discovery into filters, privacy-safe map, and results table; detailed Singer, Quartet Opening, and Map routes remain available. | `/find`, `/singers`, `/quartets`, `/map`.                            |
 | Manual   | Run the full manual smoke test plan on production before launch.                                                                                         | `docs/smoke-test-plan.md`.                                           |
 | Manual   | Confirm seed/demo data is not loaded into production.                                                                                                    | `docs/seed-data.md`; Supabase production data review.                |
@@ -141,12 +141,12 @@ Record before launch:
 
 ## Global Location and Non-US Assumptions
 
-| Status   | Item                                                                                                | Verification                                                     |
-| -------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Complete | Location fields are globally tolerant and avoid US-only validation.                                 | `docs/privacy-model.md#global-location-expectations`.            |
-| Complete | Search and smoke tests include non-US examples such as Manchester, Dublin, Toronto, or Melbourne.   | `docs/smoke-test-plan.md`.                                       |
-| Complete | Distance display supports kilometers and miles.                                                     | `lib/location/approximate-location.ts`; tests.                   |
-| Manual   | Verify at least one non-US singer profile and one non-US quartet listing in production smoke tests. | `docs/smoke-test-plan.md#my-singer-profile` and `#quartet-mode`. |
+| Status   | Item                                                                                                | Verification                                                           |
+| -------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Complete | Location fields are globally tolerant and avoid US-only validation.                                 | `docs/privacy-model.md#global-location-expectations`.                  |
+| Complete | Search and smoke tests include non-US examples such as Manchester, Dublin, Toronto, or Melbourne.   | `docs/smoke-test-plan.md`.                                             |
+| Complete | Distance display supports kilometers and miles.                                                     | `lib/location/approximate-location.ts`; tests.                         |
+| Manual   | Verify at least one non-US singer profile and one non-US quartet listing in production smoke tests. | `docs/smoke-test-plan.md#my-singer-profile` and `#my-quartet-profile`. |
 
 ## Abuse and Spam Protections
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -217,8 +217,9 @@ information.
 
 First-run onboarding first asks signed-in users for basic profile context:
 display name, country, city, and ZIP/postal code. It then asks what they want to
-do first, not what role they permanently are. A user may use the app as a singer
-and in Quartet Mode.
+do first, not what role they permanently are. A user may maintain My Singer
+Profile, My Quartet Profile, both profiles, or neither profile while getting
+oriented.
 
 Onboarding state is stored on the user's private `account_profiles` row. The app
 records whether onboarding was completed and the selected first action. This
@@ -240,8 +241,14 @@ unit.
 
 My Singer Profile is the place for public singer discovery data: public display
 name, parts, goals, experience, availability, approximate location, private
-postal code for future matching, and search visibility. Quartet Mode owns the
-same kind of location and visibility decisions for quartet listings.
+postal code for future matching, and search visibility. My Quartet Profile owns
+the same kind of location and visibility decisions for a quartet or prospective
+quartet the user represents.
+
+Each optional profile has independent visibility. Discoverable means the profile
+can appear in Find results and approximate map discovery. Hidden means it stays
+out of discovery. Filling out one profile does not require publishing it, and
+hiding one profile does not hide the other.
 
 Country on the singer profile or quartet listing drives practical defaults such
 as miles vs kilometers and country-aware labels like ZIP code, postcode, state,

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -24,8 +24,8 @@ validation.
 1. Open `/`.
 2. Pass: the page loads without a server error and clearly names Quartet Member
    Finder.
-3. Pass: primary links to Find, Help, Privacy, My Singer Profile, and Quartet
-   Mode are present.
+3. Pass: primary links include Help, Privacy, and Sign in, and the page explains
+   My Singer Profile and My Quartet Profile as optional profiles.
 4. Fail: the page exposes private email addresses, phone numbers, exact
    coordinates, private postal codes, or raw database IDs.
 
@@ -64,8 +64,8 @@ validation.
 
 1. Sign in and open `/app`.
 2. Pass: the dashboard loads behind authentication.
-3. Pass: it distinguishes My Singer Profile, Find, Quartet Mode, Account
-   Settings, Help, and Privacy.
+3. Pass: it distinguishes My Singer Profile, My Quartet Profile, Find, Help,
+   and Privacy without requiring a global mode switch.
 4. Pass: signed-out users visiting `/app` are redirected to sign in.
 5. Fail: dashboard links point to missing routes or expose another user's data.
 
@@ -77,8 +77,9 @@ validation.
 3. Pass: display name is clearly required and the location fields are clearly
    optional.
 4. Pass: workflow options are plain language and do not imply a permanent role.
-5. Pass: saving creates hidden starter profile context and routes to the chosen
-   next page.
+5. Pass: saving creates hidden starter profile context and routes to My Singer
+   Profile, My Quartet Profile, or the signed-in dashboard based on first
+   intent.
 6. Fail: onboarding publishes the profile in discovery without the visibility
    control being turned on.
 
@@ -104,7 +105,7 @@ validation.
 8. Fail: public UI exposes private postal code, formatted private address, exact
    latitude/longitude, email address, or phone number.
 
-## Quartet Mode
+## My Quartet Profile
 
 1. Open `/app/listings`.
 2. Create or edit a quartet listing with:

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -84,9 +84,12 @@ The server creates the account profile row after sign-in when needed. If neither
 completion nor skipped state is present, sign-in routes the user through
 `/app/onboarding`. Current onboarding collects display name and optional
 country/city/ZIP or postal code before asking what workflow the user wants to
-open first. Completing onboarding also creates or updates a hidden starter
-`singer_profiles` row with that basic context so profile defaults are available
-without publishing the user in discovery.
+open first. Current `onboarding_last_choice` values are
+`singer-profile-first`, `quartet-profile-first`, and `get-oriented`; legacy
+values remain allowed by the database constraint for existing rows. Completing
+onboarding also creates or updates a hidden starter `singer_profiles` row with
+that basic context so profile defaults are available without publishing the user
+in discovery.
 
 The legacy `/app/settings` route redirects to My Singer Profile. The app no
 longer asks users to re-run onboarding or choose account-level distance units.

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -2,7 +2,7 @@ export const publicHelpSections = [
   {
     body: [
       "Quartet Member Finder helps barbershop singers and incomplete quartets find each other. It is for practical discovery and safer introductions, not for building a public social network.",
-      "You can use it to create a singer profile, list an incomplete quartet, search for nearby possibilities, and send an app-mediated first contact request.",
+      "One account can support My Singer Profile, My Quartet Profile, or both. You can use either optional profile without choosing a permanent role.",
     ],
     heading: "What It Is For",
   },
@@ -11,23 +11,24 @@ export const publicHelpSections = [
       "A singer profile describes who you are as a singer: your name, parts, goals, experience, availability, travel willingness, and approximate location.",
       "Parts are grouped by voicing, so TTBB Tenor, SATB Tenor, and SSAA part labels stay distinct in discovery.",
       "Only display name is required; the optional details help others decide whether a contact request makes sense.",
-      "You choose whether the profile appears in public discovery. Hidden profiles stay out of singer search and the map.",
+      "You choose whether My Singer Profile appears in discovery. Hidden singer profiles stay out of singer search and the map, and hiding it does not hide My Quartet Profile.",
     ],
     heading: "Singer Profiles",
   },
   {
     body: [
       "After sign-in, onboarding first asks for basic profile context like display name, country, and approximate location.",
-      "Then you choose what to do first. That choice is not permanent; you can use singer search, quartet openings, and Quartet Mode later.",
+      "Then you choose what you are here to do first. That choice is not permanent; you can use My Singer Profile, My Quartet Profile, Find, and Help later.",
     ],
     heading: "First Sign-In",
   },
   {
     body: [
-      "A quartet listing is for a quartet or prospective quartet that has some parts covered and is looking for one or more singers.",
-      "Listings keep covered parts and needed parts separate within the quartet's voicing so searchers can quickly understand what the group needs.",
+      "My Quartet Profile is for a quartet or prospective quartet that has some parts covered and is looking for one or more singers.",
+      "It keeps covered parts and needed parts separate within the quartet's voicing so searchers can quickly understand what the group needs.",
+      "You choose whether My Quartet Profile appears in discovery. Hidden quartet profiles stay out of quartet search and the map, and hiding it does not hide My Singer Profile.",
     ],
-    heading: "Quartet Listings",
+    heading: "Quartet Profiles",
   },
   {
     body: [
@@ -56,8 +57,9 @@ export const publicHelpSections = [
   },
   {
     body: [
-      "You can hide a singer profile or quartet listing by turning off its search visibility and saving. Hidden items should disappear from public search and the map.",
-      "If you no longer want a profile or listing to be active, keep it hidden until deletion or stronger deactivation controls are added.",
+      "Discoverable means a profile can appear in Find results and approximate map discovery. Hidden means it stays out of discovery.",
+      "My Singer Profile and My Quartet Profile have independent visibility controls. You can make either one discoverable, both discoverable, or neither discoverable.",
+      "Filling out a profile does not require making it discoverable. If you are no longer looking personally, hide My Singer Profile; if the quartet opening is no longer active, hide My Quartet Profile.",
     ],
     heading: "Visibility Controls",
   },
@@ -94,6 +96,7 @@ export const publicPrivacySections = [
   {
     body: [
       "You choose what to put in a singer profile or quartet listing. That can include names, parts, goals, experience, availability, travel willingness, a short description, and approximate location fields.",
+      "My Singer Profile and My Quartet Profile are optional and have independent visibility controls. Filling out one does not publish the other.",
       "Do not put private contact details or exact home-location details into public text fields if you do not want other people to see them.",
     ],
     heading: "Information You Add",
@@ -107,7 +110,8 @@ export const publicPrivacySections = [
   },
   {
     body: [
-      "Singer profiles and quartet listings have visibility controls. Visible and active items can appear in public search and the map. Hidden items should stay out of those public discovery views.",
+      "Singer profiles and quartet profiles have independent visibility controls. Discoverable and active profiles can appear in search and the map. Hidden profiles should stay out of those discovery views.",
+      "Both optional profiles can be discoverable at once when that matches your situation, but neither one has to be discoverable just because it has been filled out.",
       "The database uses privacy-safe discovery views for public search rather than exposing private base tables directly.",
     ],
     heading: "Visibility",

--- a/lib/dashboard/app-dashboard.ts
+++ b/lib/dashboard/app-dashboard.ts
@@ -7,28 +7,28 @@ export type DashboardAction = {
 export const singerDashboardActions: DashboardAction[] = [
   {
     description:
-      "Create or update the profile that helps other singers and quartets understand your parts, goals, availability, and approximate area.",
+      "Create or update your optional singer presence. Make it discoverable when you want quartets or other singers to find you.",
     href: "/app/profile",
     label: "My Singer Profile",
   },
   {
     description:
-      "Search quartet openings, singer profiles, and approximate regions from one discovery page.",
-    href: "/find",
-    label: "Find",
+      "Search quartet openings after your singer context is ready. You can change the looking-for filter any time.",
+    href: "/find?kind=quartets",
+    label: "Find quartet openings",
   },
 ];
 
-export const quartetModeDashboardActions: DashboardAction[] = [
+export const quartetDashboardActions: DashboardAction[] = [
   {
     description:
-      "Create or update the listing for an incomplete quartet, including covered parts, needed parts, goals, and approximate area.",
+      "Create or update the optional profile for a quartet or prospective quartet you represent.",
     href: "/app/listings",
-    label: "Manage Quartet Listing",
+    label: "My Quartet Profile",
   },
   {
     description:
-      "Search singer profiles and nearby activity when your quartet is ready to contact someone about a missing part.",
+      "Search singer profiles when your quartet opening is ready for app-mediated first contact.",
     href: "/find?kind=singers",
     label: "Find singers",
   },
@@ -37,7 +37,7 @@ export const quartetModeDashboardActions: DashboardAction[] = [
 export const supportDashboardActions: DashboardAction[] = [
   {
     description:
-      "Review how profiles, listings, discovery, visibility, and app-mediated contact work.",
+      "Review how optional profiles, independent visibility, discovery, and app-mediated contact work.",
     href: "/help",
     label: "Help",
   },

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -9,17 +9,20 @@ export const signedInPrimaryNavigationLinks = [
     label: "My Singer Profile",
   },
   {
+    href: "/app/listings",
+    label: "My Quartet Profile",
+  },
+  {
     href: "/find",
     label: "Find",
   },
-] as const;
-
-export const signedInModeNavigationLinks = [
   {
-    href: "/app/listings",
-    label: "Quartet Mode",
+    href: "/help",
+    label: "Help",
   },
 ] as const;
+
+export const signedInModeNavigationLinks: SignedInNavigationLink[] = [];
 
 export const signedInUtilityNavigationLinks: SignedInNavigationLink[] = [];
 

--- a/lib/navigation/site-navigation.ts
+++ b/lib/navigation/site-navigation.ts
@@ -1,15 +1,15 @@
 export const publicNavigationLinks = [
   {
-    href: "/find",
-    label: "Find",
+    href: "/help",
+    label: "Help",
+  },
+  {
+    href: "/privacy",
+    label: "Privacy",
   },
   {
     href: "/sign-in",
     label: "Sign in",
-  },
-  {
-    href: "/help",
-    label: "Help",
   },
 ] as const;
 

--- a/lib/onboarding/app-onboarding.ts
+++ b/lib/onboarding/app-onboarding.ts
@@ -8,31 +8,24 @@ export type OnboardingChoice = {
 export const onboardingChoices: OnboardingChoice[] = [
   {
     description:
-      "Browse visible quartet openings after saving your starter profile context. You can complete your singer profile later.",
-    href: "/find?kind=quartets",
-    id: "find-quartet-openings",
+      "Open My Singer Profile first. You can make it discoverable when you want quartets or other singers to find you.",
+    href: "/app/profile",
+    id: "singer-profile-first",
     label: "I'm a singer looking for quartet openings",
   },
   {
     description:
-      "Browse visible singer profiles and look for people nearby or in another region who might want to sing.",
-    href: "/find?kind=singers",
-    id: "find-singers-as-singer",
-    label: "I'm a singer looking for other singers",
-  },
-  {
-    description:
-      "Open Quartet Mode and create a listing with the quartet's voicing, covered parts, missing parts, goals, and approximate area.",
+      "Open My Quartet Profile first. You can describe the opening and make it discoverable when the group is actively looking.",
     href: "/app/listings",
-    id: "quartet-mode-listing",
+    id: "quartet-profile-first",
     label: "I represent a quartet looking for a singer",
   },
   {
     description:
-      "Go to Find with your starter context saved. You can complete singer or quartet details later.",
-    href: "/find",
-    id: "browse-for-now",
-    label: "I just want to browse for now",
+      "Go to the signed-in dashboard for a quick overview. You can fill out either profile, both profiles, or neither profile while you get oriented.",
+    href: "/app",
+    id: "get-oriented",
+    label: "I'm not sure yet / I just want to get oriented",
   },
 ];
 

--- a/supabase/migrations/20260501003000_intent_based_onboarding_choices.sql
+++ b/supabase/migrations/20260501003000_intent_based_onboarding_choices.sql
@@ -1,0 +1,21 @@
+alter table public.account_profiles
+drop constraint if exists account_profiles_onboarding_last_choice_check;
+
+alter table public.account_profiles
+add constraint account_profiles_onboarding_last_choice_check
+check (
+  onboarding_last_choice is null
+  or onboarding_last_choice in (
+    'singer-profile-first',
+    'quartet-profile-first',
+    'get-oriented',
+    'my-singer-profile',
+    'find-quartet-openings',
+    'find-singers-as-singer',
+    'quartet-mode-listing',
+    'quartet-mode-find-singers',
+    'browse-for-now',
+    'read-help-privacy',
+    'skipped'
+  )
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -131,42 +131,42 @@ values
     '00000000-0000-4000-8000-000000000101',
     'Avery Demo',
     now(),
-    'my-singer-profile',
+    'singer-profile-first',
     'mi'
   ),
   (
     '00000000-0000-4000-8000-000000000102',
     'Morgan Demo',
     now(),
-    'find-quartet-openings',
+    'singer-profile-first',
     'km'
   ),
   (
     '00000000-0000-4000-8000-000000000103',
     'Priya Demo',
     now(),
-    'my-singer-profile',
+    'singer-profile-first',
     'km'
   ),
   (
     '00000000-0000-4000-8000-000000000104',
     'Noah Demo',
     now(),
-    'find-singers-as-singer',
+    'get-oriented',
     'mi'
   ),
   (
     '00000000-0000-4000-8000-000000000105',
     'Hidden Demo',
     now(),
-    'browse-for-now',
+    'get-oriented',
     'km'
   ),
   (
     '00000000-0000-4000-8000-000000000106',
     'Quartet Owner Demo',
     now(),
-    'quartet-mode-listing',
+    'quartet-profile-first',
     'km'
   );
 

--- a/test/app-dashboard.test.ts
+++ b/test/app-dashboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  quartetModeDashboardActions,
+  quartetDashboardActions,
   singerDashboardActions,
   supportDashboardActions,
 } from "@/lib/dashboard/app-dashboard";
@@ -9,13 +9,13 @@ describe("signed-in app dashboard", () => {
   it("foregrounds the singer workflow with all primary next actions", () => {
     expect(singerDashboardActions.map((action) => action.label)).toEqual([
       "My Singer Profile",
-      "Find",
+      "Find quartet openings",
     ]);
   });
 
-  it("keeps quartet mode separate from the primary singer workflow", () => {
-    expect(quartetModeDashboardActions.map((action) => action.label)).toEqual([
-      "Manage Quartet Listing",
+  it("keeps the quartet profile separate from the singer profile", () => {
+    expect(quartetDashboardActions.map((action) => action.label)).toEqual([
+      "My Quartet Profile",
       "Find singers",
     ]);
   });
@@ -23,11 +23,11 @@ describe("signed-in app dashboard", () => {
   it("links every dashboard action to an existing route", () => {
     expect([
       ...singerDashboardActions,
-      ...quartetModeDashboardActions,
+      ...quartetDashboardActions,
       ...supportDashboardActions,
     ]).toEqual([
       expect.objectContaining({ href: "/app/profile" }),
-      expect.objectContaining({ href: "/find" }),
+      expect.objectContaining({ href: "/find?kind=quartets" }),
       expect.objectContaining({ href: "/app/listings" }),
       expect.objectContaining({ href: "/find?kind=singers" }),
       expect.objectContaining({ href: "/help" }),

--- a/test/app-onboarding.test.ts
+++ b/test/app-onboarding.test.ts
@@ -17,30 +17,32 @@ const pageSource = readFileSync(
 );
 
 describe("first-run onboarding", () => {
-  it("uses the requested Singer and Quartet Mode language", () => {
+  it("uses intent-based onboarding language without permanent modes", () => {
     const text = JSON.stringify(onboardingChoices);
 
     expect(text).toContain("I'm a singer looking for quartet openings");
-    expect(text).toContain("I'm a singer looking for other singers");
     expect(text).toContain("I represent a quartet looking for a singer");
-    expect(text).toContain("I just want to browse for now");
+    expect(text).toContain("I'm not sure yet / I just want to get oriented");
+    expect(text).toContain("My Singer Profile");
+    expect(text).toContain("My Quartet Profile");
     expect(pageSource).toContain("not a permanent role");
+    expect(pageSource).toContain("What are you here to do first?");
   });
 
   it("routes each first action to the expected destination", () => {
-    expect(destinationForOnboardingChoice("find-quartet-openings")).toBe(
-      "/find?kind=quartets",
+    expect(destinationForOnboardingChoice("singer-profile-first")).toBe(
+      "/app/profile",
     );
-    expect(destinationForOnboardingChoice("quartet-mode-listing")).toBe(
+    expect(destinationForOnboardingChoice("quartet-profile-first")).toBe(
       "/app/listings",
     );
-    expect(destinationForOnboardingChoice("browse-for-now")).toBe("/find");
+    expect(destinationForOnboardingChoice("get-oriented")).toBe("/app");
     expect(destinationForOnboardingChoice("unknown")).toBe("/app");
   });
 
   it("validates choices and post-onboarding paths", () => {
-    expect(onboardingChoices.length).toBe(4);
-    expect(isValidOnboardingChoice("find-singers-as-singer")).toBe(true);
+    expect(onboardingChoices.length).toBe(3);
+    expect(isValidOnboardingChoice("quartet-profile-first")).toBe(true);
     expect(isValidOnboardingChoice("skipped")).toBe(false);
     expect(normalizePostOnboardingPath("/app/profile")).toBe("/app/profile");
     expect(normalizePostOnboardingPath("/app/onboarding")).toBe("/app");

--- a/test/empty-states.test.ts
+++ b/test/empty-states.test.ts
@@ -10,15 +10,15 @@ function normalizedSource(path: string) {
 }
 
 describe("empty and first-time states", () => {
-  it("guides first-time signed-in users from profile and Quartet Mode forms", () => {
+  it("guides first-time signed-in users from optional profile forms", () => {
     const profilePage = source("app/(protected)/app/profile/page.tsx");
     const listingPage = source("app/(protected)/app/listings/page.tsx");
 
     expect(profilePage).toContain("Create My Singer Profile");
     expect(profilePage).toContain("Your profile is hidden");
     expect(profilePage).toContain("Find, detailed singer search");
-    expect(listingPage).toContain("Start Quartet Mode");
-    expect(listingPage).toContain("This quartet listing is hidden");
+    expect(listingPage).toContain("Create My Quartet Profile");
+    expect(listingPage).toContain("My Quartet Profile is hidden");
     expect(listingPage).toContain("Find, detailed quartet search");
   });
 
@@ -30,7 +30,7 @@ describe("empty and first-time states", () => {
     expect(singersPage).toContain("No visible singer profiles match");
     expect(singersPage).toContain("Clear filters");
     expect(quartetsPage).toContain("No visible quartet openings match");
-    expect(quartetsPage).toContain("Quartet Mode listing");
+    expect(quartetsPage).toContain("My Quartet Profile");
     expect(mapPage).toContain("No approximate map regions match");
     expect(mapPage).toContain("approximate public location data");
   });

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -13,7 +13,16 @@ describe("public discovery copy", () => {
     expect(homePage).toContain("First time here? Read Help");
     expect(homePage).toContain("Who it helps");
     expect(homePage).toContain("Singers looking for quartet openings");
-    expect(homePage).toContain("Public discovery is open before you sign in.");
+    expect(homePage).toContain("Two optional profiles");
+    expect(homePage).toContain("Use either profile, or both.");
+    expect(homePage).toContain("My Singer Profile");
+    expect(homePage).toContain("My Quartet Profile");
+    expect(homePage).not.toContain(
+      "Public discovery is open before you sign in.",
+    );
+    expect(homePage).not.toContain(
+      "look around before you decide what to share",
+    );
     expect(homePage).toContain("approximate locations");
     expect(homePage).toContain("first contact happens");
   });

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -15,7 +15,9 @@ describe("public help and privacy content", () => {
     const helpText = pageText(publicHelpSections);
 
     expect(helpText).toContain("Singer Profiles");
-    expect(helpText).toContain("Quartet Listings");
+    expect(helpText).toContain("Quartet Profiles");
+    expect(helpText).toContain("One account can support My Singer Profile");
+    expect(helpText).toContain("independent visibility controls");
     expect(helpText).toContain("Search");
     expect(helpText).toContain("Find is the main discovery page");
     expect(helpText).toContain("results table");
@@ -32,6 +34,8 @@ describe("public help and privacy content", () => {
 
     expect(privacyText).toContain("Approximate Location");
     expect(privacyText).toContain("Public search results should not show");
+    expect(privacyText).toContain("independent visibility controls");
+    expect(privacyText).toContain("Both optional profiles can be discoverable");
     expect(privacyText).toContain("email addresses or phone numbers");
     expect(privacyText).toContain("global");
     expect(privacyText).toContain("not a formal legal privacy policy");

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -7,22 +7,23 @@ import {
 } from "@/lib/navigation/signed-in-nav";
 
 describe("signed-in navigation", () => {
-  it("groups singer-first tasks apart from quartet mode and utility actions", () => {
+  it("keeps stable signed-in tasks without a mode switch", () => {
     expect(signedInPrimaryNavigationLinks.map((link) => link.label)).toEqual([
       "My Singer Profile",
+      "My Quartet Profile",
       "Find",
+      "Help",
     ]);
-    expect(signedInModeNavigationLinks).toEqual([
-      { href: "/app/listings", label: "Quartet Mode" },
-    ]);
+    expect(signedInModeNavigationLinks).toEqual([]);
     expect(signedInUtilityNavigationLinks).toEqual([]);
   });
 
   it("keeps existing route targets for the reorganized labels", () => {
     expect(signedInNavigationLinks).toEqual([
       { href: "/app/profile", label: "My Singer Profile" },
+      { href: "/app/listings", label: "My Quartet Profile" },
       { href: "/find", label: "Find" },
-      { href: "/app/listings", label: "Quartet Mode" },
+      { href: "/help", label: "Help" },
     ]);
   });
 });

--- a/test/site-navigation.test.ts
+++ b/test/site-navigation.test.ts
@@ -5,11 +5,11 @@ import {
 } from "@/lib/navigation/site-navigation";
 
 describe("site navigation", () => {
-  it("keeps public discovery and help links available before login", () => {
+  it("keeps public navigation focused on help, privacy, and sign-in", () => {
     expect(publicNavigationLinks).toEqual([
-      { href: "/find", label: "Find" },
-      { href: "/sign-in", label: "Sign in" },
       { href: "/help", label: "Help" },
+      { href: "/privacy", label: "Privacy" },
+      { href: "/sign-in", label: "Sign in" },
     ]);
   });
 

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -53,8 +53,9 @@ describe("initial Supabase schema migration", () => {
     expect(migration).toContain("add column onboarding_completed_at");
     expect(migration).toContain("add column onboarding_skipped_at");
     expect(migration).toContain("add column onboarding_last_choice");
-    expect(migration).toContain("'find-quartet-openings'");
-    expect(migration).toContain("'quartet-mode-listing'");
+    expect(migration).toContain("'singer-profile-first'");
+    expect(migration).toContain("'quartet-profile-first'");
+    expect(migration).toContain("'get-oriented'");
   });
 
   it("keeps private fields out of discovery views", () => {


### PR DESCRIPTION
Closes #90

## Summary
- Replace persistent Quartet Mode language with stable My Singer Profile / My Quartet Profile framing across onboarding, dashboard, navigation, profile pages, public home, Help, and Privacy
- Reduce onboarding to three first-intent choices and route to singer profile, quartet profile, or dashboard
- Clarify independent visibility/discoverability for both optional profiles
- Add a Supabase migration for the new onboarding choice values and update seed/docs/tests

## Supabase
- Applied migration 20260501003000_intent_based_onboarding_choices.sql with supabase db push

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build