### PR TITLE
Replace pseudo-map with privacy-safe Mapbox globe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
+# Public Mapbox browser token for the interactive discovery map. Use a public
+# pk token with no secret scopes.
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=
+NEXT_PUBLIC_MAPBOX_STYLE_URL=mapbox://styles/mapbox/streets-v12
+NEXT_PUBLIC_MAPBOX_PROJECTION=globe
+
 # Local admin-only PostHog dashboard setup. Never deploy or commit a personal API key.
 POSTHOG_ENVIRONMENT_ID=404599
 POSTHOG_HOST=https://us.posthog.com
@@ -21,9 +27,3 @@ RESEND_FROM_EMAIL=
 # coordinates are persisted only when MAPBOX_GEOCODING_PERMANENT=true.
 MAPBOX_GEOCODING_TOKEN=
 MAPBOX_GEOCODING_PERMANENT=false
-
-# Optional future map provider configuration. The current MVP map does not
-# require these values and must not expose private exact coordinates.
-NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE=
-NEXT_PUBLIC_MAP_ATTRIBUTION=
-NEXT_PUBLIC_MAP_STYLE_URL=

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -1,4 +1,5 @@
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
+import { InteractiveDiscoveryMap } from "@/components/discovery/interactive-discovery-map";
 import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
@@ -169,18 +170,6 @@ function markerSummary(marker: { names: string[] }) {
   return remainingCount > 0
     ? `${previewNames}, +${remainingCount} more`
     : previewNames;
-}
-
-function markerKindLabel(marker: { count: number; kinds: string[] }) {
-  if (marker.kinds.includes("quartet") && marker.kinds.includes("singer")) {
-    return "results";
-  }
-
-  if (marker.kinds[0] === "quartet") {
-    return marker.count === 1 ? "quartet opening" : "quartet openings";
-  }
-
-  return marker.count === 1 ? "singer" : "singers";
 }
 
 function returnToPath(params: Record<string, string | string[] | undefined>) {
@@ -544,59 +533,15 @@ export default async function FindPage({ searchParams }: FindPageProps) {
         ) : null}
 
         <section className="mt-6 grid gap-6 xl:grid-cols-[minmax(22rem,0.9fr)_minmax(0,1.1fr)]">
-          <section
-            aria-labelledby="map-heading"
-            className="overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]"
-          >
-            <div className="border-b border-[#d7cec0] bg-white/85 px-4 py-3">
-              <h2 className="font-bold text-[#172023]" id="map-heading">
-                Approximate map scope
-              </h2>
-              <p className="mt-1 text-sm text-[#394548]">
-                {results.length} results across {markers.length} approximate
-                regions. Scope:{" "}
-                {textValue(filters.searchFrom) || "all visible areas"}; radius:{" "}
-                {radiusLabel}
-                {radiusSearchOrigin ? "; sorted by approximate distance." : "."}
-              </p>
-            </div>
-            <div
-              aria-label="Privacy-safe discovery map"
-              className="relative min-h-[460px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)]"
-              role="img"
-            >
-              {markers.length === 0 ? (
-                <div className="absolute inset-x-6 top-8 rounded-lg border border-[#d7cec0] bg-white/90 p-5 text-sm leading-6 text-[#394548] shadow-sm">
-                  No approximate map regions match. Try increasing the radius,
-                  clearing part filters, or changing what you are looking for.
-                </div>
-              ) : null}
-
-              {markers.map((marker) => (
-                <a
-                  className="absolute max-w-[10rem] -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm [overflow-wrap:anywhere] hover:border-[#174b4f] focus:outline-none focus:ring-2 focus:ring-[#174b4f]"
-                  href={`#result-${marker.resultIds[0]}`}
-                  key={marker.id}
-                  style={{
-                    left: `${marker.xPercent}%`,
-                    top: `${marker.yPercent}%`,
-                  }}
-                >
-                  <span className="block font-bold text-[#172023]">
-                    {marker.label}
-                  </span>
-                  <span className="mt-1 block text-[#394548]">
-                    {marker.count} {markerKindLabel(marker)}
-                  </span>
-                  {marker.parts.length > 0 ? (
-                    <span className="mt-1 block text-[#596466]">
-                      {partsLabel(marker.parts)}
-                    </span>
-                  ) : null}
-                </a>
-              ))}
-            </div>
-          </section>
+          <InteractiveDiscoveryMap
+            emptyMessage="No approximate map regions match. Try increasing the radius, clearing part filters, or changing what you are looking for."
+            markers={markers}
+            resultLabel="Interactive map scope"
+            scopeLabel={`${textValue(filters.searchFrom) || "all visible areas"}; radius: ${radiusLabel}${
+              radiusSearchOrigin ? "; sorted by approximate distance" : ""
+            }`}
+            totalResults={results.length}
+          />
 
           <section aria-labelledby="results-heading">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { AnalyticsPageTracker } from "@/components/analytics/analytics-page-tracker";
 import { SiteFooter } from "@/components/navigation/site-footer";
