### PR TITLE
Refine location fields and discoverability warning

### DIFF
--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -6,6 +6,7 @@ import {
   captureProductEvent,
   pseudonymousAnalyticsUserId,
 } from "@/lib/analytics/product-analytics";
+import { discoverabilityLocationWarning } from "@/lib/profiles/singer-profile-form";
 import {
   buildQuartetPublicLocationLabel,
   inferQuartetLocationPrecision,
@@ -140,5 +141,11 @@ export async function saveQuartetListing(formData: FormData) {
     },
     { distinctId: pseudonymousAnalyticsUserId(user.id) },
   );
-  redirectWithListingMessage("message", "Quartet listing saved.");
+  const locationWarning = discoverabilityLocationWarning(values);
+  redirectWithListingMessage(
+    "message",
+    locationWarning
+      ? `Quartet listing saved. ${locationWarning}`
+      : "Quartet listing saved.",
+  );
 }

--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -7,6 +7,7 @@ import {
 import {
   countryOptions,
   kilometersToRoundedMiles,
+  locationFieldLabelsForCountry,
 } from "@/lib/location/country-location-defaults";
 import { type Voicing } from "@/lib/parts/voicings";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -23,6 +24,7 @@ type QuartetListingRow = {
   locality: string | null;
   name: string;
   postal_code_private: string | null;
+  region: string | null;
   travel_radius_km: number | null;
 };
 
@@ -64,7 +66,7 @@ export default async function ManageListingsPage({
       ? await supabase
           .from("quartet_listings")
           .select(
-            "id, availability, country_name, description, experience_level, goals, is_visible, locality, name, postal_code_private, travel_radius_km",
+            "id, availability, country_name, description, experience_level, goals, is_visible, locality, name, postal_code_private, region, travel_radius_km",
           )
           .eq("owner_user_id", user.id)
           .order("created_at", { ascending: true })
@@ -91,6 +93,7 @@ export default async function ManageListingsPage({
       ?.filter((partRow) => partRow.status === "needed")
       .map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
   const selectedCountry = listing?.country_name ?? "United States";
+  const locationLabels = locationFieldLabelsForCountry(null, selectedCountry);
 
   return (
     <div>
@@ -199,7 +202,8 @@ export default async function ManageListingsPage({
           <p className="text-sm leading-6 text-[#394548]">
             Used only to place this listing approximately on the map and support
             location-based search. ZIP/postal code is not shown publicly, and
-            discovery shows an approximate area, not an exact address.
+            discovery shows an approximate area, not an exact address. No street
+            address is required.
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block">
@@ -225,7 +229,22 @@ export default async function ManageListingsPage({
               </select>
             </label>
             <label className="block">
-              <span className="text-sm font-semibold text-[#172023]">City</span>
+              <span className="text-sm font-semibold text-[#172023]">
+                {locationLabels.region}
+                <span className="font-normal text-[#596466]"> Optional</span>
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(listing?.region)}
+                maxLength={120}
+                name="region"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                {locationLabels.locality}
+                <span className="font-normal text-[#596466]"> Optional</span>
+              </span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
                 defaultValue={fieldValue(listing?.locality)}
@@ -235,7 +254,8 @@ export default async function ManageListingsPage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                ZIP/postal code
+                {locationLabels.postalCode}
+                <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
                 className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"

--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/analytics/product-analytics";
 import {
   buildPublicLocationLabel,
+  discoverabilityLocationWarning,
   inferLocationPrecision,
   parseSingerProfileFormData,
 } from "@/lib/profiles/singer-profile-form";
@@ -127,5 +128,11 @@ export async function saveSingerProfile(formData: FormData) {
     },
     { distinctId: pseudonymousAnalyticsUserId(user.id) },
   );
-  redirectWithProfileMessage("message", "Singer profile saved.");
+  const locationWarning = discoverabilityLocationWarning(values);
+  redirectWithProfileMessage(
+    "message",
+    locationWarning
+      ? `Singer profile saved. ${locationWarning}`
+      : "Singer profile saved.",
+  );
 }

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -7,6 +7,7 @@ import {
 import {
   countryOptions,
   kilometersToRoundedMiles,
+  locationFieldLabelsForCountry,
 } from "@/lib/location/country-location-defaults";
 import {
   VOICINGS,
@@ -29,6 +30,7 @@ type SingerProfileRow = {
   is_visible: boolean;
   locality: string | null;
   postal_code_private: string | null;
+  region: string | null;
   travel_radius_km: number | null;
 };
 
@@ -78,7 +80,7 @@ export default async function ManageProfilePage({
       ? await supabase
           .from("singer_profiles")
           .select(
-            "id, availability, bio, country_name, display_name, experience_level, goals, is_visible, locality, postal_code_private, travel_radius_km",
+            "id, availability, bio, country_name, display_name, experience_level, goals, is_visible, locality, postal_code_private, region, travel_radius_km",
           )
           .eq("user_id", user.id)
           .maybeSingle<SingerProfileRow>()
@@ -95,6 +97,7 @@ export default async function ManageProfilePage({
   const selectedParts =
     parts?.map((partRow) => `${partRow.voicing}:${partRow.part}`) ?? [];
   const selectedCountry = profile?.country_name ?? "United States";
+  const locationLabels = locationFieldLabelsForCountry(null, selectedCountry);
 
   return (
     <div>
@@ -255,7 +258,7 @@ export default async function ManageProfilePage({
             Used only to place you approximately on the map and support
             location-based search. Your ZIP/postal code is not shown publicly,
             and public discovery shows an approximate area, not your exact
-            location.
+            location. No street address is required.
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block">
@@ -283,7 +286,19 @@ export default async function ManageProfilePage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                City
+                {locationLabels.region}
+                <span className="font-normal text-[#596466]"> Optional</span>
+              </span>
+              <input
+                className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                defaultValue={fieldValue(profile?.region)}
+                maxLength={120}
+                name="region"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold text-[#172023]">
+                {locationLabels.locality}
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input
@@ -295,7 +310,7 @@ export default async function ManageProfilePage({
             </label>
             <label className="block">
               <span className="text-sm font-semibold text-[#172023]">
-                ZIP/postal code
+                {locationLabels.postalCode}
                 <span className="font-normal text-[#596466]"> Optional</span>
               </span>
               <input

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -50,8 +50,8 @@ The MVP can be English-only, but location and distance handling should be global
 
 ## Location handling
 
-Users enter a country, city, and ZIP/postal code where useful. Forms avoid
-country-code and admin-area language.
+Users enter country, state/province/region, city/locality, and ZIP/postal code
+where useful. Forms avoid country-code and street-address language.
 
 The app may store normalized location data to support distance search, but public UI should only expose approximate location.
 
@@ -59,9 +59,10 @@ Private geocoded data should be transformed into a public location summary
 before display. Public summaries may contain only locality/city, region when
 available, and country. They must not contain exact latitude, longitude, private
 postal code, formatted private address, or other precise address components.
-Until automatic geocoding is added, country plus city and ZIP/postal code are
-enough for the current approximate map/search approach because the map uses
-country/region anchors and public city/country labels rather than exact pins.
+Until automatic geocoding is added, country, region, city, and ZIP/postal code
+provide useful context for the current approximate map/search approach because
+the map uses country/region anchors and public city/country labels rather than
+exact pins.
 
 Distance helpers may use exact coordinates internally for matching later, but
 public distance display should be rounded and approximate. Find defaults
@@ -250,10 +251,15 @@ can appear in Find results and approximate map discovery. Hidden means it stays
 out of discovery. Filling out one profile does not require publishing it, and
 hiding one profile does not hide the other.
 
-Country on the singer profile or quartet listing drives practical defaults such
-as miles vs kilometers and country-aware labels like ZIP code, postcode, state,
-province, or region where practical. The app should keep those labels helpful
-without requiring strict international address validation.
+Singer profile and quartet profile location forms ask for country,
+state/province/region, city/locality, and ZIP/postal code. The fields remain
+optional for saving drafts, but if a user makes a profile discoverable with
+important location fields missing, the app warns that map placement and
+location-based search may be limited. Country on the singer profile or quartet
+listing drives practical defaults such as miles vs kilometers and country-aware
+labels like ZIP code, postcode, state, province, or region where practical. The
+app should keep those labels helpful without requiring strict international
+address validation or a street address.
 
 ## Abuse and safety considerations
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -91,6 +91,7 @@ validation.
    - parts: TTBB Lead and SATB Soprano / Mixed Tenor
    - goals: Pickup and Learning
    - country: United Kingdom
+   - region/county/state: England
    - city: Manchester
    - ZIP/postal code: `M1 TEST`
    - travel radius: `25` miles
@@ -115,6 +116,7 @@ validation.
    - needed parts: TTBB Lead and Baritone
    - goals: Regular Rehearsal and Contest
    - country: Ireland
+   - region/county/state: County Dublin
    - city: Dublin
    - ZIP/postal code: `D02 TEST`
    - travel radius: `30` miles

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -201,8 +201,9 @@ Current pattern:
 
 Application location helpers should treat base-table coordinates and private
 postal/address fields as internal matching data. User-facing profile/listing
-forms ask for country, city, and ZIP/postal code; they do not expose country
-code or admin-area fields. The reusable public transformation returns only
+forms ask for country, state/province/region, city/locality, and ZIP/postal
+code; they do not expose country code or street address fields. The reusable
+public transformation returns only
 `location_label_public`, `locality`, `region`, and `country_name` equivalents
 for display. Find can display travel-radius values in miles or kilometers, with
 miles as the default, while storage remains in kilometers.

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -66,7 +66,7 @@ export const publicHelpSections = [
   {
     body: [
       "Country is the first location cue because it helps the app use sensible labels, such as ZIP code, postcode, state, province, or region, without strict address validation.",
-      "Profile and listing forms ask for country, city, and ZIP/postal code instead of country codes or admin-area fields. ZIP/postal codes are not shown in discovery.",
+      "Profile and listing forms ask for country, state/province/region, city/locality, and ZIP/postal code instead of country codes or street addresses. ZIP/postal codes are not shown in discovery.",
       "Find defaults distance display to miles and lets you switch to kilometers when that is more useful.",
     ],
     heading: "Location Defaults",

--- a/lib/location/country-location-defaults.ts
+++ b/lib/location/country-location-defaults.ts
@@ -53,12 +53,12 @@ const labelOverrides: Record<string, LocationFieldLabels> = {
   CA: {
     locality: "City/locality",
     postalCode: "Postal code",
-    region: "Province/territory",
+    region: "Province/Territory",
   },
   GB: {
     locality: "Town/city",
     postalCode: "Postcode",
-    region: "Nation/county/region",
+    region: "Region/County/State",
   },
   IE: {
     locality: "Town/city",
@@ -73,14 +73,14 @@ const labelOverrides: Record<string, LocationFieldLabels> = {
   US: {
     locality: "City/locality",
     postalCode: "ZIP code",
-    region: "State/region",
+    region: "State",
   },
 };
 
 const defaultLocationFieldLabels: LocationFieldLabels = {
   locality: "Locality/city",
   postalCode: "Postal code",
-  region: "Region/admin area",
+  region: "State / province / region",
 };
 
 function normalizeCountryCodeValue(countryCode: string | null | undefined) {

--- a/lib/profiles/singer-profile-form.ts
+++ b/lib/profiles/singer-profile-form.ts
@@ -138,6 +138,28 @@ export function parseSingerProfileFormData(
   };
 }
 
+export function discoverabilityLocationWarning(
+  values: Pick<
+    SingerProfileFormValues,
+    "countryName" | "isVisible" | "locality" | "postalCodePrivate" | "region"
+  >,
+) {
+  if (!values.isVisible) {
+    return null;
+  }
+
+  if (
+    values.countryName &&
+    values.region &&
+    values.locality &&
+    values.postalCodePrivate
+  ) {
+    return null;
+  }
+
+  return "Discoverability will be limited without country, state/province/region, city, and ZIP/postal code. These are used only for approximate map placement and search; your ZIP/postal code is not shown publicly.";
+}
+
 export function inferLocationPrecision(
   values: Pick<
     SingerProfileFormValues,

--- a/test/location-defaults.test.ts
+++ b/test/location-defaults.test.ts
@@ -33,18 +33,24 @@ describe("country-aware location defaults", () => {
   it("adapts location field labels without strict address validation", () => {
     expect(locationFieldLabelsForCountry("US")).toMatchObject({
       postalCode: "ZIP code",
-      region: "State/region",
+      region: "State",
     });
     expect(locationFieldLabelsForCountry("CA")).toMatchObject({
       postalCode: "Postal code",
-      region: "Province/territory",
+      region: "Province/Territory",
     });
     expect(locationFieldLabelsForCountry(null, "United Kingdom")).toMatchObject(
       {
         postalCode: "Postcode",
-        region: "Nation/county/region",
+        region: "Region/County/State",
       },
     );
+    expect(
+      locationFieldLabelsForCountry(null, "Other / not listed"),
+    ).toMatchObject({
+      postalCode: "Postal code",
+      region: "State / province / region",
+    });
   });
 
   it("normalizes common country aliases", () => {

--- a/test/location-form-copy.test.ts
+++ b/test/location-form-copy.test.ts
@@ -16,14 +16,21 @@ const onboardingPage = readFileSync(
 const findPage = readFileSync("app/find/page.tsx", "utf8");
 
 describe("location and distance form copy", () => {
-  it("uses simple country, city, and ZIP/postal code fields", () => {
-    for (const source of [profilePage, listingPage, onboardingPage]) {
+  it("uses simple country, region, city, and ZIP/postal code fields", () => {
+    for (const source of [profilePage, listingPage]) {
       expect(source).toContain("Country");
-      expect(source).toContain("City");
-      expect(source).toContain("ZIP/postal code");
+      expect(source).toContain("locationLabels.region");
+      expect(source).toContain("locationLabels.locality");
+      expect(source).toContain("locationLabels.postalCode");
+      expect(source).toContain('name="region"');
+      expect(source).toContain('name="locality"');
+      expect(source).toContain('name="postalCodePrivate"');
       expect(source).not.toContain("Country code");
-      expect(source).not.toContain("Region/admin");
     }
+    expect(onboardingPage).toContain("Country");
+    expect(onboardingPage).toContain("City");
+    expect(onboardingPage).toContain("ZIP/postal code");
+    expect(onboardingPage).not.toContain("Country code");
   });
 
   it("keeps ZIP/postal code private and approximate", () => {
@@ -32,6 +39,24 @@ describe("location and distance form copy", () => {
     expect(onboardingPage).toContain("not shown publicly");
     expect(profilePage).toContain("approximate area");
     expect(listingPage).toContain("approximate area");
+    expect(profilePage).toContain("No street address is required");
+    expect(listingPage).toContain("No street");
+  });
+
+  it("warns when discoverable profiles have incomplete location fields", () => {
+    const profileAction = readFileSync(
+      "app/(protected)/app/profile/actions.ts",
+      "utf8",
+    );
+    const listingAction = readFileSync(
+      "app/(protected)/app/listings/actions.ts",
+      "utf8",
+    );
+
+    expect(profileAction).toContain("discoverabilityLocationWarning");
+    expect(listingAction).toContain("discoverabilityLocationWarning");
+    expect(profileAction).toContain("Singer profile saved.");
+    expect(listingAction).toContain("Quartet listing saved.");
   });
 
   it("puts the miles/kilometers picker only on Find", () => {

--- a/test/quartet-listing-form.test.ts
+++ b/test/quartet-listing-form.test.ts
@@ -21,6 +21,7 @@ describe("quartet listing form parsing", () => {
       formData([
         ["name", "Harbour Lights"],
         ["countryName", "Canada"],
+        ["region", "Ontario"],
         ["locality", "Toronto"],
         ["postalCodePrivate", "M5V"],
         ["voicing", "TTBB"],
@@ -33,6 +34,7 @@ describe("quartet listing form parsing", () => {
     );
 
     expect(values.countryCode).toBe("CA");
+    expect(values.region).toBe("Ontario");
     expect(values.postalCodePrivate).toBe("M5V");
     expect(values.partsCovered).toEqual([
       { part: "Lead", voicing: "TTBB" },

--- a/test/singer-profile-form.test.ts
+++ b/test/singer-profile-form.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPublicLocationLabel,
+  discoverabilityLocationWarning,
   inferLocationPrecision,
   parseSingerProfileFormData,
 } from "@/lib/profiles/singer-profile-form";
@@ -35,6 +36,7 @@ describe("singer profile form parsing", () => {
       formData([
         ["displayName", "Priya"],
         ["countryName", "United Kingdom"],
+        ["region", "England"],
         ["locality", "Manchester"],
         ["postalCodePrivate", "M1 1AE"],
         ["parts", "TTBB:Lead"],
@@ -45,6 +47,7 @@ describe("singer profile form parsing", () => {
     );
 
     expect(values.countryCode).toBe("GB");
+    expect(values.region).toBe("England");
     expect(values.postalCodePrivate).toBe("M1 1AE");
     expect(values.parts).toEqual([
       { part: "Lead", voicing: "TTBB" },
@@ -84,6 +87,38 @@ describe("singer profile form parsing", () => {
     expect(buildPublicLocationLabel(values)).toBe("Toronto, Canada area");
     expect(buildPublicLocationLabel(values)).not.toContain("M5V");
     expect(inferLocationPrecision(values)).toBe("postal_code");
+  });
+
+  it("warns when discoverable profiles have incomplete location", () => {
+    const hiddenValues = parseSingerProfileFormData(
+      formData([
+        ["displayName", "Ari"],
+        ["countryName", "Canada"],
+      ]),
+    );
+    const visibleValues = parseSingerProfileFormData(
+      formData([
+        ["displayName", "Ari"],
+        ["countryName", "Canada"],
+        ["isVisible", "on"],
+      ]),
+    );
+    const completeVisibleValues = parseSingerProfileFormData(
+      formData([
+        ["displayName", "Ari"],
+        ["countryName", "Canada"],
+        ["region", "Ontario"],
+        ["locality", "Toronto"],
+        ["postalCodePrivate", "M5V"],
+        ["isVisible", "on"],
+      ]),
+    );
+
+    expect(discoverabilityLocationWarning(hiddenValues)).toBeNull();
+    expect(discoverabilityLocationWarning(visibleValues)).toContain(
+      "Discoverability will be limited",
+    );
+    expect(discoverabilityLocationWarning(completeVisibleValues)).toBeNull();
   });
 
   it("requires a display name", () => {


### PR DESCRIPTION
Closes #85

## Summary
- Add state/province/region fields back to My Singer Profile and My Quartet Profile location forms
- Use country-aware location labels for region, locality, and postal code fields
- Allow saves with incomplete location, but warn when a discoverable profile/listing lacks country, region, city, or ZIP/postal code
- Update Help/Privacy-facing docs and smoke test guidance for the restored region model
- Add tests for US, Canada, fallback labels, region parsing, and discoverability warnings

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build