### PR TITLE
Require sign-in for discovery pages

### DIFF
--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
-import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
+import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
@@ -15,7 +16,6 @@ import {
   voicingPartValue,
 } from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type SingerFindRow = {
   country_code: string | null;
@@ -142,122 +142,118 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
   const kind = selectedKind(params.kind);
-  const supabase = await createSupabaseServerClient();
+  const supabase = await requireAuthenticatedDiscovery("/find", params);
 
   let results: FindResult[] = [];
   let errorMessage: string | null = null;
 
-  if (!supabase) {
-    errorMessage = "Supabase is not configured for discovery search yet.";
-  } else {
-    if (kind === "both" || kind === "singers") {
-      let query = supabase
-        .from("singer_discovery_profiles")
-        .select(
-          "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
-        )
-        .order("updated_at", { ascending: false });
+  if (kind === "both" || kind === "singers") {
+    let query = supabase
+      .from("singer_discovery_profiles")
+      .select(
+        "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
+      )
+      .order("updated_at", { ascending: false });
 
-      if (filters.country) {
-        query = query.ilike("country_name", `%${filters.country}%`);
-      }
-
-      if (filters.region) {
-        query = query.ilike("region", `%${filters.region}%`);
-      }
-
-      if (filters.locality) {
-        query = query.ilike("locality", `%${filters.locality}%`);
-      }
-
-      if (filters.part) {
-        query = query.contains("parts", [
-          voicingPartValue(filters.part.voicing, filters.part.part),
-        ]);
-      }
-
-      if (filters.goal) {
-        query = query.contains("goals", [filters.goal]);
-      }
-
-      const { data, error } = await query;
-
-      if (error) {
-        errorMessage = error.message;
-      } else {
-        results = [
-          ...results,
-          ...((data ?? []) as SingerFindRow[]).map((singer) => ({
-            countryCode: singer.country_code,
-            countryName: singer.country_name,
-            detailHref: "/singers",
-            id: singer.id,
-            intentLabel: "Singer profile",
-            kind: "singer" as const,
-            locality: singer.locality,
-            locationLabelPublic: singer.location_label_public,
-            name: singer.display_name,
-            parts: singer.parts,
-            region: singer.region,
-            travelRadiusKm: singer.travel_radius_km,
-          })),
-        ];
-      }
+    if (filters.country) {
+      query = query.ilike("country_name", `%${filters.country}%`);
     }
 
-    if (!errorMessage && (kind === "both" || kind === "quartets")) {
-      let query = supabase
-        .from("quartet_discovery_listings")
-        .select(
-          "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
-        )
-        .order("updated_at", { ascending: false });
+    if (filters.region) {
+      query = query.ilike("region", `%${filters.region}%`);
+    }
 
-      if (filters.country) {
-        query = query.ilike("country_name", `%${filters.country}%`);
-      }
+    if (filters.locality) {
+      query = query.ilike("locality", `%${filters.locality}%`);
+    }
 
-      if (filters.region) {
-        query = query.ilike("region", `%${filters.region}%`);
-      }
+    if (filters.part) {
+      query = query.contains("parts", [
+        voicingPartValue(filters.part.voicing, filters.part.part),
+      ]);
+    }
 
-      if (filters.locality) {
-        query = query.ilike("locality", `%${filters.locality}%`);
-      }
+    if (filters.goal) {
+      query = query.contains("goals", [filters.goal]);
+    }
 
-      if (filters.part) {
-        query = query.contains("parts_needed", [
-          voicingPartValue(filters.part.voicing, filters.part.part),
-        ]);
-      }
+    const { data, error } = await query;
 
-      if (filters.goal) {
-        query = query.contains("goals", [filters.goal]);
-      }
+    if (error) {
+      errorMessage = error.message;
+    } else {
+      results = [
+        ...results,
+        ...((data ?? []) as SingerFindRow[]).map((singer) => ({
+          countryCode: singer.country_code,
+          countryName: singer.country_name,
+          detailHref: "/singers",
+          id: singer.id,
+          intentLabel: "Singer profile",
+          kind: "singer" as const,
+          locality: singer.locality,
+          locationLabelPublic: singer.location_label_public,
+          name: singer.display_name,
+          parts: singer.parts,
+          region: singer.region,
+          travelRadiusKm: singer.travel_radius_km,
+        })),
+      ];
+    }
+  }
 
-      const { data, error } = await query;
+  if (!errorMessage && (kind === "both" || kind === "quartets")) {
+    let query = supabase
+      .from("quartet_discovery_listings")
+      .select(
+        "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
+      )
+      .order("updated_at", { ascending: false });
 
-      if (error) {
-        errorMessage = error.message;
-      } else {
-        results = [
-          ...results,
-          ...((data ?? []) as QuartetFindRow[]).map((quartet) => ({
-            countryCode: quartet.country_code,
-            countryName: quartet.country_name,
-            detailHref: "/quartets",
-            id: quartet.id,
-            intentLabel: "Quartet opening",
-            kind: "quartet" as const,
-            locality: quartet.locality,
-            locationLabelPublic: quartet.location_label_public,
-            name: quartet.name,
-            parts: quartet.parts_needed,
-            region: quartet.region,
-            travelRadiusKm: quartet.travel_radius_km,
-          })),
-        ];
-      }
+    if (filters.country) {
+      query = query.ilike("country_name", `%${filters.country}%`);
+    }
+
+    if (filters.region) {
+      query = query.ilike("region", `%${filters.region}%`);
+    }
+
+    if (filters.locality) {
+      query = query.ilike("locality", `%${filters.locality}%`);
+    }
+
+    if (filters.part) {
+      query = query.contains("parts_needed", [
+        voicingPartValue(filters.part.voicing, filters.part.part),
+      ]);
+    }
+
+    if (filters.goal) {
+      query = query.contains("goals", [filters.goal]);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      errorMessage = error.message;
+    } else {
+      results = [
+        ...results,
+        ...((data ?? []) as QuartetFindRow[]).map((quartet) => ({
+          countryCode: quartet.country_code,
+          countryName: quartet.country_name,
+          detailHref: "/quartets",
+          id: quartet.id,
+          intentLabel: "Quartet opening",
+          kind: "quartet" as const,
+          locality: quartet.locality,
+          locationLabelPublic: quartet.location_label_public,
+          name: quartet.name,
+          parts: quartet.parts_needed,
+          region: quartet.region,
+          travelRadiusKm: quartet.travel_radius_km,
+        })),
+      ];
     }
   }
 
@@ -275,7 +271,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
 
   return (
     <>
-      <PublicSiteHeader />
+      <SignedInSiteHeader />
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <header>
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
@@ -287,7 +283,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
           <p className="mt-4 max-w-3xl text-base leading-7 text-[#394548]">
             Filter by what you are looking for, scan approximate regions on the
             map, then use the results table below for details. Exact locations
-            and private contact details stay out of public discovery.
+            and private contact details stay out of discovery.
           </p>
         </header>
 
@@ -460,7 +456,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
           {results.length === 0 && !errorMessage ? (
             <section className="mt-5 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
               <h3 className="text-xl font-bold text-[#172023]">
-                No public discovery results match these filters yet
+                No discovery results match these filters yet
               </h3>
               <p className="mt-3 text-sm leading-6">
                 Try clearing filters, widening the country/region/locality, or

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
-import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
+import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
@@ -12,7 +13,6 @@ import {
   voicingPartValue,
 } from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type SingerMapRow = {
   country_code: string | null;
@@ -117,116 +117,112 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
   const kind = selectedKind(params.kind);
-  const supabase = await createSupabaseServerClient();
+  const supabase = await requireAuthenticatedDiscovery("/map", params);
 
   let mapItems: DiscoveryMapItem[] = [];
   let errorMessage: string | null = null;
 
-  if (!supabase) {
-    errorMessage = "Supabase is not configured for discovery map search yet.";
-  } else {
-    if (kind === "both" || kind === "singers") {
-      let query = supabase
-        .from("singer_discovery_profiles")
-        .select(
-          "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public",
-        )
-        .order("updated_at", { ascending: false });
+  if (kind === "both" || kind === "singers") {
+    let query = supabase
+      .from("singer_discovery_profiles")
+      .select(
+        "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public",
+      )
+      .order("updated_at", { ascending: false });
 
-      if (filters.country) {
-        query = query.ilike("country_name", `%${filters.country}%`);
-      }
-
-      if (filters.region) {
-        query = query.ilike("region", `%${filters.region}%`);
-      }
-
-      if (filters.locality) {
-        query = query.ilike("locality", `%${filters.locality}%`);
-      }
-
-      if (filters.part) {
-        query = query.contains("parts", [
-          voicingPartValue(filters.part.voicing, filters.part.part),
-        ]);
-      }
-
-      if (filters.goal) {
-        query = query.contains("goals", [filters.goal]);
-      }
-
-      const { data, error } = await query;
-
-      if (error) {
-        errorMessage = error.message;
-      } else {
-        mapItems = [
-          ...mapItems,
-          ...((data ?? []) as SingerMapRow[]).map((singer) => ({
-            countryCode: singer.country_code,
-            countryName: singer.country_name,
-            id: singer.id,
-            kind: "singer" as const,
-            locality: singer.locality,
-            locationLabelPublic: singer.location_label_public,
-            name: singer.display_name,
-            parts: singer.parts,
-            region: singer.region,
-          })),
-        ];
-      }
+    if (filters.country) {
+      query = query.ilike("country_name", `%${filters.country}%`);
     }
 
-    if (!errorMessage && (kind === "both" || kind === "quartets")) {
-      let query = supabase
-        .from("quartet_discovery_listings")
-        .select(
-          "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public",
-        )
-        .order("updated_at", { ascending: false });
+    if (filters.region) {
+      query = query.ilike("region", `%${filters.region}%`);
+    }
 
-      if (filters.country) {
-        query = query.ilike("country_name", `%${filters.country}%`);
-      }
+    if (filters.locality) {
+      query = query.ilike("locality", `%${filters.locality}%`);
+    }
 
-      if (filters.region) {
-        query = query.ilike("region", `%${filters.region}%`);
-      }
+    if (filters.part) {
+      query = query.contains("parts", [
+        voicingPartValue(filters.part.voicing, filters.part.part),
+      ]);
+    }
 
-      if (filters.locality) {
-        query = query.ilike("locality", `%${filters.locality}%`);
-      }
+    if (filters.goal) {
+      query = query.contains("goals", [filters.goal]);
+    }
 
-      if (filters.part) {
-        query = query.contains("parts_needed", [
-          voicingPartValue(filters.part.voicing, filters.part.part),
-        ]);
-      }
+    const { data, error } = await query;
 
-      if (filters.goal) {
-        query = query.contains("goals", [filters.goal]);
-      }
+    if (error) {
+      errorMessage = error.message;
+    } else {
+      mapItems = [
+        ...mapItems,
+        ...((data ?? []) as SingerMapRow[]).map((singer) => ({
+          countryCode: singer.country_code,
+          countryName: singer.country_name,
+          id: singer.id,
+          kind: "singer" as const,
+          locality: singer.locality,
+          locationLabelPublic: singer.location_label_public,
+          name: singer.display_name,
+          parts: singer.parts,
+          region: singer.region,
+        })),
+      ];
+    }
+  }
 
-      const { data, error } = await query;
+  if (!errorMessage && (kind === "both" || kind === "quartets")) {
+    let query = supabase
+      .from("quartet_discovery_listings")
+      .select(
+        "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public",
+      )
+      .order("updated_at", { ascending: false });
 
-      if (error) {
-        errorMessage = error.message;
-      } else {
-        mapItems = [
-          ...mapItems,
-          ...((data ?? []) as QuartetMapRow[]).map((quartet) => ({
-            countryCode: quartet.country_code,
-            countryName: quartet.country_name,
-            id: quartet.id,
-            kind: "quartet" as const,
-            locality: quartet.locality,
-            locationLabelPublic: quartet.location_label_public,
-            name: quartet.name,
-            parts: quartet.parts_needed,
-            region: quartet.region,
-          })),
-        ];
-      }
+    if (filters.country) {
+      query = query.ilike("country_name", `%${filters.country}%`);
+    }
+
+    if (filters.region) {
+      query = query.ilike("region", `%${filters.region}%`);
+    }
+
+    if (filters.locality) {
+      query = query.ilike("locality", `%${filters.locality}%`);
+    }
+
+    if (filters.part) {
+      query = query.contains("parts_needed", [
+        voicingPartValue(filters.part.voicing, filters.part.part),
+      ]);
+    }
+
+    if (filters.goal) {
+      query = query.contains("goals", [filters.goal]);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      errorMessage = error.message;
+    } else {
+      mapItems = [
+        ...mapItems,
+        ...((data ?? []) as QuartetMapRow[]).map((quartet) => ({
+          countryCode: quartet.country_code,
+          countryName: quartet.country_name,
+          id: quartet.id,
+          kind: "quartet" as const,
+          locality: quartet.locality,
+          locationLabelPublic: quartet.location_label_public,
+          name: quartet.name,
+          parts: quartet.parts_needed,
+          region: quartet.region,
+        })),
+      ];
     }
   }
 
@@ -244,7 +240,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
 
   return (
     <>
-      <PublicSiteHeader />
+      <SignedInSiteHeader />
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -89,9 +89,13 @@ export default function Home() {
             Share enough to be found, not enough to feel exposed.
           </h2>
           <p className="mt-4 text-base leading-7 text-[#394548]">
-            Public results use approximate locations, and first contact happens
-            through the app. You decide whether to respond or share direct
-            contact details.
+            Sign in to search quartet openings and singers. Discovery stays
+            behind sign-in, and results still use approximate locations. First
+            contact happens through the app, and you decide whether to respond
+            or share direct contact details.
+          </p>
+          <p className="mt-3 text-base leading-7 text-[#394548]">
+            Help and privacy information are available before sign-in.
           </p>
         </section>
 

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
 import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
-import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
+import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
@@ -15,7 +16,6 @@ import {
   voicingPartValue,
 } from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type QuartetDiscoveryRow = {
   availability: string | null;
@@ -122,62 +122,58 @@ export default async function QuartetSearchPage({
   const filters = parseDiscoveryFilters(params);
   const returnTo = returnToPath(params);
   const contactStatus = contactStatusMessage(params.contact);
-  const supabase = await createSupabaseServerClient();
+  const supabase = await requireAuthenticatedDiscovery("/quartets", params);
 
   let quartets: QuartetDiscoveryRow[] = [];
   let errorMessage: string | null = null;
 
-  if (!supabase) {
-    errorMessage = "Supabase is not configured for discovery search yet.";
+  let query = supabase
+    .from("quartet_discovery_listings")
+    .select(
+      "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, preferred_distance_unit, country_name, region, locality, location_label_public",
+    )
+    .order("updated_at", { ascending: false });
+
+  if (filters.country) {
+    query = query.ilike("country_name", `%${filters.country}%`);
+  }
+
+  if (filters.region) {
+    query = query.ilike("region", `%${filters.region}%`);
+  }
+
+  if (filters.locality) {
+    query = query.ilike("locality", `%${filters.locality}%`);
+  }
+
+  if (filters.part) {
+    query = query.contains("parts_needed", [
+      voicingPartValue(filters.part.voicing, filters.part.part),
+    ]);
+  }
+
+  if (filters.goal) {
+    query = query.contains("goals", [filters.goal]);
+  }
+
+  if (filters.experience) {
+    query = query.ilike("experience_level", `%${filters.experience}%`);
+  }
+
+  if (filters.availability) {
+    query = query.ilike("availability", `%${filters.availability}%`);
+  }
+
+  if (filters.travelRadiusKm != null) {
+    query = query.gte("travel_radius_km", filters.travelRadiusKm);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    errorMessage = error.message;
   } else {
-    let query = supabase
-      .from("quartet_discovery_listings")
-      .select(
-        "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, preferred_distance_unit, country_name, region, locality, location_label_public",
-      )
-      .order("updated_at", { ascending: false });
-
-    if (filters.country) {
-      query = query.ilike("country_name", `%${filters.country}%`);
-    }
-
-    if (filters.region) {
-      query = query.ilike("region", `%${filters.region}%`);
-    }
-
-    if (filters.locality) {
-      query = query.ilike("locality", `%${filters.locality}%`);
-    }
-
-    if (filters.part) {
-      query = query.contains("parts_needed", [
-        voicingPartValue(filters.part.voicing, filters.part.part),
-      ]);
-    }
-
-    if (filters.goal) {
-      query = query.contains("goals", [filters.goal]);
-    }
-
-    if (filters.experience) {
-      query = query.ilike("experience_level", `%${filters.experience}%`);
-    }
-
-    if (filters.availability) {
-      query = query.ilike("availability", `%${filters.availability}%`);
-    }
-
-    if (filters.travelRadiusKm != null) {
-      query = query.gte("travel_radius_km", filters.travelRadiusKm);
-    }
-
-    const { data, error } = await query;
-
-    if (error) {
-      errorMessage = error.message;
-    } else {
-      quartets = (data ?? []) as QuartetDiscoveryRow[];
-    }
+    quartets = (data ?? []) as QuartetDiscoveryRow[];
   }
 
   const { filterCount, flags } = filterAnalyticsProperties(filters);
@@ -195,7 +191,7 @@ export default async function QuartetSearchPage({
 
   return (
     <>
-      <PublicSiteHeader />
+      <SignedInSiteHeader />
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
 import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
-import { PublicSiteHeader } from "@/components/navigation/public-site-header";
+import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
+import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import { contactStatusMessage } from "@/lib/contact/contact-status";
 import {
   approximateLocationLabel,
@@ -15,7 +16,6 @@ import {
   voicingPartValue,
 } from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type SingerDiscoveryRow = {
   availability: string | null;
@@ -120,62 +120,58 @@ export default async function SingerSearchPage({
   const filters = parseDiscoveryFilters(params);
   const returnTo = returnToPath(params);
   const contactStatus = contactStatusMessage(params.contact);
-  const supabase = await createSupabaseServerClient();
+  const supabase = await requireAuthenticatedDiscovery("/singers", params);
 
   let singers: SingerDiscoveryRow[] = [];
   let errorMessage: string | null = null;
 
-  if (!supabase) {
-    errorMessage = "Supabase is not configured for discovery search yet.";
+  let query = supabase
+    .from("singer_discovery_profiles")
+    .select(
+      "id, display_name, parts, goals, experience_level, availability, travel_radius_km, preferred_distance_unit, country_name, region, locality, location_label_public",
+    )
+    .order("updated_at", { ascending: false });
+
+  if (filters.country) {
+    query = query.ilike("country_name", `%${filters.country}%`);
+  }
+
+  if (filters.region) {
+    query = query.ilike("region", `%${filters.region}%`);
+  }
+
+  if (filters.locality) {
+    query = query.ilike("locality", `%${filters.locality}%`);
+  }
+
+  if (filters.part) {
+    query = query.contains("parts", [
+      voicingPartValue(filters.part.voicing, filters.part.part),
+    ]);
+  }
+
+  if (filters.goal) {
+    query = query.contains("goals", [filters.goal]);
+  }
+
+  if (filters.experience) {
+    query = query.ilike("experience_level", `%${filters.experience}%`);
+  }
+
+  if (filters.availability) {
+    query = query.ilike("availability", `%${filters.availability}%`);
+  }
+
+  if (filters.travelRadiusKm != null) {
+    query = query.gte("travel_radius_km", filters.travelRadiusKm);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    errorMessage = error.message;
   } else {
-    let query = supabase
-      .from("singer_discovery_profiles")
-      .select(
-        "id, display_name, parts, goals, experience_level, availability, travel_radius_km, preferred_distance_unit, country_name, region, locality, location_label_public",
-      )
-      .order("updated_at", { ascending: false });
-
-    if (filters.country) {
-      query = query.ilike("country_name", `%${filters.country}%`);
-    }
-
-    if (filters.region) {
-      query = query.ilike("region", `%${filters.region}%`);
-    }
-
-    if (filters.locality) {
-      query = query.ilike("locality", `%${filters.locality}%`);
-    }
-
-    if (filters.part) {
-      query = query.contains("parts", [
-        voicingPartValue(filters.part.voicing, filters.part.part),
-      ]);
-    }
-
-    if (filters.goal) {
-      query = query.contains("goals", [filters.goal]);
-    }
-
-    if (filters.experience) {
-      query = query.ilike("experience_level", `%${filters.experience}%`);
-    }
-
-    if (filters.availability) {
-      query = query.ilike("availability", `%${filters.availability}%`);
-    }
-
-    if (filters.travelRadiusKm != null) {
-      query = query.gte("travel_radius_km", filters.travelRadiusKm);
-    }
-
-    const { data, error } = await query;
-
-    if (error) {
-      errorMessage = error.message;
-    } else {
-      singers = (data ?? []) as SingerDiscoveryRow[];
-    }
+    singers = (data ?? []) as SingerDiscoveryRow[];
   }
 
   const { filterCount, flags } = filterAnalyticsProperties(filters);
@@ -193,7 +189,7 @@ export default async function SingerSearchPage({
 
   return (
     <>
-      <PublicSiteHeader />
+      <SignedInSiteHeader />
       <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <div>
           <h1 className="mt-4 text-3xl font-bold text-[#172023]">

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -97,7 +97,7 @@ Singer profiles and quartet listings keep their own public
 display/location/travel details for discovery rows, and save actions infer
 `preferred_distance_unit` from country.
 
-The public discovery routes are:
+The signed-in discovery routes are:
 
 - `/find`, backed by both discovery views for consolidated filters, map, and
   results table
@@ -109,6 +109,10 @@ These routes may filter on public location fields, voicing-aware part, goals,
 experience/commitment, availability, and travel willingness. They should not
 read private base-table location or contact fields.
 
+These routes require authentication before reading discovery views. The views
+still expose only privacy-safe public fields, but anonymous visitors are
+redirected to sign in before browsing singers, quartet openings, or map results.
+
 ## Row Level Security expectations
 
 RLS should enforce:
@@ -117,7 +121,7 @@ RLS should enforce:
 - users can update/delete only their own singer profile
 - users can create quartet listings they own
 - users can update/delete only quartet listings they own
-- public discovery reads return only active/visible listings and profiles
+- discovery reads return only active/visible listings and profiles
 - private fields are not exposed in public discovery views
 - contact requests require an authenticated sender
 - recipients can read contact requests addressed to them or to listings they own

--- a/lib/auth/discovery-sign-in-path.ts
+++ b/lib/auth/discovery-sign-in-path.ts
@@ -1,0 +1,32 @@
+export type DiscoverySearchParams = Record<
+  string,
+  string | string[] | undefined
+>;
+
+export function pathWithSearch(
+  pathname: string,
+  params: DiscoverySearchParams = {},
+) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    const values = Array.isArray(value) ? value : [value];
+
+    for (const item of values) {
+      if (item) {
+        query.append(key, item);
+      }
+    }
+  }
+
+  const queryString = query.toString();
+
+  return queryString ? `${pathname}?${queryString}` : pathname;
+}
+
+export function discoverySignInPath(
+  pathname: string,
+  params: DiscoverySearchParams = {},
+) {
+  return `/sign-in?next=${encodeURIComponent(pathWithSearch(pathname, params))}`;
+}

--- a/lib/auth/require-authenticated-discovery.ts
+++ b/lib/auth/require-authenticated-discovery.ts
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+import {
+  discoverySignInPath,
+  type DiscoverySearchParams,
+} from "@/lib/auth/discovery-sign-in-path";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function requireAuthenticatedDiscovery(
+  pathname: string,
+  params: DiscoverySearchParams,
+) {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirect(discoverySignInPath(pathname, params));
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(discoverySignInPath(pathname, params));
+  }
+
+  return supabase;
+}

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -43,7 +43,7 @@ export const publicHelpSections = [
   },
   {
     body: [
-      "Public results show approximate places, such as a city or regional area. They do not show exact home addresses, exact coordinates, private postal codes, email addresses, or phone numbers.",
+      "Discovery results show approximate places, such as a city or regional area. They do not show exact home addresses, exact coordinates, private postal codes, email addresses, or phone numbers.",
       "Location fields are designed for a global barbershop community, so they are not limited to US ZIP codes or US states.",
     ],
     heading: "Location And Privacy",

--- a/test/authenticated-discovery.test.ts
+++ b/test/authenticated-discovery.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  discoverySignInPath,
+  pathWithSearch,
+} from "@/lib/auth/discovery-sign-in-path";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("authenticated discovery", () => {
+  it("preserves intended discovery destinations for sign-in redirects", () => {
+    expect(pathWithSearch("/find", { kind: "quartets" })).toBe(
+      "/find?kind=quartets",
+    );
+    expect(
+      pathWithSearch("/singers", {
+        country: "United Kingdom",
+        part: ["TTBB:Lead", "SSAA:Bass"],
+      }),
+    ).toBe("/singers?country=United+Kingdom&part=TTBB%3ALead&part=SSAA%3ABass");
+    expect(discoverySignInPath("/map", { kind: "singers" })).toBe(
+      "/sign-in?next=%2Fmap%3Fkind%3Dsingers",
+    );
+  });
+
+  it("gates every discovery page before reading discovery views", () => {
+    const pages = [
+      ["app/find/page.tsx", 'requireAuthenticatedDiscovery("/find", params)'],
+      [
+        "app/singers/page.tsx",
+        'requireAuthenticatedDiscovery("/singers", params)',
+      ],
+      [
+        "app/quartets/page.tsx",
+        'requireAuthenticatedDiscovery("/quartets", params)',
+      ],
+      ["app/map/page.tsx", 'requireAuthenticatedDiscovery("/map", params)'],
+    ];
+
+    for (const [path, gate] of pages) {
+      const page = source(path);
+
+      expect(page).toContain(gate);
+      expect(page.indexOf(gate)).toBeLessThan(page.indexOf(".from("));
+      expect(page).toContain("SignedInSiteHeader");
+      expect(page).not.toContain("PublicSiteHeader");
+    }
+  });
+
+  it("keeps signed-out page access limited to home, sign-in, help, and privacy", () => {
+    const publicPages = [
+      "app/page.tsx",
+      "app/sign-in/page.tsx",
+      "app/help/page.tsx",
+      "app/privacy/page.tsx",
+    ];
+    const gatedPages = [
+      "app/find/page.tsx",
+      "app/singers/page.tsx",
+      "app/quartets/page.tsx",
+      "app/map/page.tsx",
+      "app/(protected)/app/layout.tsx",
+    ];
+
+    for (const path of publicPages) {
+      expect(source(path)).not.toContain("requireAuthenticatedDiscovery");
+    }
+
+    for (const path of gatedPages) {
+      const page = source(path);
+
+      expect(page).toMatch(
+        /requireAuthenticatedDiscovery|redirect\("\/sign-in/,
+      );
+    }
+  });
+});

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -5,9 +5,13 @@ function source(path: string) {
   return readFileSync(path, "utf8");
 }
 
+function normalizedSource(path: string) {
+  return source(path).replace(/\s+/g, " ");
+}
+
 describe("public discovery copy", () => {
   it("makes the first-time path obvious on the public home page", () => {
-    const homePage = source("app/page.tsx");
+    const homePage = normalizedSource("app/page.tsx");
 
     expect(homePage).toContain("Sign in to get started");
     expect(homePage).toContain("First time here? Read Help");
@@ -17,6 +21,13 @@ describe("public discovery copy", () => {
     expect(homePage).toContain("Use either profile, or both.");
     expect(homePage).toContain("My Singer Profile");
     expect(homePage).toContain("My Quartet Profile");
+    expect(homePage).toContain(
+      "Sign in to search quartet openings and singers",
+    );
+    expect(homePage).toContain("Discovery stays behind sign-in");
+    expect(homePage).toContain(
+      "Help and privacy information are available before sign-in",
+    );
     expect(homePage).not.toContain(
       "Public discovery is open before you sign in.",
     );
@@ -24,7 +35,7 @@ describe("public discovery copy", () => {
       "look around before you decide what to share",
     );
     expect(homePage).toContain("approximate locations");
-    expect(homePage).toContain("first contact happens");
+    expect(homePage).toContain("First contact happens");
   });
 
   it("frames quartet discovery as openings for missing parts", () => {


### PR DESCRIPTION
Closes #81

## Summary
- Gate /find, /singers, /quartets, and /map behind sign-in before any discovery views are queried
- Preserve the intended destination in next when redirecting anonymous visitors to sign in
- Use the signed-in navigation shell on discovery pages after authentication
- Update home/help/privacy-facing copy so it is clear discovery stays behind sign-in
- Add tests for redirect URL preservation and discovery page gating

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build