+import "mapbox-gl/dist/mapbox-gl.css";
 import "./globals.css";
 
 export const metadata: Metadata = {

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { DiscoveryModeNav } from "@/components/discovery/discovery-mode-nav";
+import { InteractiveDiscoveryMap } from "@/components/discovery/interactive-discovery-map";
 import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
@@ -99,18 +100,6 @@ function markerSummary(marker: { names: string[] }) {
   return remainingCount > 0
     ? `${previewNames}, +${remainingCount} more`
     : previewNames;
-}
-
-function markerKindLabel(marker: { count: number; kinds: string[] }) {
-  if (marker.kinds.includes("quartet") && marker.kinds.includes("singer")) {
-    return "listings";
-  }
-
-  if (marker.kinds[0] === "quartet") {
-    return marker.count === 1 ? "quartet listing" : "quartet listings";
-  }
-
-  return marker.count === 1 ? "singer profile" : "singer profiles";
 }
 
 export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
@@ -356,41 +345,16 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           </p>
         ) : null}
 
-        <section className="mt-8 overflow-hidden rounded-lg border border-[#d7cec0] bg-[#e7f0eb]">
-          <div
-            aria-label="Privacy-safe discovery map"
-            className="relative min-h-[520px] bg-[radial-gradient(circle_at_22%_38%,#c5d7c8_0_9%,transparent_10%),radial-gradient(circle_at_49%_38%,#c5d7c8_0_8%,transparent_9%),radial-gradient(circle_at_55%_55%,#c5d7c8_0_13%,transparent_14%),radial-gradient(circle_at_77%_63%,#c5d7c8_0_9%,transparent_10%),linear-gradient(135deg,#e7f0eb,#d9e8e1)] sm:min-h-[420px]"
-            role="img"
-          >
-            <div className="absolute inset-x-0 top-0 flex flex-col gap-1 bg-white/85 px-4 py-3 text-sm text-[#394548] backdrop-blur sm:flex-row sm:items-center sm:justify-between">
-              <span>{markers.length} approximate regions</span>
-              <span>
-                {mapItems.length} visible listings with public location
-              </span>
-            </div>
-
-            {markers.map((marker) => (
-              <div
-                className="absolute max-w-[10rem] -translate-x-1/2 -translate-y-1/2 rounded-md border border-[#174b4f]/30 bg-white px-3 py-2 text-sm shadow-sm [overflow-wrap:anywhere] sm:max-w-48"
-                key={marker.id}
-                style={{
-                  left: `${marker.xPercent}%`,
-                  top: `${marker.yPercent}%`,
-                }}
-              >
-                <p className="font-bold text-[#172023]">{marker.label}</p>
-                <p className="mt-1 text-[#394548]">
-                  {marker.count} {markerKindLabel(marker)}
-                </p>
-                {marker.parts.length > 0 ? (
-                  <p className="mt-1 text-[#596466]">
-                    {partsLabel(marker.parts)}
-                  </p>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        </section>
+        <div className="mt-8">
+          <InteractiveDiscoveryMap
+            emptyMessage="The map only shows visible singer profiles and quartet openings with approximate public location data."
+            markers={markers}
+            resultBasePath="/map"
+            resultLabel="Interactive discovery map"
+            scopeLabel="current map filters"
+            totalResults={mapItems.length}
+          />
+        </div>
 
         <section className="mt-8 grid gap-4 md:grid-cols-2">
           {markers.length === 0 && !errorMessage ? (
@@ -421,6 +385,7 @@ export default async function DiscoveryMapPage({ searchParams }: MapPageProps) {
           {markers.map((marker) => (
             <article
               className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm"
+              id={`result-${marker.resultIds[0]}`}
               key={marker.id}
             >
               <h2 className="text-xl font-bold text-[#172023]">

--- a/components/discovery/interactive-discovery-map.tsx
+++ b/components/discovery/interactive-discovery-map.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type {
+  LngLatBoundsLike,
+  Map as MapboxMap,
+  MapOptions,
+  Marker as MapboxMarker,
+} from "mapbox-gl";
+import { groupVoicingParts } from "@/lib/parts/voicings";
+import type { DiscoveryMapMarker } from "@/lib/location/map-markers";
+
+type InteractiveDiscoveryMapProps = {
+  emptyMessage: string;
+  markers: DiscoveryMapMarker[];
+  resultBasePath?: string;
+  resultLabel: string;
+  scopeLabel: string;
+  totalResults: number;
+};
+
+const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+const MAPBOX_STYLE =
+  process.env.NEXT_PUBLIC_MAPBOX_STYLE_URL ??
+  "mapbox://styles/mapbox/streets-v12";
+const MAP_PROJECTION = process.env.NEXT_PUBLIC_MAPBOX_PROJECTION ?? "globe";
+const DEFAULT_CENTER: [number, number] = [-15, 22];
+
+function markerKindLabel(marker: DiscoveryMapMarker) {
+  if (marker.kinds.includes("quartet") && marker.kinds.includes("singer")) {
+    return "results";
+  }
+
+  if (marker.kinds[0] === "quartet") {
+    return marker.count === 1 ? "quartet opening" : "quartet openings";
+  }
+
+  return marker.count === 1 ? "singer" : "singers";
+}
+
+function markerSummary(marker: DiscoveryMapMarker) {
+  const previewNames = marker.names.slice(0, 3).join(", ");
+  const remainingCount = marker.names.length - 3;
+
+  return remainingCount > 0
+    ? `${previewNames}, +${remainingCount} more`
+    : previewNames;
+}
+
+function partsLabel(values: string[]) {
+  return groupVoicingParts(values) || "No parts listed";
+}
+
+function centerForMarkers(markers: DiscoveryMapMarker[]): [number, number] {
+  if (markers.length === 0) {
+    return DEFAULT_CENTER;
+  }
+
+  return [
+    markers.reduce((total, marker) => total + marker.longitude, 0) /
+      markers.length,
+    markers.reduce((total, marker) => total + marker.latitude, 0) /
+      markers.length,
+  ];
+}
+
+function boundsForMarkers(
+  markers: DiscoveryMapMarker[],
+  mapboxgl: typeof import("mapbox-gl").default,
+): LngLatBoundsLike {
+  const bounds = new mapboxgl.LngLatBounds();
+
+  for (const marker of markers) {
+    bounds.extend([marker.longitude, marker.latitude]);
+  }
+
+  return bounds;
+}
+
+function createPopupNode(marker: DiscoveryMapMarker, resultBasePath: string) {
+  const container = document.createElement("div");
+  container.className = "max-w-xs text-sm";
+
+  const title = document.createElement("h3");
+  title.className = "font-bold text-[#172023]";
+  title.textContent = marker.label;
+  container.append(title);
+
+  const summary = document.createElement("p");
+  summary.className = "mt-1 text-[#394548]";
+  summary.textContent = `${marker.count} ${markerKindLabel(
+    marker,
+  )}: ${markerSummary(marker)}`;
+  container.append(summary);
+
+  if (marker.parts.length > 0) {
+    const parts = document.createElement("p");
+    parts.className = "mt-2 font-semibold text-[#2f6f73]";
+    parts.textContent = partsLabel(marker.parts);
+    container.append(parts);
+  }
+
+  const link = document.createElement("a");
+  link.className =
+    "mt-3 inline-flex min-h-10 items-center rounded-md bg-[#174b4f] px-3 py-2 font-semibold text-white hover:bg-[#10393c]";
+  link.href = `${resultBasePath}#result-${marker.resultIds[0]}`;
+  link.textContent = "View matching result";
+  container.append(link);
+
+  return container;
+}
+
+function createMarkerElement(marker: DiscoveryMapMarker) {
+  const element = document.createElement("button");
+  element.type = "button";
+  element.className =
+    "flex h-9 min-w-9 items-center justify-center rounded-full border-2 border-white bg-[#174b4f] px-2 text-sm font-bold text-white shadow-md hover:bg-[#10393c] focus:outline-none focus:ring-2 focus:ring-[#f5bd47]";
+  element.textContent = String(marker.count);
+  element.setAttribute(
+    "aria-label",
+    `${marker.label}: ${marker.count} ${markerKindLabel(marker)}`,
+  );
+
+  return element;
+}
+
+export function InteractiveDiscoveryMap({
+  emptyMessage,
+  markers,
+  resultBasePath = "",
+  resultLabel,
+  scopeLabel,
+  totalResults,
+}: InteractiveDiscoveryMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<MapboxMap | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !MAPBOX_TOKEN) {
+      return;
+    }
+
+    let canceled = false;
+    let map: MapboxMap | null = null;
+    let markerInstances: MapboxMarker[] = [];
+
+    async function initializeMap() {
+      const mapboxgl = (await import("mapbox-gl")).default;
+
+      if (canceled || !containerRef.current) {
+        return;
+      }
+
+      mapboxgl.accessToken = MAPBOX_TOKEN;
+
+      map = new mapboxgl.Map({
+        attributionControl: false,
+        center: centerForMarkers(markers),
+        container: containerRef.current,
+        cooperativeGestures: true,
+        projection: MAP_PROJECTION as MapOptions["projection"],
+        style: MAPBOX_STYLE,
+        zoom: markers.length > 1 ? 2.2 : 4,
+      });
+
+      map.addControl(
+        new mapboxgl.NavigationControl({ showCompass: false }),
+        "top-right",
+      );
+      map.addControl(
+        new mapboxgl.AttributionControl({ compact: true }),
+        "bottom-right",
+      );
+      map.on("style.load", () => {
+        map?.setFog({
+          color: "rgb(225, 236, 232)",
+          "high-color": "rgb(95, 137, 150)",
+          "horizon-blend": 0.04,
+          "space-color": "rgb(15, 34, 39)",
+          "star-intensity": 0.15,
+        });
+      });
+
+      markerInstances = markers.map((marker) => {
+        const popup = new mapboxgl.Popup({
+          closeButton: true,
+          closeOnClick: true,
+          maxWidth: "320px",
+          offset: 18,
+        }).setDOMContent(createPopupNode(marker, resultBasePath));
+
+        return new mapboxgl.Marker({
+          element: createMarkerElement(marker),
+        })
+          .setLngLat([marker.longitude, marker.latitude])
+          .setPopup(popup)
+          .addTo(map as MapboxMap);
+      });
+
+      if (markers.length > 1) {
+        map.fitBounds(boundsForMarkers(markers, mapboxgl), {
+          duration: 0,
+          maxZoom: 5,
+          padding: 70,
+        });
+      }
+
+      mapRef.current = map;
+    }
+
+    void initializeMap();
+
+    return () => {
+      canceled = true;
+
+      for (const marker of markerInstances) {
+        marker.remove();
+      }
+
+      map?.remove();
+      mapRef.current = null;
+    };
+  }, [markers, resultBasePath]);
+
+  return (
+    <section
+      aria-label="Interactive privacy-safe discovery map"
+      className="overflow-hidden rounded-lg border border-[#d7cec0] bg-[#dce8e3]"
+    >
+      <div className="border-b border-[#d7cec0] bg-white/90 px-4 py-3">
+        <h2 className="font-bold text-[#172023]">{resultLabel}</h2>
+        <p className="mt-1 text-sm text-[#394548]">
+          {totalResults} visible results across {markers.length} approximate
+          regions. Scope: {scopeLabel}.
+        </p>
+      </div>
+
+      <div className="relative h-[30rem] bg-[#cbded9]">
+        {MAPBOX_TOKEN ? (
+          <div
+            aria-label="Mapbox globe discovery map"
+            className="h-full w-full"
+            ref={containerRef}
+          />
+        ) : (
+          <div
+            className="absolute inset-x-6 top-8 rounded-lg border border-[#d7cec0] bg-white/95 p-5 text-sm leading-6 text-[#394548] shadow-sm"
+            role="status"
+          >
+            Mapbox map rendering needs `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`.
+            Results remain available below the map.
+          </div>
+        )}
+
+        {markers.length === 0 ? (
+          <div className="absolute inset-x-6 bottom-8 rounded-lg border border-[#d7cec0] bg-white/95 p-5 text-sm leading-6 text-[#394548] shadow-sm">
+            {emptyMessage}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/docs/accessibility-mobile-audit.md
+++ b/docs/accessibility-mobile-audit.md
@@ -25,10 +25,13 @@ This pre-launch audit covers the core public and signed-in flows:
 - Error and success messages use status or alert semantics where server-rendered feedback appears.
 - Search filters accept global country, region, locality, and long location strings without US-only assumptions.
 - Contact and feedback flows keep personal contact details private and retain app-mediated language.
-- Find keeps filters/search above the privacy-safe approximate map and includes a results table below the visual map.
+- Find keeps filters/search above the privacy-safe interactive map and includes
+  result cards below the visual map.
 
 ## Follow-Up Issues
 
 - Add automated accessibility scanning to CI after the UI surface stabilizes.
-- Revisit the map if it becomes a real interactive map widget; keyboard panning, zoom controls, and marker popovers will need a separate accessibility pass.
+- Run a focused accessibility pass on the Mapbox widget after production data is
+  available; marker popovers are keyboard-openable, and result cards remain the
+  primary accessible way to browse results.
 - Consider a compact mobile filter drawer if discovery filters grow beyond the current launch fields.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,9 +30,8 @@ Codex/local development path:
 - Vercel: web hosting, preview deployments, production deployment
 - Supabase: auth, database, Row Level Security
 - Resend: transactional email and contact relay notifications
-- Map provider: provider-agnostic MVP map now; MapLibre with
-  OpenStreetMap-compatible raster or vector tiles is the preferred future
-  provider approach when richer panning/zooming is needed
+- Map provider: Mapbox GL JS for the interactive discovery map, using a
+  non-Mercator projection by default
 - Namecheap: domain registrar for `quartetmemberfinder.org`
 
 ## Global location expectations
@@ -69,6 +68,12 @@ Expected variables will likely include:
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `NEXT_PUBLIC_POSTHOG_KEY` optional product analytics key
 - `NEXT_PUBLIC_POSTHOG_HOST` optional PostHog ingest host
+- `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` public Mapbox browser token for the
+  interactive discovery map
+- `NEXT_PUBLIC_MAPBOX_STYLE_URL` optional Mapbox style URL, defaulting to
+  `mapbox://styles/mapbox/streets-v12`
+- `NEXT_PUBLIC_MAPBOX_PROJECTION` optional Mapbox GL projection, defaulting to
+  `globe`
 - `SUPABASE_SERVICE_ROLE_KEY` for server-only administrative scripts, never browser code
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
@@ -117,6 +122,8 @@ Recommended Vercel project setup:
 NEXT_PUBLIC_APP_URL=https://quartetmemberfinder.org
 NEXT_PUBLIC_SUPABASE_URL=<production Supabase project URL>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<production Supabase anon key>
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=<public Mapbox pk token>
+NEXT_PUBLIC_MAPBOX_PROJECTION=globe
 SUPABASE_SERVICE_ROLE_KEY=<production Supabase service-role key>
 RESEND_API_KEY=<production Resend API key>
 RESEND_FROM_EMAIL=messages@quartetmemberfinder.org
@@ -445,9 +452,15 @@ service-role code.
 
 ## Maps and geocoding
 
-The current public discovery map does not require a third-party map tile
-provider. It uses public discovery-view location summaries and country/region
-anchors to render approximate regional markers.
+The interactive discovery map uses Mapbox GL JS with the `globe` projection by
+default. Mapbox GL also supports alternatives such as `equalEarth`,
+`naturalEarth`, `winkelTripel`, and `equirectangular`; use
+`NEXT_PUBLIC_MAPBOX_PROJECTION` if the product needs a different non-Mercator
+presentation later.
+
+The browser map requires `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`. Use a public
+`pk...` token with no secret scopes. Do not put an `sk...` secret token in a
+`NEXT_PUBLIC_` variable.
 
 Approximate radius search can use server-side Mapbox geocoding. Keep
 `MAPBOX_GEOCODING_TOKEN` server-only. Set `MAPBOX_GEOCODING_PERMANENT=true`
@@ -455,19 +468,10 @@ only when the Mapbox account is allowed to store geocoding results, because
 profile/listing save actions persist private approximate coordinates in
 Supabase.
 
-When interactive tiles are added, use a provider-compatible MapLibre setup
-rather than sending exact home coordinates to the browser. Provider
-configuration should be optional and documented in `.env.example`. Expected
-future public configuration values are:
-
-- `NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE`
-- `NEXT_PUBLIC_MAP_ATTRIBUTION`
-- `NEXT_PUBLIC_MAP_STYLE_URL` when using a hosted vector style
-
 Geocoding provider secrets, if any, must be server-only. Browser-rendered map
 props should contain approximate public labels, regional anchors, rounded
-distances, or jittered/blurred marker positions, never exact private
-latitude/longitude or private address fields.
+distances, or jittered/blurred marker positions derived from public discovery
+fields, never exact private latitude/longitude or private address fields.
 
 ## Product analytics
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -23,9 +23,11 @@ The current scaffold includes `.env.example` with safe placeholder keys:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
-- `NEXT_PUBLIC_MAP_TILE_URL_TEMPLATE` optional future map tile template
-- `NEXT_PUBLIC_MAP_ATTRIBUTION` optional future map attribution
-- `NEXT_PUBLIC_MAP_STYLE_URL` optional future hosted map style
+- `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` optional public Mapbox browser token for
+  the interactive discovery map
+- `NEXT_PUBLIC_MAPBOX_STYLE_URL` optional Mapbox style URL
+- `NEXT_PUBLIC_MAPBOX_PROJECTION` optional Mapbox GL projection, defaulting to
+  `globe`
 
 Do not expose server-only values in browser code.
 
@@ -111,10 +113,13 @@ must happen in server code after the database resolves the recipient.
 
 ## Maps
 
-The MVP discovery map does not require a map provider. Optional public map
-values are reserved for a future MapLibre/OpenStreetMap-compatible tile setup.
-Geocoding secrets, if later needed, should be server-only and must not use the
-`NEXT_PUBLIC_` prefix.
+The discovery map uses Mapbox GL JS. Set `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` in
+Vercel Production and Preview to render the interactive map. This must be a
+public `pk...` token with no secret scopes. `NEXT_PUBLIC_MAPBOX_PROJECTION`
+defaults to `globe` so the primary map is not Web Mercator.
+
+Server-side geocoding uses separate `MAPBOX_GEOCODING_*` values. Geocoding
+secrets should be server-only and must not use the `NEXT_PUBLIC_` prefix.
 
 ## Product Analytics
 

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -118,15 +118,15 @@ Record before launch:
 
 ## Core User Flows
 
-| Status   | Item                                                                                                                                                     | Verification                                                         |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Complete | Onboarding routes signed-in first-time users to a useful first action.                                                                                   | Issue #41; smoke test plan.                                          |
-| Complete | Empty states provide useful next actions.                                                                                                                | Issue #40; smoke test plan.                                          |
-| Complete | My Singer Profile stores parts, goals, location, visibility, and private postal code separately.                                                         | `/app/profile`; `docs/privacy-model.md#singer-profile-management`.   |
-| Complete | My Quartet Profile stores covered parts and needed parts separately.                                                                                     | `/app/listings`; `docs/privacy-model.md#quartet-listing-management`. |
-| Complete | Find consolidates public discovery into filters, privacy-safe map, and results table; detailed Singer, Quartet Opening, and Map routes remain available. | `/find`, `/singers`, `/quartets`, `/map`.                            |
-| Manual   | Run the full manual smoke test plan on production before launch.                                                                                         | `docs/smoke-test-plan.md`.                                           |
-| Manual   | Confirm seed/demo data is not loaded into production.                                                                                                    | `docs/seed-data.md`; Supabase production data review.                |
+| Status   | Item                                                                                                                                                                  | Verification                                                         |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Complete | Onboarding routes signed-in first-time users to a useful first action.                                                                                                | Issue #41; smoke test plan.                                          |
+| Complete | Empty states provide useful next actions.                                                                                                                             | Issue #40; smoke test plan.                                          |
+| Complete | My Singer Profile stores parts, goals, location, visibility, and private postal code separately.                                                                      | `/app/profile`; `docs/privacy-model.md#singer-profile-management`.   |
+| Complete | My Quartet Profile stores covered parts and needed parts separately.                                                                                                  | `/app/listings`; `docs/privacy-model.md#quartet-listing-management`. |
+| Complete | Find consolidates public discovery into filters, a privacy-safe interactive map, and result cards; detailed Singer, Quartet Opening, and Map routes remain available. | `/find`, `/singers`, `/quartets`, `/map`.                            |
+| Manual   | Run the full manual smoke test plan on production before launch.                                                                                                      | `docs/smoke-test-plan.md`.                                           |
+| Manual   | Confirm seed/demo data is not loaded into production.                                                                                                                 | `docs/seed-data.md`; Supabase production data review.                |
 
 ## Accessibility and Mobile
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -85,13 +85,14 @@ Avoid exact map pins. Map interfaces should use one of the following:
 - region/city-level markers
 - search-result areas rather than exact addresses
 
-The MVP discovery map uses region-level markers derived from public discovery
-fields only: public location label, locality, region, country, country code, and
-rounded approximate distance when radius search is active. It must not receive
-base-table coordinates, private postal codes, or formatted private addresses in
-browser-rendered props. Marker placement may use country/region anchors and
-deterministic offsets so nearby results can cluster without implying a home
-address or exact rehearsal location.
+The interactive discovery map uses Mapbox GL JS with a non-Mercator `globe`
+projection by default. It renders region-level markers derived from public
+discovery fields only: public location label, locality, region, country, country
+code, and rounded approximate distance when radius search is active. It must not
+receive base-table coordinates, private postal codes, or formatted private
+addresses in browser-rendered props. Marker placement may use country/region
+anchors and deterministic offsets so nearby results can cluster without implying
+a home address or exact rehearsal location.
 
 ## Visibility controls
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -140,15 +140,17 @@ validation.
 3. Pass: the distance-unit picker defaults to Miles and sits beside the radius
    field.
 4. Pass: part filtering accepts multiple voicing-aware values.
-5. Pass: the approximate map and result cards use the same filtered result set.
-6. Pass: result cards distinguish singer profiles from quartet openings and
+5. Pass: the interactive map and result cards use the same filtered result set.
+6. Pass: the map uses a non-Mercator Mapbox projection, supports pan/zoom, and
+   opens marker summaries that link to matching result cards.
+7. Pass: result cards distinguish singer profiles from quartet openings and
    include enough decision-making detail to open the details/contact panel.
-7. Pass: details/contact panels stay on `/find` and do not expose private email,
+8. Pass: details/contact panels stay on `/find` and do not expose private email,
    phone, exact ZIP/postal code, street address, or exact coordinates.
-8. Pass: empty results show helpful next actions, including increasing radius or
+9. Pass: empty results show helpful next actions, including increasing radius or
    changing filters.
-9. Fail: hidden or inactive profiles/listings appear in public results.
-10. Fail: public UI exposes owner user IDs, private postal codes, exact
+10. Fail: hidden or inactive profiles/listings appear in public results.
+11. Fail: public UI exposes owner user IDs, private postal codes, exact
     coordinates, email addresses, or phone numbers.
 
 ## Detailed Quartet Opening Search
@@ -177,9 +179,9 @@ validation.
 2. Test filters for United States and at least one non-US location, such as
    Ireland or United Kingdom.
 3. Pass: visible singer profiles and quartet listings with public locations
-   appear as approximate region markers.
+   appear as approximate markers on the interactive map.
 4. Pass: repeated locations cluster without exposing private exact coordinates.
-5. Pass: markers are still usable on mobile width.
+5. Pass: markers are still usable on mobile width and the page can still scroll.
 6. Fail: markers use exact home pins, raw latitude/longitude, or private postal
    code labels.
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -252,7 +252,10 @@ not stored.
 
 The public map route must continue to use those discovery views rather than base
 tables. Map markers are built from public location summaries and country/region
-anchors; no latitude/longitude columns should be selected for browser display.
+anchors; no private latitude/longitude columns should be selected for browser
+display. The browser may receive approximate marker coordinates derived from
+public country/region/locality values so the interactive map can place regional
+markers without exposing stored home-location coordinates.
 
 ## Contact data expectations
 

--- a/lib/location/map-markers.ts
+++ b/lib/location/map-markers.ts
@@ -20,8 +20,10 @@ export type DiscoveryMapItem = {
 export type DiscoveryMapMarker = {
   id: string;
   count: number;
+  latitude: number;
   kinds: DiscoveryMapKind[];
   label: string;
+  longitude: number;
   names: string[];
   parts: string[];
   resultIds: string[];
@@ -30,32 +32,79 @@ export type DiscoveryMapMarker = {
 };
 
 type MapAnchor = {
+  latitude: number;
+  longitude: number;
   xPercent: number;
   yPercent: number;
 };
 
 const COUNTRY_ANCHORS: Record<string, MapAnchor> = {
-  australia: { xPercent: 80, yPercent: 72 },
-  au: { xPercent: 80, yPercent: 72 },
-  canada: { xPercent: 22, yPercent: 24 },
-  ca: { xPercent: 22, yPercent: 24 },
-  france: { xPercent: 49, yPercent: 39 },
-  fr: { xPercent: 49, yPercent: 39 },
-  germany: { xPercent: 51, yPercent: 37 },
-  de: { xPercent: 51, yPercent: 37 },
-  ireland: { xPercent: 46, yPercent: 35 },
-  ie: { xPercent: 46, yPercent: 35 },
-  netherlands: { xPercent: 49, yPercent: 35 },
-  nl: { xPercent: 49, yPercent: 35 },
-  "new zealand": { xPercent: 86, yPercent: 78 },
-  nz: { xPercent: 86, yPercent: 78 },
-  "united kingdom": { xPercent: 47, yPercent: 34 },
-  uk: { xPercent: 47, yPercent: 34 },
-  gb: { xPercent: 47, yPercent: 34 },
-  "united states": { xPercent: 24, yPercent: 43 },
-  "united states of america": { xPercent: 24, yPercent: 43 },
-  us: { xPercent: 24, yPercent: 43 },
-  usa: { xPercent: 24, yPercent: 43 },
+  australia: {
+    latitude: -25.2744,
+    longitude: 133.7751,
+    xPercent: 80,
+    yPercent: 72,
+  },
+  au: { latitude: -25.2744, longitude: 133.7751, xPercent: 80, yPercent: 72 },
+  canada: {
+    latitude: 56.1304,
+    longitude: -106.3468,
+    xPercent: 22,
+    yPercent: 24,
+  },
+  ca: { latitude: 56.1304, longitude: -106.3468, xPercent: 22, yPercent: 24 },
+  france: { latitude: 46.2276, longitude: 2.2137, xPercent: 49, yPercent: 39 },
+  fr: { latitude: 46.2276, longitude: 2.2137, xPercent: 49, yPercent: 39 },
+  germany: {
+    latitude: 51.1657,
+    longitude: 10.4515,
+    xPercent: 51,
+    yPercent: 37,
+  },
+  de: { latitude: 51.1657, longitude: 10.4515, xPercent: 51, yPercent: 37 },
+  ireland: {
+    latitude: 53.1424,
+    longitude: -7.6921,
+    xPercent: 46,
+    yPercent: 35,
+  },
+  ie: { latitude: 53.1424, longitude: -7.6921, xPercent: 46, yPercent: 35 },
+  netherlands: {
+    latitude: 52.1326,
+    longitude: 5.2913,
+    xPercent: 49,
+    yPercent: 35,
+  },
+  nl: { latitude: 52.1326, longitude: 5.2913, xPercent: 49, yPercent: 35 },
+  "new zealand": {
+    latitude: -40.9006,
+    longitude: 174.886,
+    xPercent: 86,
+    yPercent: 78,
+  },
+  nz: { latitude: -40.9006, longitude: 174.886, xPercent: 86, yPercent: 78 },
+  "united kingdom": {
+    latitude: 55.3781,
+    longitude: -3.436,
+    xPercent: 47,
+    yPercent: 34,
+  },
+  uk: { latitude: 55.3781, longitude: -3.436, xPercent: 47, yPercent: 34 },
+  gb: { latitude: 55.3781, longitude: -3.436, xPercent: 47, yPercent: 34 },
+  "united states": {
+    latitude: 39.8283,
+    longitude: -98.5795,
+    xPercent: 24,
+    yPercent: 43,
+  },
+  "united states of america": {
+    latitude: 39.8283,
+    longitude: -98.5795,
+    xPercent: 24,
+    yPercent: 43,
+  },
+  us: { latitude: 39.8283, longitude: -98.5795, xPercent: 24, yPercent: 43 },
+  usa: { latitude: 39.8283, longitude: -98.5795, xPercent: 24, yPercent: 43 },
 };
 
 function stableHash(value: string) {
@@ -90,6 +139,8 @@ function anchorForItem(item: DiscoveryMapItem): MapAnchor {
   );
 
   return {
+    latitude: 50 - ((hash >>> 12) % 100),
+    longitude: -170 + (hash % 340),
     xPercent: 12 + (hash % 76),
     yPercent: 24 + ((hash >>> 8) % 50),
   };
@@ -104,6 +155,14 @@ function approximateMarkerPosition(item: DiscoveryMapItem): MapAnchor {
   const yOffset = ((offsetHash >>> 4) % 11) - 5;
 
   return {
+    latitude: Math.min(
+      80,
+      Math.max(-60, anchor.latitude + (((offsetHash >>> 10) % 60) - 30) / 10),
+    ),
+    longitude: Math.min(
+      175,
+      Math.max(-175, anchor.longitude + (((offsetHash >>> 16) % 80) - 40) / 10),
+    ),
     xPercent: Math.min(92, Math.max(8, anchor.xPercent + xOffset)),
     yPercent: Math.min(82, Math.max(16, anchor.yPercent + yOffset)),
   };
@@ -148,13 +207,16 @@ export function buildDiscoveryMapMarkers(
       continue;
     }
 
-    const { xPercent, yPercent } = approximateMarkerPosition(item);
+    const { latitude, longitude, xPercent, yPercent } =
+      approximateMarkerPosition(item);
 
     markerGroups.set(groupKey, {
       count: 1,
       id: groupKey,
       kinds: [item.kind],
+      latitude,
       label,
+      longitude,
       names: [item.name],
       parts: [...item.parts].sort(),
       resultIds: [item.id],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.105.1",
+        "mapbox-gl": "^3.23.0",
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -1581,6 +1582,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2704,6 +2740,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2727,6 +2778,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2745,6 +2802,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -3954,6 +4020,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cheap-ruler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
+      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
+      "license": "ISC"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -4037,6 +4109,12 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -4233,6 +4311,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.345",
@@ -5184,6 +5268,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5254,6 +5344,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5315,6 +5411,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -6026,6 +6128,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6417,6 +6525,55 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mapbox-gl": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.23.0.tgz",
+      "integrity": "sha512-zzjNAaMNvXnAVEUrYpOWmRVEBCIWgDAMLRPvSOoKY3smKvrINFVrRK/1jEpUDbEa7Ppf5Q/nwC6E07tz/i7IKw==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "workspaces": [
+        "src/style-spec",
+        "packages/pmtiles-provider",
+        "test/build/vite",
+        "test/build/webpack",
+        "test/build/typings"
+      ],
+      "dependencies": {
+        "@mapbox/mapbox-gl-supported": "^3.0.0",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/geojson-vt": "^3.2.5",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "cheap-ruler": "^4.0.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^3.0.1",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.4",
+        "grid-index": "^1.1.0",
+        "kdbush": "^4.0.2",
+        "martinez-polygon-clipping": "^0.8.1",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0"
+      }
+    },
+    "node_modules/martinez-polygon-clipping": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
+      "integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^2.0.4",
+        "splaytree": "^0.1.4",
+        "tinyqueue": "3.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6489,6 +6646,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6897,6 +7060,18 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6954,6 +7129,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -7030,6 +7211,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7060,6 +7247,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -7192,6 +7385,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7202,6 +7404,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -7555,6 +7763,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/splaytree": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+      "license": "MIT"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -7782,6 +7996,15 @@
         }
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7900,6 +8123,12 @@
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.105.1",
+    "mapbox-gl": "^3.23.0",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/test/interactive-map.test.ts
+++ b/test/interactive-map.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const component = readFileSync(
+  "components/discovery/interactive-discovery-map.tsx",
+  "utf8",
+);
+const envExample = readFileSync(".env.example", "utf8");
+
+describe("interactive discovery map", () => {
+  it("uses Mapbox GL with a non-Mercator default projection", () => {
+    expect(component).toContain("mapbox-gl");
+    expect(component).toContain('?? "globe"');
+    expect(component).not.toContain('?? "mercator"');
+    expect(component).toContain("cooperativeGestures");
+  });
+
+  it("documents the required public browser token", () => {
+    expect(envExample).toContain("NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN");
+    expect(envExample).toContain("NEXT_PUBLIC_MAPBOX_PROJECTION=globe");
+    expect(component).toContain("NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN");
+  });
+
+  it("does not expose private location field names in browser map props", () => {
+    expect(component).not.toMatch(
+      /postal_code_private|latitude_private|longitude_private/,
+    );
+  });
+});

--- a/test/map-markers.test.ts
+++ b/test/map-markers.test.ts
@@ -39,8 +39,10 @@ describe("privacy-safe discovery map markers", () => {
       expect(marker.xPercent).toBeLessThanOrEqual(92);
       expect(marker.yPercent).toBeGreaterThanOrEqual(16);
       expect(marker.yPercent).toBeLessThanOrEqual(82);
-      expect(Object.keys(marker)).not.toContain("latitude");
-      expect(Object.keys(marker)).not.toContain("longitude");
+      expect(marker.latitude).toBeGreaterThanOrEqual(-60);
+      expect(marker.latitude).toBeLessThanOrEqual(80);
+      expect(marker.longitude).toBeGreaterThanOrEqual(-175);
+      expect(marker.longitude).toBeLessThanOrEqual(175);
     }
   });
 

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -60,7 +60,7 @@ describe("public discovery copy", () => {
 
     expect(findPage).toContain("Search quartet openings and singers");
     expect(findPage).toContain("Filter discovery results");
-    expect(findPage).toContain("Privacy-safe discovery map");
+    expect(findPage).toContain("InteractiveDiscoveryMap");
     expect(findPage).toContain("Search from");
     expect(findPage).toContain("Within");
     expect(findPage).toContain("multiple");


### PR DESCRIPTION
Closes #104

## Summary
- replace the CSS pseudo-map in /find and /map with a shared Mapbox GL interactive map component
- default the map to the non-Mercator globe projection, with optional projection/style env overrides
- keep markers privacy-safe by deriving approximate regional coordinates from public discovery fields rather than selecting private stored coordinates
- connect marker popups to matching result cards/region summaries and keep accessible list/card results available below the map
- document Mapbox setup, env vars, privacy behavior, and smoke-test expectations

## Environment
- requires NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN in Vercel Production and Preview for the browser map to render
- token should be a public pk token with no secret scopes
- optional: NEXT_PUBLIC_MAPBOX_STYLE_URL and NEXT_PUBLIC_MAPBOX_PROJECTION, defaulting to mapbox://styles/mapbox/streets-v12 and globe

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build

## Notes
- no Supabase migration in this PR
- local dev server started, but shell HTTP probes could not connect to localhost in this sandbox; production build completed successfully