### PR TITLE
Redesign Find into map and card discovery experience

### DIFF
--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -1,15 +1,15 @@
-import Link from "next/link";
+import { ContactRequestForm } from "@/components/contact/contact-request-form";
 import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import {
-  buildDiscoveryMapMarkers,
-  type DiscoveryMapItem,
-} from "@/lib/location/map-markers";
-import {
   approximateLocationLabel,
   travelRadiusLabel,
 } from "@/lib/location/approximate-location";
+import {
+  buildDiscoveryMapMarkers,
+  type DiscoveryMapItem,
+} from "@/lib/location/map-markers";
 import {
   groupVoicingParts,
   voicingPartOptions,
@@ -18,9 +18,11 @@ import {
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 
 type SingerFindRow = {
+  availability: string | null;
   country_code: string | null;
   country_name: string | null;
   display_name: string;
+  experience_level: string | null;
   goals: string[];
   id: string;
   locality: string | null;
@@ -31,13 +33,17 @@ type SingerFindRow = {
 };
 
 type QuartetFindRow = {
+  availability: string | null;
   country_code: string | null;
   country_name: string | null;
+  description: string | null;
+  experience_level: string | null;
   goals: string[];
   id: string;
   locality: string | null;
   location_label_public: string | null;
   name: string;
+  parts_covered: string[];
   parts_needed: string[];
   region: string | null;
   travel_radius_km: number | null;
@@ -48,15 +54,21 @@ type FindPageProps = {
 };
 
 type FindResult = DiscoveryMapItem & {
-  detailHref: string;
-  intentLabel: string;
+  availability: string | null;
+  description: string | null;
+  experienceLevel: string | null;
+  goals: string[];
+  partsCovered: string[];
+  partsNeeded: string[];
+  resultLabel: string;
+  targetKind: "quartet" | "singer";
   travelRadiusKm: number | null;
 };
 
 const kindOptions = [
-  ["both", "Singers and quartet openings"],
   ["quartets", "Quartet openings"],
   ["singers", "Singers"],
+  ["both", "Both"],
 ];
 
 const partOptions = voicingPartOptions("Any voicing / part");
@@ -79,18 +91,30 @@ const distanceUnitOptions = [
 const filterControlClass =
   "mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20";
 
-function textValue(value: string | null) {
-  return value ?? "";
+function textValue(value: string | null | number) {
+  return value == null ? "" : String(value);
 }
 
 function selectedKind(value: string | string[] | undefined) {
   const rawValue = Array.isArray(value) ? value[0] : value;
 
-  return rawValue === "singers" || rawValue === "quartets" ? rawValue : "both";
+  return rawValue === "singers" || rawValue === "both" ? rawValue : "quartets";
+}
+
+function tags(values: string[]) {
+  return values.map((value) => value.replaceAll("_", " ")).join(", ");
+}
+
+function preview(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  return value.length > 180 ? `${value.slice(0, 177)}...` : value;
 }
 
 function partsLabel(values: string[]) {
-  return groupVoicingParts(values) || "Any";
+  return groupVoicingParts(values) || "Not listed";
 }
 
 function locationLabel(item: FindResult) {
@@ -100,6 +124,26 @@ function locationLabel(item: FindResult) {
     locationLabelPublic: item.locationLabelPublic,
     region: item.region,
   });
+}
+
+function selectedPartValues(filters: ReturnType<typeof parseDiscoveryFilters>) {
+  return filters.parts.map((part) => voicingPartValue(part.voicing, part.part));
+}
+
+function resultMatchesSelectedParts(
+  result: FindResult,
+  selectedParts: string[],
+) {
+  if (selectedParts.length === 0) {
+    return true;
+  }
+
+  const searchableParts =
+    result.kind === "quartet"
+      ? result.partsNeeded
+      : [...result.parts, ...result.partsNeeded];
+
+  return selectedParts.some((part) => searchableParts.includes(part));
 }
 
 function markerSummary(marker: { names: string[] }) {
@@ -123,15 +167,32 @@ function markerKindLabel(marker: { count: number; kinds: string[] }) {
   return marker.count === 1 ? "singer" : "singers";
 }
 
+function returnToPath(params: Record<string, string | string[] | undefined>) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    const values = Array.isArray(value) ? value : [value];
+
+    for (const item of values) {
+      if (item) {
+        query.append(key, item);
+      }
+    }
+  }
+
+  const queryString = query.toString();
+
+  return queryString ? `/find?${queryString}` : "/find";
+}
+
 function filterAnalyticsProperties(
   filters: ReturnType<typeof parseDiscoveryFilters>,
 ) {
   const flags = {
-    has_country_filter: Boolean(filters.country),
     has_goal_filter: Boolean(filters.goal),
-    has_locality_filter: Boolean(filters.locality),
-    has_part_filter: Boolean(filters.part),
-    has_region_filter: Boolean(filters.region),
+    has_part_filter: filters.parts.length > 0,
+    has_radius: filters.radius != null,
+    has_search_origin: Boolean(filters.searchFrom),
   };
   const filterCount = Object.values(flags).filter(Boolean).length;
 
@@ -142,6 +203,8 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
   const kind = selectedKind(params.kind);
+  const selectedParts = selectedPartValues(filters);
+  const returnTo = returnToPath(params);
   const supabase = await requireAuthenticatedDiscovery("/find", params);
 
   let results: FindResult[] = [];
@@ -151,27 +214,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     let query = supabase
       .from("singer_discovery_profiles")
       .select(
-        "id, display_name, parts, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
+        "id, display_name, parts, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
       )
       .order("updated_at", { ascending: false });
-
-    if (filters.country) {
-      query = query.ilike("country_name", `%${filters.country}%`);
-    }
-
-    if (filters.region) {
-      query = query.ilike("region", `%${filters.region}%`);
-    }
-
-    if (filters.locality) {
-      query = query.ilike("locality", `%${filters.locality}%`);
-    }
-
-    if (filters.part) {
-      query = query.contains("parts", [
-        voicingPartValue(filters.part.voicing, filters.part.part),
-      ]);
-    }
 
     if (filters.goal) {
       query = query.contains("goals", [filters.goal]);
@@ -185,17 +230,23 @@ export default async function FindPage({ searchParams }: FindPageProps) {
       results = [
         ...results,
         ...((data ?? []) as SingerFindRow[]).map((singer) => ({
+          availability: singer.availability,
           countryCode: singer.country_code,
           countryName: singer.country_name,
-          detailHref: "/singers",
+          description: null,
+          experienceLevel: singer.experience_level,
+          goals: singer.goals,
           id: singer.id,
-          intentLabel: "Singer profile",
           kind: "singer" as const,
           locality: singer.locality,
           locationLabelPublic: singer.location_label_public,
           name: singer.display_name,
           parts: singer.parts,
+          partsCovered: [],
+          partsNeeded: [],
           region: singer.region,
+          resultLabel: "Singer",
+          targetKind: "singer" as const,
           travelRadiusKm: singer.travel_radius_km,
         })),
       ];
@@ -206,27 +257,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     let query = supabase
       .from("quartet_discovery_listings")
       .select(
-        "id, name, parts_needed, goals, country_code, country_name, region, locality, location_label_public, travel_radius_km",
+        "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
       )
       .order("updated_at", { ascending: false });
-
-    if (filters.country) {
-      query = query.ilike("country_name", `%${filters.country}%`);
-    }
-
-    if (filters.region) {
-      query = query.ilike("region", `%${filters.region}%`);
-    }
-
-    if (filters.locality) {
-      query = query.ilike("locality", `%${filters.locality}%`);
-    }
-
-    if (filters.part) {
-      query = query.contains("parts_needed", [
-        voicingPartValue(filters.part.voicing, filters.part.part),
-      ]);
-    }
 
     if (filters.goal) {
       query = query.contains("goals", [filters.goal]);
@@ -240,25 +273,39 @@ export default async function FindPage({ searchParams }: FindPageProps) {
       results = [
         ...results,
         ...((data ?? []) as QuartetFindRow[]).map((quartet) => ({
+          availability: quartet.availability,
           countryCode: quartet.country_code,
           countryName: quartet.country_name,
-          detailHref: "/quartets",
+          description: quartet.description,
+          experienceLevel: quartet.experience_level,
+          goals: quartet.goals,
           id: quartet.id,
-          intentLabel: "Quartet opening",
           kind: "quartet" as const,
           locality: quartet.locality,
           locationLabelPublic: quartet.location_label_public,
           name: quartet.name,
           parts: quartet.parts_needed,
+          partsCovered: quartet.parts_covered,
+          partsNeeded: quartet.parts_needed,
           region: quartet.region,
+          resultLabel: "Quartet opening",
+          targetKind: "quartet" as const,
           travelRadiusKm: quartet.travel_radius_km,
         })),
       ];
     }
   }
 
+  results = results.filter((result) =>
+    resultMatchesSelectedParts(result, selectedParts),
+  );
+
   const markers = buildDiscoveryMapMarkers(results);
   const { filterCount, flags } = filterAnalyticsProperties(filters);
+  const radiusLabel =
+    filters.radius == null
+      ? "Any distance"
+      : `${filters.radius} ${filters.distanceUnit === "km" ? "kilometers" : "miles"}`;
 
   await captureProductEvent("map_viewed", {
     ...flags,
@@ -272,271 +319,364 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   return (
     <>
       <SignedInSiteHeader />
-      <main className="mx-auto w-full max-w-6xl px-6 py-12">
-        <header>
+      <main className="mx-auto w-full max-w-7xl px-6 py-8">
+        <header className="max-w-4xl">
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
             Find
           </p>
-          <h1 className="mt-4 text-4xl font-bold text-[#172023]">
-            Search singers and quartet openings in one place.
+          <h1 className="mt-3 text-3xl font-bold text-[#172023] sm:text-4xl">
+            Search quartet openings and singers from one discovery map.
           </h1>
-          <p className="mt-4 max-w-3xl text-base leading-7 text-[#394548]">
-            Filter by what you are looking for, scan approximate regions on the
-            map, then use the results table below for details. Exact locations
-            and private contact details stay out of discovery.
+          <p className="mt-4 text-base leading-7 text-[#394548]">
+            Start with a place, radius, parts, and intent. Results use
+            approximate locations only, and contact stays inside Quartet Member
+            Finder until both people choose to share direct details.
           </p>
         </header>
 
         <form
           aria-label="Filter discovery results"
-          className="mt-8 grid gap-4 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 sm:grid-cols-2 lg:grid-cols-5"
+          className="mt-6 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 shadow-sm"
         >
-          <label className="block">
-            <span className="text-sm font-semibold">Looking for</span>
-            <select
-              className={filterControlClass}
-              defaultValue={kind}
-              name="kind"
-            >
-              {kindOptions.map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold">Country</span>
-            <input
-              className={filterControlClass}
-              defaultValue={textValue(filters.country)}
-              name="country"
-              placeholder="Canada"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold">Region</span>
-            <input
-              className={filterControlClass}
-              defaultValue={textValue(filters.region)}
-              name="region"
-              placeholder="Ontario"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold">Locality</span>
-            <input
-              className={filterControlClass}
-              defaultValue={textValue(filters.locality)}
-              name="locality"
-              placeholder="Toronto"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold">Part</span>
-            <select
-              className={filterControlClass}
-              defaultValue={
-                filters.part
-                  ? voicingPartValue(filters.part.voicing, filters.part.part)
-                  : ""
-              }
-              name="part"
-            >
-              {partOptions.map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold">Goal</span>
-            <select
-              className={filterControlClass}
-              defaultValue={textValue(filters.goal)}
-              name="goal"
-            >
-              {goalOptions.map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="block">
-            <span className="text-sm font-semibold">Distance units</span>
-            <select
-              className={filterControlClass}
-              defaultValue={filters.distanceUnit}
-              name="distanceUnit"
-            >
-              {distanceUnitOptions.map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="flex flex-col gap-3 sm:col-span-2 sm:flex-row sm:items-end lg:col-span-3">
-            <button
-              className="rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
-              type="submit"
-            >
-              Search
-            </button>
-            <Link
-              className="inline-flex min-h-11 items-center rounded-md px-2 py-2 font-semibold text-[#2f6f73] hover:bg-white/70"
-              href="/find"
-            >
-              Clear
-            </Link>
+          <div className="grid gap-4 lg:grid-cols-[1fr_1.4fr_0.7fr_0.9fr]">
+            <label className="block">
+              <span className="text-sm font-semibold">Looking for</span>
+              <select
+                className={filterControlClass}
+                defaultValue={kind}
+                name="kind"
+              >
+                {kindOptions.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-semibold">Search from</span>
+              <input
+                className={filterControlClass}
+                defaultValue={textValue(filters.searchFrom)}
+                name="searchFrom"
+                placeholder="Fort Collins, CO or M5V, Canada"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-semibold">Within</span>
+              <input
+                className={filterControlClass}
+                defaultValue={textValue(filters.radius)}
+                min={1}
+                name="radius"
+                placeholder="25"
+                type="number"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-semibold">Distance units</span>
+              <select
+                className={filterControlClass}
+                defaultValue={filters.distanceUnit}
+                name="distanceUnit"
+              >
+                {distanceUnitOptions.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-[1.5fr_1fr_auto]">
+            <label className="block">
+              <span className="text-sm font-semibold">Parts</span>
+              <select
+                className={`${filterControlClass} min-h-32`}
+                defaultValue={selectedParts}
+                multiple
+                name="part"
+              >
+                {partOptions.slice(1).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-2 block text-xs leading-5 text-[#596466]">
+                Select one or more voicing-aware parts. Leave blank for any
+                part.
+              </span>
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-semibold">Goal</span>
+              <select
+                className={filterControlClass}
+                defaultValue={textValue(filters.goal)}
+                name="goal"
+              >
+                {goalOptions.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="flex flex-col gap-3 lg:justify-end">
+              <button
+                className="rounded-md bg-[#174b4f] px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c]"
+                type="submit"
+              >
+                Search
+              </button>
+              <a
+                className="inline-flex min-h-11 items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-[#2f6f73] hover:bg-white/70"
+                href="/find"
+              >
+                Clear filters
+              </a>
+            </div>
+          </div>
+
+          <p className="mt-4 rounded-md border border-[#d7cec0] bg-white/70 p-3 text-sm leading-6 text-[#394548]">
+            Radius search is ready in the interface, but exact
+            distance-from-place filtering is not enabled until approximate
+            geocoding is added. The current result set still uses privacy-safe
+            discovery data and approximate map regions.
+          </p>
         </form>
 
         {errorMessage ? (
           <p
-            className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
             role="alert"
           >
             {errorMessage}
           </p>
         ) : null}
 
-        <section className="mt-8 overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]">
-          <div
-            aria-label="Privacy-safe discovery map"
-            className="relative min-h-[520px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)] sm:min-h-[420px]"
-            role="img"
+        <section className="mt-6 grid gap-6 xl:grid-cols-[minmax(22rem,0.9fr)_minmax(0,1.1fr)]">
+          <section
+            aria-labelledby="map-heading"
+            className="overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]"
           >
-            <div className="absolute inset-x-0 top-0 flex flex-col gap-1 bg-white/85 px-4 py-3 text-sm text-[#394548] backdrop-blur sm:flex-row sm:items-center sm:justify-between">
-              <span>{markers.length} approximate regions</span>
-              <span>{results.length} visible discovery results</span>
-            </div>
-
-            {markers.map((marker) => (
-              <div
-                className="absolute max-w-[10rem] -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm [overflow-wrap:anywhere] sm:max-w-48"
-                key={marker.id}
-                style={{
-                  left: `${marker.xPercent}%`,
-                  top: `${marker.yPercent}%`,
-                }}
-              >
-                <p className="font-bold text-[#172023]">{marker.label}</p>
-                <p className="mt-1 text-[#394548]">
-                  {marker.count} {markerKindLabel(marker)}
-                </p>
-                {marker.parts.length > 0 ? (
-                  <p className="mt-1 text-[#596466]">
-                    {partsLabel(marker.parts)}
-                  </p>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="mt-8">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h2 className="text-2xl font-bold text-[#172023]">
-                Results table
+            <div className="border-b border-[#d7cec0] bg-white/85 px-4 py-3">
+              <h2 className="font-bold text-[#172023]" id="map-heading">
+                Approximate map scope
               </h2>
-              <p className="mt-2 text-sm text-[#394548]">
-                Use the table for details after scanning the map.
+              <p className="mt-1 text-sm text-[#394548]">
+                {results.length} results across {markers.length} approximate
+                regions. Scope:{" "}
+                {textValue(filters.searchFrom) || "all visible areas"}; radius:{" "}
+                {radiusLabel}.
               </p>
             </div>
-            <div className="flex flex-wrap gap-3 text-sm font-semibold text-[#2f6f73]">
-              <Link href="/quartets">Detailed quartet search</Link>
-              <Link href="/singers">Detailed singer search</Link>
+            <div
+              aria-label="Privacy-safe discovery map"
+              className="relative min-h-[460px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)]"
+              role="img"
+            >
+              {markers.length === 0 ? (
+                <div className="absolute inset-x-6 top-8 rounded-lg border border-[#d7cec0] bg-white/90 p-5 text-sm leading-6 text-[#394548] shadow-sm">
+                  No approximate map regions match. Try increasing the radius,
+                  clearing part filters, or changing what you are looking for.
+                </div>
+              ) : null}
+
+              {markers.map((marker) => (
+                <a
+                  className="absolute max-w-[10rem] -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm [overflow-wrap:anywhere] hover:border-[#174b4f] focus:outline-none focus:ring-2 focus:ring-[#174b4f]"
+                  href={`#result-${marker.resultIds[0]}`}
+                  key={marker.id}
+                  style={{
+                    left: `${marker.xPercent}%`,
+                    top: `${marker.yPercent}%`,
+                  }}
+                >
+                  <span className="block font-bold text-[#172023]">
+                    {marker.label}
+                  </span>
+                  <span className="mt-1 block text-[#394548]">
+                    {marker.count} {markerKindLabel(marker)}
+                  </span>
+                  {marker.parts.length > 0 ? (
+                    <span className="mt-1 block text-[#596466]">
+                      {partsLabel(marker.parts)}
+                    </span>
+                  ) : null}
+                </a>
+              ))}
             </div>
-          </div>
+          </section>
 
-          {results.length === 0 && !errorMessage ? (
-            <section className="mt-5 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
-              <h3 className="text-xl font-bold text-[#172023]">
-                No discovery results match these filters yet
-              </h3>
-              <p className="mt-3 text-sm leading-6">
-                Try clearing filters, widening the country/region/locality, or
-                switching what you are looking for.
-              </p>
-            </section>
-          ) : null}
+          <section aria-labelledby="results-heading">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2
+                  className="text-2xl font-bold text-[#172023]"
+                  id="results-heading"
+                >
+                  Matching results
+                </h2>
+                <p className="mt-1 text-sm text-[#394548]">
+                  Cards and detail panels show only privacy-safe discovery
+                  fields.
+                </p>
+              </div>
+            </div>
 
-          {results.length > 0 ? (
-            <div className="mt-5 overflow-x-auto rounded-lg border border-[#d7cec0] bg-[#fffaf2]">
-              <table className="w-full min-w-[46rem] border-collapse text-left text-sm">
-                <thead className="bg-white/70 text-[#172023]">
-                  <tr>
-                    <th className="px-4 py-3 font-bold">Result</th>
-                    <th className="px-4 py-3 font-bold">Type</th>
-                    <th className="px-4 py-3 font-bold">Parts</th>
-                    <th className="px-4 py-3 font-bold">Approximate area</th>
-                    <th className="px-4 py-3 font-bold">Travel</th>
-                    <th className="px-4 py-3 font-bold">Next step</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {results.map((result) => (
-                    <tr
-                      className="border-t border-[#d7cec0] align-top"
-                      key={`${result.kind}-${result.id}`}
-                    >
-                      <td className="px-4 py-3 font-semibold text-[#172023]">
+            {results.length === 0 && !errorMessage ? (
+              <section className="mt-5 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
+                <h3 className="text-xl font-bold text-[#172023]">
+                  No results match this search yet
+                </h3>
+                <p className="mt-3 text-sm leading-6">
+                  Try increasing the radius, selecting fewer parts, clearing
+                  goal filters, or searching both singers and quartet openings.
+                  If no origin is entered, add a city/region/country or postal
+                  code to make the search easier to interpret.
+                </p>
+              </section>
+            ) : null}
+
+            <div className="mt-5 grid gap-4">
+              {results.map((result) => (
+                <article
+                  className="scroll-mt-8 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+                  id={`result-${result.id}`}
+                  key={`${result.kind}-${result.id}`}
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#2f6f73]">
+                        {result.resultLabel}
+                      </p>
+                      <h3 className="mt-2 text-2xl font-bold text-[#172023]">
                         {result.name}
-                      </td>
-                      <td className="px-4 py-3 text-[#394548]">
-                        {result.intentLabel}
-                      </td>
-                      <td className="px-4 py-3 text-[#394548]">
-                        {partsLabel(result.parts)}
-                      </td>
-                      <td className="px-4 py-3 text-[#394548]">
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-[#394548]">
                         {locationLabel(result)}
-                      </td>
-                      <td className="px-4 py-3 text-[#394548]">
+                      </p>
+                    </div>
+                    <a
+                      className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-sm font-semibold text-[#174b4f] hover:border-[#174b4f]"
+                      href={`#details-${result.id}`}
+                    >
+                      More details
+                    </a>
+                  </div>
+
+                  <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+                    <div>
+                      <dt className="font-semibold text-[#172023]">
+                        {result.kind === "quartet"
+                          ? "Parts needed"
+                          : "Parts sung"}
+                      </dt>
+                      <dd className="mt-1 text-[#394548]">
+                        {partsLabel(
+                          result.kind === "quartet"
+                            ? result.partsNeeded
+                            : result.parts,
+                        )}
+                      </dd>
+                    </div>
+                    {result.kind === "quartet" ? (
+                      <div>
+                        <dt className="font-semibold text-[#172023]">
+                          Parts covered
+                        </dt>
+                        <dd className="mt-1 text-[#394548]">
+                          {partsLabel(result.partsCovered)}
+                        </dd>
+                      </div>
+                    ) : null}
+                    <div>
+                      <dt className="font-semibold text-[#172023]">Goals</dt>
+                      <dd className="mt-1 text-[#394548]">
+                        {result.goals.length > 0
+                          ? tags(result.goals)
+                          : "Not listed"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="font-semibold text-[#172023]">Travel</dt>
+                      <dd className="mt-1 text-[#394548]">
                         {travelRadiusLabel(
                           result.travelRadiusKm,
                           filters.distanceUnit,
                         ) ?? "Not listed"}
-                      </td>
-                      <td className="px-4 py-3">
-                        <Link
-                          className="font-semibold text-[#2f6f73]"
-                          href={result.detailHref}
-                        >
-                          Open detailed search
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+                      </dd>
+                    </div>
+                  </dl>
+
+                  {preview(result.description) ? (
+                    <p className="mt-4 text-sm leading-6 text-[#394548]">
+                      {preview(result.description)}
+                    </p>
+                  ) : null}
+
+                  <details
+                    className="mt-4 rounded-md border border-[#d7cec0] bg-white p-4"
+                    id={`details-${result.id}`}
+                  >
+                    <summary className="cursor-pointer text-base font-bold text-[#172023]">
+                      {result.name} details and contact
+                    </summary>
+                    <div className="mt-4 grid gap-3 text-sm leading-6 text-[#394548]">
+                      <p>
+                        <span className="font-semibold text-[#172023]">
+                          Approximate area:
+                        </span>{" "}
+                        {locationLabel(result)}
+                      </p>
+                      <p>
+                        <span className="font-semibold text-[#172023]">
+                          Experience/commitment:
+                        </span>{" "}
+                        {result.experienceLevel ?? "Not listed"}
+                      </p>
+                      <p>
+                        <span className="font-semibold text-[#172023]">
+                          Availability:
+                        </span>{" "}
+                        {result.availability ?? "Not listed"}
+                      </p>
+                      {result.description ? <p>{result.description}</p> : null}
+                    </div>
+                    <ContactRequestForm
+                      returnTo={returnTo}
+                      targetId={result.id}
+                      targetKind={result.targetKind}
+                      targetName={result.name}
+                    />
+                  </details>
+                </article>
+              ))}
             </div>
-          ) : null}
+          </section>
         </section>
 
         {markers.length > 0 ? (
-          <section className="mt-8 grid gap-4 md:grid-cols-2">
+          <section className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {markers.map((marker) => (
               <article
                 className="rounded-lg border border-[#d7cec0] bg-white/60 p-5 shadow-sm"
                 key={marker.id}
               >
-                <h2 className="text-xl font-bold text-[#172023]">
+                <h2 className="text-lg font-bold text-[#172023]">
                   {marker.label}
                 </h2>
                 <p className="mt-2 text-sm text-[#394548]">
                   {marker.count} visible result{marker.count === 1 ? "" : "s"}:
                   {" " + markerSummary(marker)}
                 </p>
-                {marker.parts.length > 0 ? (
-                  <p className="mt-3 text-sm font-semibold text-[#2f6f73]">
-                    {partsLabel(marker.parts)}
-                  </p>
-                ) : null}
               </article>
             ))}
           </section>

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -135,17 +135,21 @@ validation.
 ## Find
 
 1. Open `/find`.
-2. Filter by country, region/locality, part, goal, and looking-for mode using
-   data known to exist in the environment.
-3. Pass: the distance-unit picker defaults to Miles and can be changed to
-   Kilometers for travel-radius display.
-4. Pass: valid filters narrow the consolidated results without crashing.
-5. Pass: the approximate map appears above the results table.
-6. Pass: the table distinguishes singer profiles from quartet openings.
-7. Pass: empty results show helpful next actions, including clearing filters.
-8. Fail: hidden or inactive profiles/listings appear in public results.
-9. Fail: public UI exposes owner user IDs, private postal codes, exact
-   coordinates, email addresses, or phone numbers.
+2. Enter a Search from place, radius, distance unit, looking-for mode, one or
+   more parts, and a goal using data known to exist in the environment.
+3. Pass: the distance-unit picker defaults to Miles and sits beside the radius
+   field.
+4. Pass: part filtering accepts multiple voicing-aware values.
+5. Pass: the approximate map and result cards use the same filtered result set.
+6. Pass: result cards distinguish singer profiles from quartet openings and
+   include enough decision-making detail to open the details/contact panel.
+7. Pass: details/contact panels stay on `/find` and do not expose private email,
+   phone, exact ZIP/postal code, street address, or exact coordinates.
+8. Pass: empty results show helpful next actions, including increasing radius or
+   changing filters.
+9. Fail: hidden or inactive profiles/listings appear in public results.
+10. Fail: public UI exposes owner user IDs, private postal codes, exact
+    coordinates, email addresses, or phone numbers.
 
 ## Detailed Quartet Opening Search
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -105,9 +105,11 @@ The signed-in discovery routes are:
 - `/quartets`, backed by `quartet_discovery_listings`
 - `/map`, backed by both discovery views as a compatibility map view
 
-These routes may filter on public location fields, voicing-aware part, goals,
-experience/commitment, availability, and travel willingness. They should not
-read private base-table location or contact fields.
+These routes may filter on voicing-aware parts and goals. `/find` presents a
+search-origin and radius interface, but true distance-from-origin filtering
+requires a future approximate geocoding/RPC layer; until then, the map and cards
+use privacy-safe public location summaries from the discovery views. They should
+not read private base-table location or contact fields.
 
 These routes require authentication before reading discovery views. The views
 still expose only privacy-safe public fields, but anonymous visitors are

--- a/lib/location/map-markers.ts
+++ b/lib/location/map-markers.ts
@@ -24,6 +24,7 @@ export type DiscoveryMapMarker = {
   label: string;
   names: string[];
   parts: string[];
+  resultIds: string[];
   xPercent: number;
   yPercent: number;
 };
@@ -143,6 +144,7 @@ export function buildDiscoveryMapMarkers(
       existingMarker.parts = Array.from(
         new Set([...existingMarker.parts, ...item.parts]),
       ).sort();
+      existingMarker.resultIds.push(item.id);
       continue;
     }
 
@@ -155,6 +157,7 @@ export function buildDiscoveryMapMarkers(
       label,
       names: [item.name],
       parts: [...item.parts].sort(),
+      resultIds: [item.id],
       xPercent,
       yPercent,
     });

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -16,7 +16,10 @@ export type DiscoveryFilters = {
   goal: ProfileGoal | null;
   locality: string | null;
   part: VoicingPartSelection | null;
+  parts: VoicingPartSelection[];
+  radius: number | null;
   region: string | null;
+  searchFrom: string | null;
   travelRadiusKm: number | null;
 };
 
@@ -60,9 +63,35 @@ function parseTravelRadiusKm(value: string | string[] | undefined) {
   return radius;
 }
 
+function parseRadius(value: string | string[] | undefined) {
+  const normalized = normalizeSearchText(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const radius = Number(normalized);
+
+  if (!Number.isInteger(radius) || radius <= 0 || radius > 10000) {
+    return null;
+  }
+
+  return radius;
+}
+
+function parsePartList(value: string | string[] | undefined) {
+  const values = Array.isArray(value) ? value : [value];
+
+  return values
+    .map((item) => parseVoicingPartValue(normalizeSearchText(item) ?? ""))
+    .filter((part): part is VoicingPartSelection => part != null);
+}
+
 export function parseDiscoveryFilters(
   searchParams: Record<string, string | string[] | undefined>,
 ): DiscoveryFilters {
+  const parts = parsePartList(searchParams.part);
+
   return {
     availability: normalizeSearchText(searchParams.availability),
     country: normalizeSearchText(searchParams.country),
@@ -70,14 +99,25 @@ export function parseDiscoveryFilters(
     experience: normalizeSearchText(searchParams.experience),
     goal: parseAllowedValue(searchParams.goal, PROFILE_GOALS),
     locality: normalizeSearchText(searchParams.locality),
-    part: parseVoicingPartValue(normalizeSearchText(searchParams.part) ?? ""),
+    part: parts[0] ?? null,
+    parts,
+    radius: parseRadius(searchParams.radius),
     region: normalizeSearchText(searchParams.region),
+    searchFrom: normalizeSearchText(searchParams.searchFrom),
     travelRadiusKm: parseTravelRadiusKm(searchParams.travelRadiusKm),
   };
 }
 
 export function hasDiscoveryFilters(filters: DiscoveryFilters) {
-  return Object.entries(filters).some(
-    ([key, value]) => key !== "distanceUnit" && value !== null,
-  );
+  return Object.entries(filters).some(([key, value]) => {
+    if (key === "distanceUnit") {
+      return false;
+    }
+
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+
+    return value !== null;
+  });
 }

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -13,6 +13,8 @@ describe("discovery filters", () => {
       goal: "contest",
       part: "SATB:Soprano",
       distanceUnit: "km",
+      radius: "25",
+      searchFrom: " Manchester, England ",
       travelRadiusKm: "50",
     });
 
@@ -21,7 +23,10 @@ describe("discovery filters", () => {
     expect(filters.region).toBe("Greater Manchester");
     expect(filters.goal).toBe("contest");
     expect(filters.part).toEqual({ part: "Soprano", voicing: "SATB" });
+    expect(filters.parts).toEqual([{ part: "Soprano", voicing: "SATB" }]);
     expect(filters.distanceUnit).toBe("km");
+    expect(filters.radius).toBe(25);
+    expect(filters.searchFrom).toBe("Manchester, England");
     expect(filters.travelRadiusKm).toBe(50);
     expect(hasDiscoveryFilters(filters)).toBe(true);
   });
@@ -35,7 +40,9 @@ describe("discovery filters", () => {
 
     expect(filters.goal).toBeNull();
     expect(filters.part).toBeNull();
+    expect(filters.parts).toEqual([]);
     expect(filters.travelRadiusKm).toBeNull();
+    expect(filters.radius).toBeNull();
     expect(filters.distanceUnit).toBe("mi");
     expect(hasDiscoveryFilters(filters)).toBe(false);
   });
@@ -54,8 +61,27 @@ describe("discovery filters", () => {
     expect(filters.locality).toBe("Dublin");
     expect(filters.goal).toBe("pickup");
     expect(filters.part).toEqual({ part: "Tenor", voicing: "TTBB" });
+    expect(filters.parts).toEqual([{ part: "Tenor", voicing: "TTBB" }]);
     expect(filters.distanceUnit).toBe("km");
     expect(filters.travelRadiusKm).toBe(10000);
+  });
+
+  it("supports multi-select parts and a radius tied to units", () => {
+    const filters = parseDiscoveryFilters({
+      part: ["TTBB:Lead", "TTBB:Baritone", "melody"],
+      radius: "35",
+      distanceUnit: "mi",
+      searchFrom: "Fort Collins, CO",
+    });
+
+    expect(filters.parts).toEqual([
+      { part: "Lead", voicing: "TTBB" },
+      { part: "Baritone", voicing: "TTBB" },
+    ]);
+    expect(filters.radius).toBe(35);
+    expect(filters.distanceUnit).toBe("mi");
+    expect(filters.searchFrom).toBe("Fort Collins, CO");
+    expect(hasDiscoveryFilters(filters)).toBe(true);
   });
 
   it("rejects decimal, negative, and too-large travel radius filters", () => {
@@ -68,5 +94,8 @@ describe("discovery filters", () => {
     expect(
       parseDiscoveryFilters({ travelRadiusKm: "10001" }).travelRadiusKm,
     ).toBeNull();
+    expect(parseDiscoveryFilters({ radius: "10.5" }).radius).toBeNull();
+    expect(parseDiscoveryFilters({ radius: "-1" }).radius).toBeNull();
+    expect(parseDiscoveryFilters({ radius: "10001" }).radius).toBeNull();
   });
 });

--- a/test/map-markers.test.ts
+++ b/test/map-markers.test.ts
@@ -77,6 +77,7 @@ describe("privacy-safe discovery map markers", () => {
       label: "Dublin, Leinster, Ireland area",
       names: ["Casey", "River City Four"],
       parts: ["SSAA:Soprano 2", "TTBB:Tenor"],
+      resultIds: ["singer-1", "quartet-1"],
     });
   });
 

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -55,14 +55,19 @@ describe("public discovery copy", () => {
     expect(singerPage).toContain("looking for other singers nearby");
   });
 
-  it("consolidates discovery around filters, map, and table", () => {
+  it("consolidates discovery around search origin, map, cards, and details", () => {
     const findPage = source("app/find/page.tsx");
 
-    expect(findPage).toContain("Search singers and quartet openings");
+    expect(findPage).toContain("Search quartet openings and singers");
     expect(findPage).toContain("Filter discovery results");
     expect(findPage).toContain("Privacy-safe discovery map");
-    expect(findPage).toContain("Results table");
-    expect(findPage).toContain("Detailed quartet search");
-    expect(findPage).toContain("Detailed singer search");
+    expect(findPage).toContain("Search from");
+    expect(findPage).toContain("Within");
+    expect(findPage).toContain("multiple");
+    expect(findPage).toContain("Matching results");
+    expect(findPage).toContain("details and contact");
+    expect(findPage).not.toContain("Detailed quartet search");
+    expect(findPage).not.toContain("Detailed singer search");
+    expect(findPage).not.toContain("Open detailed search");
   });
 });


### PR DESCRIPTION
Closes #86

## Summary
- Redesign /find around Search from, radius, distance units, looking-for, multi-select parts, and goal controls
- Replace the table/detailed-search links with connected approximate map markers, richer result cards, expandable details, and contact forms
- Fetch richer singer/quartet discovery fields while keeping exact location and private contact data hidden
- Extend discovery filter parsing for multi-select parts, search origin, and radius
- Document that true distance-from-origin filtering still needs a future approximate geocoding/RPC layer

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build