### PR TITLE
Unify signed-in navigation shell

### DIFF
--- a/app/(protected)/app/layout.tsx
+++ b/app/(protected)/app/layout.tsx
@@ -1,10 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { signOut } from "@/app/auth/actions";
-import {
-  signedInPrimaryNavigationLinks,
-  signedInUtilityNavigationLinks,
-} from "@/lib/navigation/signed-in-nav";
+import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -43,56 +39,7 @@ export default async function ProtectedAppLayout({
 
   return (
     <div>
-      <header className="border-b border-[#d7cec0] bg-[#fffaf2]/90">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <Link
-              className="w-fit rounded-sm text-lg font-bold text-[#172023]"
-              href="/app"
-            >
-              Quartet Member Finder
-            </Link>
-            <div className="flex flex-wrap items-center gap-2">
-              {signedInUtilityNavigationLinks.map((link) => (
-                <Link
-                  className="inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm font-semibold text-[#394548] hover:bg-white/70 hover:text-[#174b4f]"
-                  href={link.href}
-                  key={link.href}
-                >
-                  {link.label}
-                </Link>
-              ))}
-              <form action={signOut}>
-                <button
-                  className="w-fit rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
-                  type="submit"
-                >
-                  Sign out
-                </button>
-              </form>
-            </div>
-          </div>
-          <nav
-            aria-label="App navigation"
-            className="grid gap-3 lg:grid-cols-[1fr_auto]"
-          >
-            <div
-              className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap"
-              aria-label="App tasks"
-            >
-              {signedInPrimaryNavigationLinks.map((link) => (
-                <Link
-                  className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] bg-white/60 px-3 py-2 text-center text-sm font-semibold text-[#394548] hover:border-[#2f6f73] hover:text-[#174b4f]"
-                  href={link.href}
-                  key={link.href}
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-          </nav>
-        </div>
-      </header>
+      <SignedInSiteHeader />
       <main className="mx-auto w-full max-w-6xl px-6 py-10">{children}</main>
     </div>
   );

--- a/components/navigation/signed-in-site-header.tsx
+++ b/components/navigation/signed-in-site-header.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { signOut } from "@/app/auth/actions";
+import { signedInNavigationLinks } from "@/lib/navigation/signed-in-nav";
+
+export function SignedInSiteHeader() {
+  return (
+    <header className="border-b border-[#d7cec0] bg-[#fffaf2]/90">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            className="w-fit rounded-sm text-lg font-bold text-[#172023]"
+            href="/app"
+          >
+            Quartet Member Finder
+          </Link>
+          <form action={signOut}>
+            <button
+              className="w-fit rounded-md border border-[#d7cec0] px-3 py-2 text-sm font-semibold text-[#172023] hover:bg-white"
+              type="submit"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+        <nav aria-label="App navigation">
+          <div
+            aria-label="App tasks"
+            className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap"
+          >
+            {signedInNavigationLinks.map((link) => (
+              <Link
+                className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] bg-white/60 px-3 py-2 text-center text-sm font-semibold text-[#394548] hover:border-[#2f6f73] hover:text-[#174b4f]"
+                href={link.href}
+                key={link.href}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -1,9 +1,4 @@
-type SignedInNavigationLink = {
-  href: string;
-  label: string;
-};
-
-export const signedInPrimaryNavigationLinks = [
+export const signedInNavigationLinks = [
   {
     href: "/app/profile",
     label: "My Singer Profile",
@@ -20,14 +15,4 @@ export const signedInPrimaryNavigationLinks = [
     href: "/help",
     label: "Help",
   },
-] as const;
-
-export const signedInModeNavigationLinks: SignedInNavigationLink[] = [];
-
-export const signedInUtilityNavigationLinks: SignedInNavigationLink[] = [];
-
-export const signedInNavigationLinks = [
-  ...signedInPrimaryNavigationLinks,
-  ...signedInModeNavigationLinks,
-  ...signedInUtilityNavigationLinks,
 ] as const;

--- a/test/navigation-shell.test.ts
+++ b/test/navigation-shell.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("shared navigation shells", () => {
+  it("uses one shared signed-in header for protected app pages", () => {
+    const protectedLayout = source("app/(protected)/app/layout.tsx");
+    const signedInHeader = source(
+      "components/navigation/signed-in-site-header.tsx",
+    );
+
+    expect(protectedLayout).toContain("<SignedInSiteHeader />");
+    expect(signedInHeader).toContain("signedInNavigationLinks.map");
+    expect(signedInHeader).toContain("Sign out");
+  });
+
+  it("keeps normal protected pages out of navigation ownership", () => {
+    const protectedPages = [
+      "app/(protected)/app/page.tsx",
+      "app/(protected)/app/profile/page.tsx",
+      "app/(protected)/app/listings/page.tsx",
+      "app/(protected)/app/onboarding/page.tsx",
+    ];
+
+    for (const page of protectedPages) {
+      const pageSource = source(page);
+
+      expect(pageSource).not.toContain("App navigation");
+      expect(pageSource).not.toContain("signedInNavigationLinks");
+      expect(pageSource).not.toContain("Sign out");
+    }
+  });
+
+  it("keeps signed-out navigation public-support only", () => {
+    const publicHeader = source("components/navigation/public-site-header.tsx");
+    const publicNavigation = source("lib/navigation/site-navigation.ts");
+
+    expect(publicHeader).toContain("publicNavigationLinks.map");
+    expect(publicNavigation).toContain('href: "/help"');
+    expect(publicNavigation).toContain('href: "/privacy"');
+    expect(publicNavigation).toContain('href: "/sign-in"');
+    expect(publicNavigation).not.toContain('href: "/find"');
+    expect(publicNavigation).not.toContain('href: "/map"');
+    expect(publicNavigation).not.toContain('href: "/singers"');
+    expect(publicNavigation).not.toContain('href: "/quartets"');
+  });
+});

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -1,29 +1,31 @@
 import { describe, expect, it } from "vitest";
-import {
-  signedInModeNavigationLinks,
-  signedInNavigationLinks,
-  signedInPrimaryNavigationLinks,
-  signedInUtilityNavigationLinks,
-} from "@/lib/navigation/signed-in-nav";
+import { signedInNavigationLinks } from "@/lib/navigation/signed-in-nav";
 
 describe("signed-in navigation", () => {
   it("keeps stable signed-in tasks without a mode switch", () => {
-    expect(signedInPrimaryNavigationLinks.map((link) => link.label)).toEqual([
+    expect(signedInNavigationLinks.map((link) => link.label)).toEqual([
       "My Singer Profile",
       "My Quartet Profile",
       "Find",
       "Help",
     ]);
-    expect(signedInModeNavigationLinks).toEqual([]);
-    expect(signedInUtilityNavigationLinks).toEqual([]);
   });
 
-  it("keeps existing route targets for the reorganized labels", () => {
+  it("uses shared discovery instead of top-level detailed search routes", () => {
     expect(signedInNavigationLinks).toEqual([
       { href: "/app/profile", label: "My Singer Profile" },
       { href: "/app/listings", label: "My Quartet Profile" },
       { href: "/find", label: "Find" },
       { href: "/help", label: "Help" },
     ]);
+    expect(signedInNavigationLinks.map((link) => link.href)).not.toContain(
+      "/singers",
+    );
+    expect(signedInNavigationLinks.map((link) => link.href)).not.toContain(
+      "/quartets",
+    );
+    expect(signedInNavigationLinks.map((link) => link.href)).not.toContain(
+      "/map",
+    );
   });
 });


### PR DESCRIPTION
Closes #89

## Summary
- Move signed-in app navigation into a shared SignedInSiteHeader component used by the protected app layout
- Simplify the signed-in nav config to one stable list: My Singer Profile, My Quartet Profile, Find, Help
- Add tests that protected pages do not own their own nav and that signed-out nav stays limited to Help, Privacy, and Sign in

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build