### PR TITLE
Add approximate geocoding and radius search backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
 
+# Optional server-side approximate geocoding for radius search. Profile/listing
+# coordinates are persisted only when MAPBOX_GEOCODING_PERMANENT=true.
+MAPBOX_GEOCODING_TOKEN=
+MAPBOX_GEOCODING_PERMANENT=false
+
 # Optional future map provider configuration. The current MVP map does not
 # require these values and must not expose private exact coordinates.
 NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE=

--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -13,6 +13,7 @@ import {
   parseQuartetListingFormData,
 } from "@/lib/quartets/quartet-listing-form";
 import { distanceUnitForCountry } from "@/lib/location/country-location-defaults";
+import { geocodeApproximateLocation } from "@/lib/location/geocoding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function redirectWithListingMessage(
@@ -51,6 +52,10 @@ export async function saveQuartetListing(formData: FormData) {
     );
   }
 
+  const geocodingResult = await geocodeApproximateLocation(values, {
+    storageMode: "permanent",
+  });
+  const geocodedCoordinates = geocodingResult.coordinates;
   const listingPayload = {
     availability: values.availability,
     country_code: values.countryCode,
@@ -60,9 +65,13 @@ export async function saveQuartetListing(formData: FormData) {
     goals: values.goals,
     is_active: true,
     is_visible: values.isVisible,
+    latitude_private: geocodedCoordinates?.latitude ?? null,
     locality: values.locality,
     location_label_public: buildQuartetPublicLocationLabel(values),
-    location_precision: inferQuartetLocationPrecision(values),
+    location_precision: geocodedCoordinates
+      ? "geocoded"
+      : inferQuartetLocationPrecision(values),
+    longitude_private: geocodedCoordinates?.longitude ?? null,
     name: values.name,
     owner_user_id: user.id,
     postal_code_private: values.postalCodePrivate,

--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -13,6 +13,7 @@ import {
   parseSingerProfileFormData,
 } from "@/lib/profiles/singer-profile-form";
 import { distanceUnitForCountry } from "@/lib/location/country-location-defaults";
+import { geocodeApproximateLocation } from "@/lib/location/geocoding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function redirectWithProfileMessage(
@@ -57,6 +58,10 @@ export async function saveSingerProfile(formData: FormData) {
     values.countryCode,
     values.countryName,
   );
+  const geocodingResult = await geocodeApproximateLocation(values, {
+    storageMode: "permanent",
+  });
+  const geocodedCoordinates = geocodingResult.coordinates;
 
   const { data: profile, error: profileError } = await supabase
     .from("singer_profiles")
@@ -71,9 +76,13 @@ export async function saveSingerProfile(formData: FormData) {
         goals: values.goals,
         is_active: true,
         is_visible: values.isVisible,
+        latitude_private: geocodedCoordinates?.latitude ?? null,
         locality: values.locality,
         location_label_public: locationLabelPublic,
-        location_precision: locationPrecision,
+        location_precision: geocodedCoordinates
+          ? "geocoded"
+          : locationPrecision,
+        longitude_private: geocodedCoordinates?.longitude ?? null,
         postal_code_private: values.postalCodePrivate,
         preferred_distance_unit: preferredDistanceUnit,
         region: values.region,

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -4,8 +4,14 @@ import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import {
   approximateLocationLabel,
+  formatApproximateDistance,
+  milesToKilometers,
   travelRadiusLabel,
 } from "@/lib/location/approximate-location";
+import {
+  geocodeApproximateLocation,
+  type ApproximateGeocodingStatus,
+} from "@/lib/location/geocoding";
 import {
   buildDiscoveryMapMarkers,
   type DiscoveryMapItem,
@@ -30,6 +36,7 @@ type SingerFindRow = {
   parts: string[];
   region: string | null;
   travel_radius_km: number | null;
+  distance_km?: number | null;
 };
 
 type QuartetFindRow = {
@@ -47,6 +54,7 @@ type QuartetFindRow = {
   parts_needed: string[];
   region: string | null;
   travel_radius_km: number | null;
+  distance_km?: number | null;
 };
 
 type FindPageProps = {
@@ -63,6 +71,7 @@ type FindResult = DiscoveryMapItem & {
   resultLabel: string;
   targetKind: "quartet" | "singer";
   travelRadiusKm: number | null;
+  distanceKm: number | null;
 };
 
 const kindOptions = [
@@ -124,6 +133,13 @@ function locationLabel(item: FindResult) {
     locationLabelPublic: item.locationLabelPublic,
     region: item.region,
   });
+}
+
+function distanceLabel(
+  item: FindResult,
+  filters: ReturnType<typeof parseDiscoveryFilters>,
+) {
+  return formatApproximateDistance(item.distanceKm, filters.distanceUnit);
 }
 
 function selectedPartValues(filters: ReturnType<typeof parseDiscoveryFilters>) {
@@ -199,6 +215,29 @@ function filterAnalyticsProperties(
   return { filterCount, flags };
 }
 
+function radiusToKilometers(
+  radius: number | null,
+  unit: ReturnType<typeof parseDiscoveryFilters>["distanceUnit"],
+) {
+  if (radius == null) {
+    return null;
+  }
+
+  return unit === "mi" ? milesToKilometers(radius) : radius;
+}
+
+function geocodingStatusMessage(status: ApproximateGeocodingStatus) {
+  if (status === "not_configured") {
+    return "Radius search needs server-side Mapbox geocoding configuration before a search origin can be resolved.";
+  }
+
+  if (status === "not_found") {
+    return "That search origin could not be resolved. Try a city plus region/country or a postal code plus country.";
+  }
+
+  return "The search origin could not be resolved right now. Try again in a moment or clear the location search.";
+}
+
 export default async function FindPage({ searchParams }: FindPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
@@ -206,23 +245,55 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   const selectedParts = selectedPartValues(filters);
   const returnTo = returnToPath(params);
   const supabase = await requireAuthenticatedDiscovery("/find", params);
+  const radiusKm = radiusToKilometers(filters.radius, filters.distanceUnit);
+  const shouldUseRadiusSearch = Boolean(filters.searchFrom && radiusKm);
+  const geocodingResult = shouldUseRadiusSearch
+    ? await geocodeApproximateLocation(
+        {
+          locality: filters.searchFrom,
+        },
+        { storageMode: "temporary" },
+      )
+    : null;
+  const radiusSearchOrigin = geocodingResult?.coordinates ?? null;
 
   let results: FindResult[] = [];
   let errorMessage: string | null = null;
+  let searchNotice: string | null = null;
+
+  if (filters.searchFrom && filters.radius == null) {
+    searchNotice =
+      "Add a radius to search by distance from the entered place. Without a radius, results show all visible areas that match the other filters.";
+  } else if (filters.radius != null && !filters.searchFrom) {
+    searchNotice =
+      "Add a search origin to use radius filtering. Without a search origin, results show all visible areas that match the other filters.";
+  } else if (shouldUseRadiusSearch && geocodingResult?.status !== "resolved") {
+    searchNotice = geocodingStatusMessage(geocodingResult?.status ?? "failed");
+  }
 
   if (kind === "both" || kind === "singers") {
-    let query = supabase
-      .from("singer_discovery_profiles")
-      .select(
-        "id, display_name, parts, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
-      )
-      .order("updated_at", { ascending: false });
+    const { data, error } =
+      radiusSearchOrigin && radiusKm
+        ? await supabase.rpc("search_singer_discovery_profiles", {
+            goal_filter: filters.goal,
+            radius_km: radiusKm,
+            search_latitude: radiusSearchOrigin.latitude,
+            search_longitude: radiusSearchOrigin.longitude,
+          })
+        : await (() => {
+            let query = supabase
+              .from("singer_discovery_profiles")
+              .select(
+                "id, display_name, parts, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
+              )
+              .order("updated_at", { ascending: false });
 
-    if (filters.goal) {
-      query = query.contains("goals", [filters.goal]);
-    }
+            if (filters.goal) {
+              query = query.contains("goals", [filters.goal]);
+            }
 
-    const { data, error } = await query;
+            return query;
+          })();
 
     if (error) {
       errorMessage = error.message;
@@ -234,6 +305,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
           countryCode: singer.country_code,
           countryName: singer.country_name,
           description: null,
+          distanceKm: singer.distance_km ?? null,
           experienceLevel: singer.experience_level,
           goals: singer.goals,
           id: singer.id,
@@ -254,18 +326,28 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   }
 
   if (!errorMessage && (kind === "both" || kind === "quartets")) {
-    let query = supabase
-      .from("quartet_discovery_listings")
-      .select(
-        "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
-      )
-      .order("updated_at", { ascending: false });
+    const { data, error } =
+      radiusSearchOrigin && radiusKm
+        ? await supabase.rpc("search_quartet_discovery_listings", {
+            goal_filter: filters.goal,
+            radius_km: radiusKm,
+            search_latitude: radiusSearchOrigin.latitude,
+            search_longitude: radiusSearchOrigin.longitude,
+          })
+        : await (() => {
+            let query = supabase
+              .from("quartet_discovery_listings")
+              .select(
+                "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
+              )
+              .order("updated_at", { ascending: false });
 
-    if (filters.goal) {
-      query = query.contains("goals", [filters.goal]);
-    }
+            if (filters.goal) {
+              query = query.contains("goals", [filters.goal]);
+            }
 
-    const { data, error } = await query;
+            return query;
+          })();
 
     if (error) {
       errorMessage = error.message;
@@ -277,6 +359,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
           countryCode: quartet.country_code,
           countryName: quartet.country_name,
           description: quartet.description,
+          distanceKm: quartet.distance_km ?? null,
           experienceLevel: quartet.experience_level,
           goals: quartet.goals,
           id: quartet.id,
@@ -444,12 +527,11 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             </div>
           </div>
 
-          <p className="mt-4 rounded-md border border-[#d7cec0] bg-white/70 p-3 text-sm leading-6 text-[#394548]">
-            Radius search is ready in the interface, but exact
-            distance-from-place filtering is not enabled until approximate
-            geocoding is added. The current result set still uses privacy-safe
-            discovery data and approximate map regions.
-          </p>
+          {searchNotice ? (
+            <p className="mt-4 rounded-md border border-[#d7cec0] bg-white/70 p-3 text-sm leading-6 text-[#394548]">
+              {searchNotice}
+            </p>
+          ) : null}
         </form>
 
         {errorMessage ? (
@@ -474,7 +556,8 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                 {results.length} results across {markers.length} approximate
                 regions. Scope:{" "}
                 {textValue(filters.searchFrom) || "all visible areas"}; radius:{" "}
-                {radiusLabel}.
+                {radiusLabel}
+                {radiusSearchOrigin ? "; sorted by approximate distance." : "."}
               </p>
             </div>
             <div
@@ -562,6 +645,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                       </h3>
                       <p className="mt-2 text-sm leading-6 text-[#394548]">
                         {locationLabel(result)}
+                        {distanceLabel(result, filters)
+                          ? `; ${distanceLabel(result, filters)}`
+                          : ""}
                       </p>
                     </div>
                     <a
@@ -635,6 +721,9 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                           Approximate area:
                         </span>{" "}
                         {locationLabel(result)}
+                        {distanceLabel(result, filters)
+                          ? `; ${distanceLabel(result, filters)}`
+                          : ""}
                       </p>
                       <p>
                         <span className="font-semibold text-[#172023]">

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,6 +72,9 @@ Expected variables will likely include:
 - `SUPABASE_SERVICE_ROLE_KEY` for server-only administrative scripts, never browser code
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
+- `MAPBOX_GEOCODING_TOKEN` optional server-only token for approximate geocoding
+- `MAPBOX_GEOCODING_PERMANENT` set to `true` only when permanent Mapbox geocoding
+  storage is allowed for the account
 - `NEXT_PUBLIC_APP_URL`
 
 Do not commit real secrets.
@@ -117,12 +120,18 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<production Supabase anon key>
 SUPABASE_SERVICE_ROLE_KEY=<production Supabase service-role key>
 RESEND_API_KEY=<production Resend API key>
 RESEND_FROM_EMAIL=messages@quartetmemberfinder.org
+MAPBOX_GEOCODING_TOKEN=<server-only Mapbox token>
+MAPBOX_GEOCODING_PERMANENT=true
 ```
 
 Preview should use a safe preview/staging Supabase project if available, not
 production data. For preview builds, set `NEXT_PUBLIC_APP_URL` to the exact
 preview URL being tested or keep a documented preview/staging host with matching
 Supabase Auth redirects.
+
+Approximate radius search is documented in `docs/location-geocoding.md`. Leave
+Mapbox geocoding variables blank until the account is ready for the expected
+request volume and permanent geocoding storage terms.
 
 ### Vercel custom domain setup
 
@@ -436,14 +445,20 @@ service-role code.
 
 ## Maps and geocoding
 
-The current public discovery map does not require a third-party map or geocoder
-environment variable. It uses public discovery-view location summaries and
-country/region anchors to render approximate regional markers.
+The current public discovery map does not require a third-party map tile
+provider. It uses public discovery-view location summaries and country/region
+anchors to render approximate regional markers.
 
-When interactive tiles or geocoding are added, use a provider-compatible
-MapLibre setup rather than sending exact home coordinates to the browser.
-Provider configuration should be optional and documented in `.env.example`.
-Expected future public configuration values are:
+Approximate radius search can use server-side Mapbox geocoding. Keep
+`MAPBOX_GEOCODING_TOKEN` server-only. Set `MAPBOX_GEOCODING_PERMANENT=true`
+only when the Mapbox account is allowed to store geocoding results, because
+profile/listing save actions persist private approximate coordinates in
+Supabase.
+
+When interactive tiles are added, use a provider-compatible MapLibre setup
+rather than sending exact home coordinates to the browser. Provider
+configuration should be optional and documented in `.env.example`. Expected
+future public configuration values are:
 
 - `NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE`
 - `NEXT_PUBLIC_MAP_ATTRIBUTION`

--- a/docs/location-geocoding.md
+++ b/docs/location-geocoding.md
@@ -1,0 +1,77 @@
+# Location Geocoding
+
+Quartet Member Finder uses privacy-preserving approximate geocoding for radius
+search. Exact home addresses are not required or displayed.
+
+## Provider
+
+The MVP server-side geocoder uses Mapbox Geocoding API v6 forward geocoding.
+The app sends only approximate location components:
+
+- ZIP/postal code, when the user provides one
+- city/locality
+- state/province/region
+- country name or country code
+
+It does not send or require street addresses.
+
+## Environment
+
+Set these server-only environment variables in Vercel:
+
+```text
+MAPBOX_GEOCODING_TOKEN=<Mapbox access token>
+MAPBOX_GEOCODING_PERMANENT=true
+```
+
+`MAPBOX_GEOCODING_TOKEN` enables search-origin resolution for `/find`.
+`MAPBOX_GEOCODING_PERMANENT=true` is required before profile/listing save
+actions persist geocoded coordinates in Supabase. This keeps stored coordinates
+aligned with Mapbox's permanent geocoding terms.
+
+Local development can leave both values blank. In that case radius search
+explains that geocoding is not configured, and saved profiles/listings do not
+store coordinates.
+
+## Storage
+
+Singer profiles and quartet listings store coordinates only in private base-table
+columns:
+
+- `latitude_private`
+- `longitude_private`
+- `location_precision`
+
+Public discovery views never expose exact coordinates, postal codes, private
+addresses, owner IDs, or recipient contact details.
+
+## Radius Search
+
+When a signed-in user enters a search origin and radius on `/find`, the server:
+
+1. Resolves the origin with temporary Mapbox geocoding.
+2. Converts miles to kilometers when needed.
+3. Calls Supabase RPC functions that filter visible records by approximate
+   distance.
+4. Returns existing public discovery fields plus `distance_km`.
+
+The browser receives an approximate distance label such as “about 12 mi / 19 km
+away.” It does not receive exact coordinates.
+
+## Failure Behavior
+
+If geocoding is not configured, Mapbox is unavailable, or the origin cannot be
+resolved, `/find` shows a plain-language notice. It still lets users browse
+visible discovery results using non-distance filters.
+
+Profiles/listings saved while geocoding is unavailable do not receive private
+coordinates. They remain visible in non-radius discovery if the owner chose to
+publish them, but they cannot match radius searches until saved again after
+geocoding is configured.
+
+## Cost and Limits
+
+Mapbox requests may be billed and rate limited according to the Mapbox account's
+current plan. Search-origin lookups are temporary geocoding requests. Saved
+profile/listing location lookups use `permanent=true` only when
+`MAPBOX_GEOCODING_PERMANENT=true` is set.

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -59,9 +59,10 @@ Private geocoded data should be transformed into a public location summary
 before display. Public summaries may contain only locality/city, region when
 available, and country. They must not contain exact latitude, longitude, private
 postal code, formatted private address, or other precise address components.
-Until automatic geocoding is added, country, region, city, and ZIP/postal code
-provide useful context for the current approximate map/search approach because
-the map uses country/region anchors and public city/country labels rather than
+When server-side geocoding is configured, the app may store private approximate
+coordinates for matching and radius search. Country, region, city, and ZIP/postal
+code still provide useful context for approximate map/search behavior because
+browser maps use public city/country labels and regional markers rather than
 exact pins.
 
 Distance helpers may use exact coordinates internally for matching later, but
@@ -85,11 +86,12 @@ Avoid exact map pins. Map interfaces should use one of the following:
 - search-result areas rather than exact addresses
 
 The MVP discovery map uses region-level markers derived from public discovery
-view fields only: public location label, locality, region, country, and country
-code. It must not receive base-table coordinates, private postal codes, or
-formatted private addresses in browser-rendered props. Marker placement may use
-country/region anchors and deterministic offsets so nearby results can cluster
-without implying a home address or exact rehearsal location.
+fields only: public location label, locality, region, country, country code, and
+rounded approximate distance when radius search is active. It must not receive
+base-table coordinates, private postal codes, or formatted private addresses in
+browser-rendered props. Marker placement may use country/region anchors and
+deterministic offsets so nearby results can cluster without implying a home
+address or exact rehearsal location.
 
 ## Visibility controls
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -20,6 +20,8 @@ It includes these data areas:
 - `feedback_submissions`: private authenticated-user feedback from the help page.
 - `singer_discovery_profiles`: privacy-safe singer discovery view.
 - `quartet_discovery_listings`: privacy-safe quartet discovery view.
+- `search_singer_discovery_profiles`: authenticated radius-search RPC.
+- `search_quartet_discovery_listings`: authenticated radius-search RPC.
 
 The schema also defines enums for distance units, location precision, quartet
 part status, and contact request status. Earlier migrations created a
@@ -105,11 +107,13 @@ The signed-in discovery routes are:
 - `/quartets`, backed by `quartet_discovery_listings`
 - `/map`, backed by both discovery views as a compatibility map view
 
-These routes may filter on voicing-aware parts and goals. `/find` presents a
-search-origin and radius interface, but true distance-from-origin filtering
-requires a future approximate geocoding/RPC layer; until then, the map and cards
-use privacy-safe public location summaries from the discovery views. They should
-not read private base-table location or contact fields.
+These routes may filter on voicing-aware parts and goals. `/find` can resolve a
+search origin and radius when server-side geocoding is configured, then use
+authenticated RPC functions to return visible results sorted by approximate
+distance. If a search origin is missing, radius is missing, or geocoding cannot
+resolve the origin, `/find` falls back to visible discovery results with a clear
+notice. Browser code should not read private base-table location or contact
+fields.
 
 These routes require authentication before reading discovery views. The views
 still expose only privacy-safe public fields, but anonymous visitors are
@@ -140,9 +144,11 @@ Public discovery is exposed through:
 
 - `singer_discovery_profiles`
 - `quartet_discovery_listings`
+- `search_singer_discovery_profiles`
+- `search_quartet_discovery_listings`
 
-Those views filter to `is_visible = true` and `is_active = true` and include
-only privacy-safe columns. They intentionally omit:
+Those views and functions filter to `is_visible = true` and `is_active = true`
+and include only privacy-safe columns. They intentionally omit:
 
 - `user_id` and `owner_user_id`
 - private postal codes
@@ -228,6 +234,21 @@ location fields:
 The public discovery views expose country, region, locality, public location
 label, and preferred distance unit. They do not expose private postal codes,
 formatted addresses, or exact coordinates.
+
+Approximate radius search uses
+`supabase/migrations/20260501020000_approximate_radius_search.sql`:
+
+- `distance_between_coordinates_km` computes private server/database distance.
+- `search_singer_discovery_profiles` returns visible singer rows within a
+  caller-provided radius and includes only `distance_km`, not coordinates.
+- `search_quartet_discovery_listings` does the same for quartet listings.
+- radius indexes cover visible active rows with private coordinates.
+- execute grants are limited to authenticated users.
+
+The app's server actions geocode profile/listing location fields through the
+server-only approximate geocoder when configured. Saved coordinates remain in
+private base-table fields. Search-origin geocoding for `/find` is temporary and
+not stored.
 
 The public map route must continue to use those discovery views rather than base
 tables. Map markers are built from public location summaries and country/region

--- a/lib/location/geocoding.ts
+++ b/lib/location/geocoding.ts
@@ -1,0 +1,146 @@
+import type { Coordinates } from "@/lib/location/approximate-location";
+
+type GeocodingStorageMode = "permanent" | "temporary";
+
+export type ApproximateGeocodingInput = {
+  countryCode?: string | null;
+  countryName?: string | null;
+  locality?: string | null;
+  postalCodePrivate?: string | null;
+  region?: string | null;
+};
+
+export type ApproximateGeocodingStatus =
+  | "failed"
+  | "not_configured"
+  | "not_found"
+  | "resolved";
+
+export type ApproximateGeocodingResult =
+  | {
+      coordinates: Coordinates;
+      status: "resolved";
+    }
+  | {
+      coordinates: null;
+      status: Exclude<ApproximateGeocodingStatus, "resolved">;
+    };
+
+type MapboxFeature = {
+  geometry?: {
+    coordinates?: [number, number];
+  };
+};
+
+type MapboxGeocodingResponse = {
+  features?: MapboxFeature[];
+};
+
+type GeocodingFetch = typeof fetch;
+
+const MAPBOX_FORWARD_GEOCODING_URL =
+  "https://api.mapbox.com/search/geocode/v6/forward";
+
+const APPROXIMATE_TYPES = [
+  "postcode",
+  "place",
+  "locality",
+  "region",
+  "country",
+];
+
+function trimToNull(value: string | null | undefined) {
+  const normalized = value?.trim();
+
+  return normalized ? normalized : null;
+}
+
+function isValidCoordinate(coordinates: Coordinates) {
+  return (
+    Number.isFinite(coordinates.latitude) &&
+    Number.isFinite(coordinates.longitude) &&
+    coordinates.latitude >= -90 &&
+    coordinates.latitude <= 90 &&
+    coordinates.longitude >= -180 &&
+    coordinates.longitude <= 180
+  );
+}
+
+function mapboxPermanentStorageEnabled() {
+  return process.env.MAPBOX_GEOCODING_PERMANENT === "true";
+}
+
+export function buildApproximateGeocodingQuery(
+  input: ApproximateGeocodingInput,
+) {
+  return [
+    trimToNull(input.postalCodePrivate),
+    trimToNull(input.locality),
+    trimToNull(input.region),
+    trimToNull(input.countryName) ?? trimToNull(input.countryCode),
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
+
+export function geocodingEnabledForStorage(mode: GeocodingStorageMode) {
+  if (!process.env.MAPBOX_GEOCODING_TOKEN) {
+    return false;
+  }
+
+  return mode === "temporary" || mapboxPermanentStorageEnabled();
+}
+
+export async function geocodeApproximateLocation(
+  input: ApproximateGeocodingInput,
+  {
+    fetchImpl = fetch,
+    storageMode = "temporary",
+  }: {
+    fetchImpl?: GeocodingFetch;
+    storageMode?: GeocodingStorageMode;
+  } = {},
+): Promise<ApproximateGeocodingResult> {
+  const query = buildApproximateGeocodingQuery(input);
+  const token = process.env.MAPBOX_GEOCODING_TOKEN;
+
+  if (!query || !token || !geocodingEnabledForStorage(storageMode)) {
+    return { coordinates: null, status: "not_configured" };
+  }
+
+  const url = new URL(MAPBOX_FORWARD_GEOCODING_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("limit", "1");
+  url.searchParams.set("types", APPROXIMATE_TYPES.join(","));
+  url.searchParams.set("access_token", token);
+
+  if (storageMode === "permanent") {
+    url.searchParams.set("permanent", "true");
+  }
+
+  try {
+    const response = await fetchImpl(url);
+
+    if (!response.ok) {
+      return { coordinates: null, status: "failed" };
+    }
+
+    const body = (await response.json()) as MapboxGeocodingResponse;
+    const [longitude, latitude] =
+      body.features?.[0]?.geometry?.coordinates ?? [];
+
+    if (typeof latitude !== "number" || typeof longitude !== "number") {
+      return { coordinates: null, status: "not_found" };
+    }
+
+    const coordinates = { latitude, longitude };
+
+    if (!isValidCoordinate(coordinates)) {
+      return { coordinates: null, status: "not_found" };
+    }
+
+    return { coordinates, status: "resolved" };
+  } catch {
+    return { coordinates: null, status: "failed" };
+  }
+}

--- a/supabase/migrations/20260501020000_approximate_radius_search.sql
+++ b/supabase/migrations/20260501020000_approximate_radius_search.sql
@@ -1,0 +1,275 @@
+create or replace function public.distance_between_coordinates_km(
+  origin_latitude double precision,
+  origin_longitude double precision,
+  destination_latitude double precision,
+  destination_longitude double precision
+)
+returns double precision
+language sql
+immutable
+strict
+as $$
+  select 6371.0088 * 2 * atan2(
+    sqrt(
+      power(sin(radians(destination_latitude - origin_latitude) / 2), 2)
+      + cos(radians(origin_latitude))
+        * cos(radians(destination_latitude))
+        * power(sin(radians(destination_longitude - origin_longitude) / 2), 2)
+    ),
+    sqrt(
+      greatest(
+        0,
+        1 - (
+          power(sin(radians(destination_latitude - origin_latitude) / 2), 2)
+          + cos(radians(origin_latitude))
+            * cos(radians(destination_latitude))
+            * power(sin(radians(destination_longitude - origin_longitude) / 2), 2)
+        )
+      )
+    )
+  );
+$$;
+
+create index if not exists singer_profiles_radius_search_idx
+  on public.singer_profiles (is_visible, is_active, latitude_private, longitude_private)
+  where latitude_private is not null
+    and longitude_private is not null;
+
+create index if not exists quartet_listings_radius_search_idx
+  on public.quartet_listings (is_visible, is_active, latitude_private, longitude_private)
+  where latitude_private is not null
+    and longitude_private is not null;
+
+create or replace function public.search_singer_discovery_profiles(
+  search_latitude double precision,
+  search_longitude double precision,
+  radius_km double precision,
+  goal_filter text default null
+)
+returns table (
+  id uuid,
+  display_name text,
+  parts text[],
+  goals text[],
+  experience_level text,
+  availability text,
+  travel_radius_km integer,
+  preferred_distance_unit public.distance_unit,
+  country_code text,
+  country_name text,
+  region text,
+  locality text,
+  location_label_public text,
+  updated_at timestamptz,
+  distance_km double precision
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with visible_profiles as (
+    select
+      singer_profiles.*,
+      public.distance_between_coordinates_km(
+        search_latitude,
+        search_longitude,
+        singer_profiles.latitude_private::double precision,
+        singer_profiles.longitude_private::double precision
+      ) as calculated_distance_km
+    from public.singer_profiles
+    where singer_profiles.is_visible = true
+      and singer_profiles.is_active = true
+      and singer_profiles.latitude_private is not null
+      and singer_profiles.longitude_private is not null
+      and radius_km > 0
+      and search_latitude between -90 and 90
+      and search_longitude between -180 and 180
+      and (
+        goal_filter is null
+        or singer_profiles.goals @> array[goal_filter]
+      )
+  )
+  select
+    visible_profiles.id,
+    visible_profiles.display_name,
+    coalesce(
+      array_agg(
+        singer_profile_parts.voicing || ':' || singer_profile_parts.part
+        order by singer_profile_parts.voicing, singer_profile_parts.part
+      )
+        filter (where singer_profile_parts.part is not null),
+      '{}'
+    ) as parts,
+    visible_profiles.goals,
+    visible_profiles.experience_level,
+    visible_profiles.availability,
+    visible_profiles.travel_radius_km,
+    visible_profiles.preferred_distance_unit,
+    visible_profiles.country_code,
+    visible_profiles.country_name,
+    visible_profiles.region,
+    visible_profiles.locality,
+    visible_profiles.location_label_public,
+    visible_profiles.updated_at,
+    visible_profiles.calculated_distance_km as distance_km
+  from visible_profiles
+  left join public.singer_profile_parts
+    on singer_profile_parts.singer_profile_id = visible_profiles.id
+  where visible_profiles.calculated_distance_km <= radius_km
+  group by
+    visible_profiles.id,
+    visible_profiles.display_name,
+    visible_profiles.goals,
+    visible_profiles.experience_level,
+    visible_profiles.availability,
+    visible_profiles.travel_radius_km,
+    visible_profiles.preferred_distance_unit,
+    visible_profiles.country_code,
+    visible_profiles.country_name,
+    visible_profiles.region,
+    visible_profiles.locality,
+    visible_profiles.location_label_public,
+    visible_profiles.updated_at,
+    visible_profiles.calculated_distance_km
+  order by visible_profiles.calculated_distance_km asc, visible_profiles.updated_at desc;
+$$;
+
+create or replace function public.search_quartet_discovery_listings(
+  search_latitude double precision,
+  search_longitude double precision,
+  radius_km double precision,
+  goal_filter text default null
+)
+returns table (
+  id uuid,
+  name text,
+  description text,
+  parts_covered text[],
+  parts_needed text[],
+  goals text[],
+  experience_level text,
+  availability text,
+  travel_radius_km integer,
+  preferred_distance_unit public.distance_unit,
+  country_code text,
+  country_name text,
+  region text,
+  locality text,
+  location_label_public text,
+  updated_at timestamptz,
+  distance_km double precision
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with visible_listings as (
+    select
+      quartet_listings.*,
+      public.distance_between_coordinates_km(
+        search_latitude,
+        search_longitude,
+        quartet_listings.latitude_private::double precision,
+        quartet_listings.longitude_private::double precision
+      ) as calculated_distance_km
+    from public.quartet_listings
+    where quartet_listings.is_visible = true
+      and quartet_listings.is_active = true
+      and quartet_listings.latitude_private is not null
+      and quartet_listings.longitude_private is not null
+      and radius_km > 0
+      and search_latitude between -90 and 90
+      and search_longitude between -180 and 180
+      and (
+        goal_filter is null
+        or quartet_listings.goals @> array[goal_filter]
+      )
+  )
+  select
+    visible_listings.id,
+    visible_listings.name,
+    visible_listings.description,
+    coalesce(
+      array_agg(
+        quartet_listing_parts.voicing || ':' || quartet_listing_parts.part
+        order by quartet_listing_parts.voicing, quartet_listing_parts.part
+      )
+        filter (where quartet_listing_parts.status = 'covered'),
+      '{}'
+    ) as parts_covered,
+    coalesce(
+      array_agg(
+        quartet_listing_parts.voicing || ':' || quartet_listing_parts.part
+        order by quartet_listing_parts.voicing, quartet_listing_parts.part
+      )
+        filter (where quartet_listing_parts.status = 'needed'),
+      '{}'
+    ) as parts_needed,
+    visible_listings.goals,
+    visible_listings.experience_level,
+    visible_listings.availability,
+    visible_listings.travel_radius_km,
+    visible_listings.preferred_distance_unit,
+    visible_listings.country_code,
+    visible_listings.country_name,
+    visible_listings.region,
+    visible_listings.locality,
+    visible_listings.location_label_public,
+    visible_listings.updated_at,
+    visible_listings.calculated_distance_km as distance_km
+  from visible_listings
+  left join public.quartet_listing_parts
+    on quartet_listing_parts.quartet_listing_id = visible_listings.id
+  where visible_listings.calculated_distance_km <= radius_km
+  group by
+    visible_listings.id,
+    visible_listings.name,
+    visible_listings.description,
+    visible_listings.goals,
+    visible_listings.experience_level,
+    visible_listings.availability,
+    visible_listings.travel_radius_km,
+    visible_listings.preferred_distance_unit,
+    visible_listings.country_code,
+    visible_listings.country_name,
+    visible_listings.region,
+    visible_listings.locality,
+    visible_listings.location_label_public,
+    visible_listings.updated_at,
+    visible_listings.calculated_distance_km
+  order by visible_listings.calculated_distance_km asc, visible_listings.updated_at desc;
+$$;
+
+revoke all on function public.distance_between_coordinates_km(
+  double precision,
+  double precision,
+  double precision,
+  double precision
+) from public;
+revoke all on function public.search_singer_discovery_profiles(
+  double precision,
+  double precision,
+  double precision,
+  text
+) from public;
+revoke all on function public.search_quartet_discovery_listings(
+  double precision,
+  double precision,
+  double precision,
+  text
+) from public;
+
+grant execute on function public.search_singer_discovery_profiles(
+  double precision,
+  double precision,
+  double precision,
+  text
+) to authenticated;
+grant execute on function public.search_quartet_discovery_listings(
+  double precision,
+  double precision,
+  double precision,
+  text
+) to authenticated;

--- a/test/geocoding.test.ts
+++ b/test/geocoding.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildApproximateGeocodingQuery,
+  geocodeApproximateLocation,
+  geocodingEnabledForStorage,
+} from "@/lib/location/geocoding";
+
+describe("approximate geocoding", () => {
+  beforeEach(() => {
+    delete process.env.MAPBOX_GEOCODING_TOKEN;
+    delete process.env.MAPBOX_GEOCODING_PERMANENT;
+  });
+
+  it("builds approximate queries without street or public label data", () => {
+    expect(
+      buildApproximateGeocodingQuery({
+        countryName: "United States",
+        locality: "Fort Collins",
+        postalCodePrivate: "80521",
+        region: "CO",
+      }),
+    ).toBe("80521, Fort Collins, CO, United States");
+  });
+
+  it("requires permanent storage opt-in before persisted geocoding", () => {
+    process.env.MAPBOX_GEOCODING_TOKEN = "pk.test";
+
+    expect(geocodingEnabledForStorage("temporary")).toBe(true);
+    expect(geocodingEnabledForStorage("permanent")).toBe(false);
+
+    process.env.MAPBOX_GEOCODING_PERMANENT = "true";
+
+    expect(geocodingEnabledForStorage("permanent")).toBe(true);
+  });
+
+  it("resolves Mapbox coordinates without exposing the provider response", async () => {
+    process.env.MAPBOX_GEOCODING_TOKEN = "pk.test";
+    const fetchImpl = vi.fn().mockResolvedValue({
+      json: async () => ({
+        features: [
+          {
+            geometry: {
+              coordinates: [-105.0844, 40.5853],
+            },
+          },
+        ],
+      }),
+      ok: true,
+    });
+
+    const result = await geocodeApproximateLocation(
+      {
+        countryName: "United States",
+        locality: "Fort Collins",
+        region: "CO",
+      },
+      { fetchImpl },
+    );
+
+    expect(result).toEqual({
+      coordinates: { latitude: 40.5853, longitude: -105.0844 },
+      status: "resolved",
+    });
+    const requestedUrl = fetchImpl.mock.calls[0][0] as URL;
+    expect(requestedUrl.searchParams.get("types")).toBe(
+      "postcode,place,locality,region,country",
+    );
+    expect(requestedUrl.searchParams.get("permanent")).toBeNull();
+  });
+
+  it("returns not configured when a persisted lookup cannot be stored", async () => {
+    process.env.MAPBOX_GEOCODING_TOKEN = "pk.test";
+
+    await expect(
+      geocodeApproximateLocation(
+        { countryName: "Canada", locality: "Toronto", region: "Ontario" },
+        { storageMode: "permanent" },
+      ),
+    ).resolves.toEqual({ coordinates: null, status: "not_configured" });
+  });
+});

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -32,6 +32,21 @@ function viewDefinition(viewName: string) {
   return match[0];
 }
 
+function functionReturnDefinition(functionName: string) {
+  const pattern = new RegExp(
+    `create or replace function public\\.${functionName}[\\s\\S]*?returns table \\(([\\s\\S]*?)\\)\\nlanguage`,
+    "i",
+  );
+
+  const match = migration.match(pattern);
+
+  if (!match) {
+    throw new Error(`Missing ${functionName} return definition`);
+  }
+
+  return match[1];
+}
+
 describe("initial Supabase schema migration", () => {
   it("enables row level security on every app table", () => {
     for (const table of appTables) {
@@ -68,6 +83,37 @@ describe("initial Supabase schema migration", () => {
     expect(viewDefinition("quartet_discovery_listings")).not.toMatch(
       privateFieldPattern,
     );
+  });
+
+  it("adds authenticated radius search without returning exact coordinates", () => {
+    expect(migration).toContain(
+      "create or replace function public.distance_between_coordinates_km",
+    );
+    expect(migration).toContain(
+      "create or replace function public.search_singer_discovery_profiles",
+    );
+    expect(migration).toContain(
+      "create or replace function public.search_quartet_discovery_listings",
+    );
+    expect(migration).toContain(
+      "grant execute on function public.search_singer_discovery_profiles",
+    );
+    expect(migration).toContain(
+      "grant execute on function public.search_quartet_discovery_listings",
+    );
+    expect(
+      functionReturnDefinition("search_singer_discovery_profiles"),
+    ).toContain("distance_km double precision");
+    expect(
+      functionReturnDefinition("search_quartet_discovery_listings"),
+    ).toContain("distance_km double precision");
+    expect(migration).toContain("latitude_private is not null");
+    expect(
+      functionReturnDefinition("search_singer_discovery_profiles"),
+    ).not.toMatch(/latitude_private|longitude_private/i);
+    expect(
+      functionReturnDefinition("search_quartet_discovery_listings"),
+    ).not.toMatch(/latitude_private|longitude_private/i);
   });
 
   it("stores and exposes parts with explicit voicing context", () => {


### PR DESCRIPTION
Closes #101

## Summary
- add server-side Mapbox approximate geocoding helpers and env docs
- save private approximate coordinates for singer profiles and quartet listings when permanent geocoding is configured
- add Supabase distance-search RPCs for visible singer/quartet discovery results without exposing exact coordinates
- wire /find to resolve a search origin, call radius RPCs, show approximate distance, and explain missing geocoding/radius states

## Supabase migration
- adds 20260501020000_approximate_radius_search.sql with distance helper, radius indexes, and authenticated radius-search RPCs
- production should apply this through the existing GitHub Actions deployment workflow

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build

## Notes
- Mapbox docs require permanent geocoding opt-in before stored/cached geocoding results; profile/listing coordinate persistence is gated by MAPBOX_GEOCODING_PERMANENT=true
- Public discovery receives distance_km only, never private postal codes or exact coordinates