### PR TITLE
Build app-mediated Messages workflow

### DIFF
--- a/app/(protected)/app/messages/[id]/page.tsx
+++ b/app/(protected)/app/messages/[id]/page.tsx
@@ -1,0 +1,248 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { sendMessageReply } from "@/app/(protected)/app/messages/actions";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type MessageDetailPageProps = {
+  params: Promise<{
+    id: string;
+  }>;
+  searchParams: Promise<{
+    reply?: string;
+  }>;
+};
+
+type ContactRequestRow = {
+  created_at: string;
+  id: string;
+  message_body: string;
+  quartet_listing_id: string | null;
+  recipient_user_id: string | null;
+  sender_user_id: string;
+  singer_profile_id: string | null;
+  status: string;
+};
+
+type ContactReplyRow = {
+  created_at: string;
+  id: string;
+  message_body: string;
+  sender_user_id: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function replyStatusMessage(value: string | undefined) {
+  if (value === "sent") {
+    return "Reply sent. The other person has been notified by email.";
+  }
+
+  if (value === "stored") {
+    return "Reply saved. Email notification is waiting on Resend or server email configuration.";
+  }
+
+  if (value === "error") {
+    return "Unable to send that reply. Check the message and try again.";
+  }
+
+  return null;
+}
+
+function targetKind(request: ContactRequestRow) {
+  return request.singer_profile_id ? "singer profile" : "quartet profile";
+}
+
+async function targetName(
+  supabase: NonNullable<Awaited<ReturnType<typeof createSupabaseServerClient>>>,
+  request: ContactRequestRow,
+) {
+  if (request.singer_profile_id) {
+    const [{ data: owned }, { data: visible }] = await Promise.all([
+      supabase
+        .from("singer_profiles")
+        .select("display_name")
+        .eq("id", request.singer_profile_id)
+        .maybeSingle(),
+      supabase
+        .from("singer_discovery_profiles")
+        .select("display_name")
+        .eq("id", request.singer_profile_id)
+        .maybeSingle(),
+    ]);
+
+    return owned?.display_name ?? visible?.display_name ?? "Singer profile";
+  }
+
+  const quartetId = request.quartet_listing_id ?? "unknown";
+  const [{ data: owned }, { data: visible }] = await Promise.all([
+    supabase
+      .from("quartet_listings")
+      .select("name")
+      .eq("id", quartetId)
+      .maybeSingle(),
+    supabase
+      .from("quartet_discovery_listings")
+      .select("name")
+      .eq("id", quartetId)
+      .maybeSingle(),
+  ]);
+
+  return owned?.name ?? visible?.name ?? "Quartet profile";
+}
+
+export default async function MessageDetailPage({
+  params,
+  searchParams,
+}: MessageDetailPageProps) {
+  const [{ id }, query] = await Promise.all([params, searchParams]);
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  if (!supabase || !user) {
+    return null;
+  }
+
+  const { data: request } = await supabase
+    .from("contact_requests")
+    .select(
+      "id, sender_user_id, recipient_user_id, singer_profile_id, quartet_listing_id, message_body, status, created_at",
+    )
+    .eq("id", id)
+    .maybeSingle<ContactRequestRow>();
+
+  if (
+    !request ||
+    (request.sender_user_id !== user.id &&
+      request.recipient_user_id !== user.id)
+  ) {
+    notFound();
+  }
+
+  const [{ data: replies }, resolvedTargetName] = await Promise.all([
+    supabase
+      .from("contact_request_replies")
+      .select("id, sender_user_id, message_body, created_at")
+      .eq("contact_request_id", request.id)
+      .order("created_at", { ascending: true }),
+    targetName(supabase, request),
+  ]);
+  const replyStatus = replyStatusMessage(query.reply);
+  const userIsOriginalSender = request.sender_user_id === user.id;
+
+  return (
+    <div className="max-w-3xl">
+      <Link className="font-semibold text-[#2f6f73]" href="/app/messages">
+        Back to Messages
+      </Link>
+      <header className="mt-6">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Message detail
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          {resolvedTargetName}
+        </h1>
+        <p className="mt-3 text-base leading-7 text-[#394548]">
+          {userIsOriginalSender
+            ? `You sent this first contact request to a ${targetKind(request)}.`
+            : `This first contact request was sent to your ${targetKind(
+                request,
+              )}.`}
+        </p>
+      </header>
+
+      {replyStatus ? (
+        <p
+          className={`mt-6 rounded-lg border p-4 text-sm ${
+            query.reply === "error"
+              ? "border-red-200 bg-red-50 text-red-800"
+              : "border-[#b7d7ce] bg-[#eef8f4] text-[#174b4f]"
+          }`}
+          role={query.reply === "error" ? "alert" : "status"}
+        >
+          {replyStatus}
+        </p>
+      ) : null}
+
+      <article className="mt-8 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <h2 className="text-xl font-bold text-[#172023]">Original message</h2>
+          <p className="text-sm text-[#596466]">
+            {formatDate(request.created_at)}
+          </p>
+        </div>
+        <p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-[#394548]">
+          {request.message_body}
+        </p>
+      </article>
+
+      <section className="mt-8" aria-labelledby="replies-heading">
+        <h2 className="text-2xl font-bold text-[#172023]" id="replies-heading">
+          Replies
+        </h2>
+        {(replies ?? []).length === 0 ? (
+          <p className="mt-3 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-sm leading-6 text-[#394548]">
+            No replies yet. Replies stay in the app, and notification emails
+            link back here.
+          </p>
+        ) : (
+          <div className="mt-4 space-y-4">
+            {((replies ?? []) as ContactReplyRow[]).map((reply) => (
+              <article
+                className="rounded-lg border border-[#d7cec0] bg-white p-5"
+                key={reply.id}
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <h3 className="font-bold text-[#172023]">
+                    {reply.sender_user_id === user.id
+                      ? "You"
+                      : "The other participant"}
+                  </h3>
+                  <p className="text-sm text-[#596466]">
+                    {formatDate(reply.created_at)}
+                  </p>
+                </div>
+                <p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-[#394548]">
+                  {reply.message_body}
+                </p>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <form
+        action={sendMessageReply}
+        className="mt-8 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+      >
+        <input name="requestId" type="hidden" value={request.id} />
+        <label className="block">
+          <span className="text-sm font-semibold text-[#172023]">Reply</span>
+          <textarea
+            className="mt-2 min-h-32 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            maxLength={2000}
+            name="message"
+            placeholder="Write a friendly reply. Share direct contact details only if you choose to."
+            required
+          />
+        </label>
+        <p className="mt-3 text-sm leading-6 text-[#596466]">
+          Private email addresses and phone numbers are not shown by default.
+          The notification email points the other participant back to Messages.
+        </p>
+        <button
+          className="mt-4 w-full rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#10393c] sm:w-fit"
+          type="submit"
+        >
+          Send reply
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/(protected)/app/messages/actions.ts
+++ b/app/(protected)/app/messages/actions.ts
@@ -1,0 +1,191 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  CONTACT_MESSAGE_MAX_LENGTH,
+  getContactRelayConfig,
+  sendContactReplyNotification,
+  type ContactTarget,
+} from "@/lib/contact/contact-relay";
+import {
+  createSupabaseAdminClient,
+  createSupabaseServerClient,
+} from "@/lib/supabase/server";
+
+type ContactRequestRow = {
+  id: string;
+  quartet_listing_id: string | null;
+  recipient_user_id: string | null;
+  sender_user_id: string;
+  singer_profile_id: string | null;
+};
+
+type ContactReplyRow = {
+  id: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function redirectWithReplyStatus(
+  requestId: string,
+  status: "error" | "sent" | "stored",
+): never {
+  redirect(`/app/messages/${requestId}?reply=${status}`);
+}
+
+function trimMessage(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+async function resolveContactTarget(
+  supabase: NonNullable<Awaited<ReturnType<typeof createSupabaseServerClient>>>,
+  request: ContactRequestRow,
+): Promise<ContactTarget> {
+  if (request.singer_profile_id) {
+    const [{ data: owned }, { data: visible }] = await Promise.all([
+      supabase
+        .from("singer_profiles")
+        .select("id, display_name")
+        .eq("id", request.singer_profile_id)
+        .maybeSingle(),
+      supabase
+        .from("singer_discovery_profiles")
+        .select("id, display_name")
+        .eq("id", request.singer_profile_id)
+        .maybeSingle(),
+    ]);
+
+    return {
+      id: request.singer_profile_id,
+      kind: "singer",
+      name: owned?.display_name ?? visible?.display_name ?? "Singer profile",
+    };
+  }
+
+  const quartetId = request.quartet_listing_id ?? "unknown";
+  const [{ data: owned }, { data: visible }] = await Promise.all([
+    supabase
+      .from("quartet_listings")
+      .select("id, name")
+      .eq("id", quartetId)
+      .maybeSingle(),
+    supabase
+      .from("quartet_discovery_listings")
+      .select("id, name")
+      .eq("id", quartetId)
+      .maybeSingle(),
+  ]);
+
+  return {
+    id: quartetId,
+    kind: "quartet",
+    name: owned?.name ?? visible?.name ?? "Quartet profile",
+  };
+}
+
+export async function sendMessageReply(formData: FormData) {
+  const requestId = String(formData.get("requestId") ?? "").trim();
+  const message = trimMessage(formData.get("message"));
+
+  if (!UUID_PATTERN.test(requestId) || !message) {
+    redirect("/app/messages?reply=error");
+  }
+
+  if (message.length > CONTACT_MESSAGE_MAX_LENGTH) {
+    redirectWithReplyStatus(requestId, "error");
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithReplyStatus(requestId, "error");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(
+      `/sign-in?next=${encodeURIComponent(`/app/messages/${requestId}`)}`,
+    );
+  }
+
+  const { data: contactRequest, error: requestError } = await supabase
+    .from("contact_requests")
+    .select(
+      "id, sender_user_id, recipient_user_id, singer_profile_id, quartet_listing_id",
+    )
+    .eq("id", requestId)
+    .maybeSingle<ContactRequestRow>();
+
+  if (
+    requestError ||
+    !contactRequest ||
+    (contactRequest.sender_user_id !== user.id &&
+      contactRequest.recipient_user_id !== user.id)
+  ) {
+    redirect("/app/messages?reply=error");
+  }
+
+  const { data: reply, error: replyError } = await supabase
+    .from("contact_request_replies")
+    .insert({
+      contact_request_id: requestId,
+      message_body: message,
+      sender_user_id: user.id,
+    })
+    .select("id")
+    .single<ContactReplyRow>();
+
+  if (replyError || !reply) {
+    redirectWithReplyStatus(requestId, "error");
+  }
+
+  const otherUserId =
+    contactRequest.sender_user_id === user.id
+      ? contactRequest.recipient_user_id
+      : contactRequest.sender_user_id;
+  const admin = createSupabaseAdminClient();
+  const relayConfig = getContactRelayConfig();
+
+  if (!admin || !relayConfig || !otherUserId) {
+    revalidatePath(`/app/messages/${requestId}`);
+    redirectWithReplyStatus(requestId, "stored");
+  }
+
+  const { data: recipient, error: recipientError } =
+    await admin.auth.admin.getUserById(otherUserId);
+
+  if (recipientError || !recipient.user?.email) {
+    revalidatePath(`/app/messages/${requestId}`);
+    redirectWithReplyStatus(requestId, "stored");
+  }
+
+  try {
+    await sendContactReplyNotification(relayConfig, {
+      recipientEmail: recipient.user.email,
+      replierDisplayName: "A signed-in Quartet Member Finder user",
+      requestId,
+      target: await resolveContactTarget(supabase, contactRequest),
+    });
+    await admin
+      .from("contact_request_replies")
+      .update({ notification_status: "delivered" })
+      .eq("id", reply.id);
+  } catch {
+    revalidatePath(`/app/messages/${requestId}`);
+    redirectWithReplyStatus(requestId, "stored");
+  }
+
+  revalidatePath(`/app/messages/${requestId}`);
+  redirectWithReplyStatus(requestId, "sent");
+}

--- a/app/(protected)/app/messages/page.tsx
+++ b/app/(protected)/app/messages/page.tsx
@@ -1,0 +1,249 @@
+import Link from "next/link";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type MessagesPageProps = {
+  searchParams: Promise<{
+    view?: string;
+  }>;
+};
+
+type ContactRequestRow = {
+  created_at: string;
+  id: string;
+  message_body: string;
+  quartet_listing_id: string | null;
+  recipient_user_id: string | null;
+  sender_user_id: string;
+  singer_profile_id: string | null;
+  status: string;
+  updated_at: string;
+};
+
+type ContactReplyRow = {
+  contact_request_id: string;
+  created_at: string;
+};
+
+const previewLength = 180;
+
+function previewMessage(message: string) {
+  const normalized = message.replace(/\s+/g, " ").trim();
+
+  return normalized.length > previewLength
+    ? `${normalized.slice(0, previewLength - 1)}...`
+    : normalized;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function targetKind(request: ContactRequestRow) {
+  return request.singer_profile_id ? "singer profile" : "quartet profile";
+}
+
+async function targetNames(
+  supabase: NonNullable<Awaited<ReturnType<typeof createSupabaseServerClient>>>,
+  requests: ContactRequestRow[],
+) {
+  const names = new Map<string, string>();
+  const singerIds = requests
+    .map((request) => request.singer_profile_id)
+    .filter((id): id is string => Boolean(id));
+  const quartetIds = requests
+    .map((request) => request.quartet_listing_id)
+    .filter((id): id is string => Boolean(id));
+
+  if (singerIds.length > 0) {
+    const [{ data: owned }, { data: visible }] = await Promise.all([
+      supabase
+        .from("singer_profiles")
+        .select("id, display_name")
+        .in("id", singerIds),
+      supabase
+        .from("singer_discovery_profiles")
+        .select("id, display_name")
+        .in("id", singerIds),
+    ]);
+
+    for (const singer of [...(visible ?? []), ...(owned ?? [])]) {
+      names.set(singer.id, singer.display_name);
+    }
+  }
+
+  if (quartetIds.length > 0) {
+    const [{ data: owned }, { data: visible }] = await Promise.all([
+      supabase.from("quartet_listings").select("id, name").in("id", quartetIds),
+      supabase
+        .from("quartet_discovery_listings")
+        .select("id, name")
+        .in("id", quartetIds),
+    ]);
+
+    for (const quartet of [...(visible ?? []), ...(owned ?? [])]) {
+      names.set(quartet.id, quartet.name);
+    }
+  }
+
+  return names;
+}
+
+function targetName(request: ContactRequestRow, names: Map<string, string>) {
+  const id = request.singer_profile_id ?? request.quartet_listing_id;
+
+  if (!id) {
+    return targetKind(request);
+  }
+
+  return names.get(id) ?? targetKind(request);
+}
+
+export default async function MessagesPage({
+  searchParams,
+}: MessagesPageProps) {
+  const params = await searchParams;
+  const activeView = params.view === "sent" ? "sent" : "inbox";
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  if (!supabase || !user) {
+    return null;
+  }
+
+  const query = supabase
+    .from("contact_requests")
+    .select(
+      "id, sender_user_id, recipient_user_id, singer_profile_id, quartet_listing_id, message_body, status, created_at, updated_at",
+    )
+    .order("updated_at", { ascending: false });
+
+  const { data, error } =
+    activeView === "sent"
+      ? await query.eq("sender_user_id", user.id)
+      : await query.eq("recipient_user_id", user.id);
+  const requests = (data ?? []) as ContactRequestRow[];
+  const names = await targetNames(supabase, requests);
+  const requestIds = requests.map((request) => request.id);
+  const { data: replyRows } =
+    requestIds.length > 0
+      ? await supabase
+          .from("contact_request_replies")
+          .select("contact_request_id, created_at")
+          .in("contact_request_id", requestIds)
+      : { data: [] };
+  const replyCounts = new Map<string, number>();
+
+  for (const reply of (replyRows ?? []) as ContactReplyRow[]) {
+    replyCounts.set(
+      reply.contact_request_id,
+      (replyCounts.get(reply.contact_request_id) ?? 0) + 1,
+    );
+  }
+
+  return (
+    <div>
+      <header className="max-w-3xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Messages
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">Messages</h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          Read app-mediated contact requests and replies without exposing
+          private email addresses or phone numbers by default.
+        </p>
+      </header>
+
+      <nav aria-label="Message views" className="mt-8 flex flex-wrap gap-3">
+        {[
+          { href: "/app/messages", label: "Inbox", view: "inbox" },
+          { href: "/app/messages?view=sent", label: "Sent", view: "sent" },
+        ].map((link) => (
+          <Link
+            aria-current={activeView === link.view ? "page" : undefined}
+            className={`rounded-md border px-4 py-2 text-sm font-semibold ${
+              activeView === link.view
+                ? "border-[#174b4f] bg-[#174b4f] text-white"
+                : "border-[#d7cec0] bg-[#fffaf2] text-[#394548] hover:border-[#2f6f73]"
+            }`}
+            href={link.href}
+            key={link.view}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+
+      {error ? (
+        <p
+          className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+          role="alert"
+        >
+          Unable to load messages right now.
+        </p>
+      ) : null}
+
+      {!error && requests.length === 0 ? (
+        <section className="mt-8 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">
+            {activeView === "sent" ? "No sent messages yet" : "Inbox is empty"}
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            {activeView === "sent"
+              ? "Messages you send to singers or quartet profiles will appear here."
+              : "Messages you receive through the app will appear here."}
+          </p>
+          {activeView === "inbox" ? (
+            <p className="mt-3 text-sm leading-6 text-[#394548]">
+              You can still send messages before publishing a profile. Receiving
+              messages depends on having a discoverable singer or quartet
+              profile.
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="mt-8 grid gap-4">
+        {requests.map((request) => (
+          <Link
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm hover:border-[#2f6f73]"
+            href={`/app/messages/${request.id}`}
+            key={request.id}
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-xl font-bold text-[#172023]">
+                  {targetName(request, names)}
+                </h2>
+                <p className="mt-1 text-sm text-[#596466]">
+                  {activeView === "sent"
+                    ? `Sent to a ${targetKind(request)}`
+                    : `Received for your ${targetKind(request)}`}
+                </p>
+              </div>
+              <p className="text-sm text-[#596466]">
+                {formatDate(request.updated_at ?? request.created_at)}
+              </p>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-[#394548]">
+              {previewMessage(request.message_body)}
+            </p>
+            <p className="mt-4 text-sm font-semibold text-[#2f6f73]">
+              {replyCounts.get(request.id)
+                ? `${replyCounts.get(request.id)} repl${
+                    replyCounts.get(request.id) === 1 ? "y" : "ies"
+                  }`
+                : activeView === "sent"
+                  ? "No replies yet"
+                  : "Awaiting your reply"}
+            </p>
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -153,7 +153,8 @@ The MVP contact flow should:
 1. Allow a signed-in user to send a short message to a singer or quartet listing.
 2. Notify the recipient by email using Resend.
 3. Avoid exposing the recipient’s email address to the sender.
-4. Allow the recipient to decide whether to reply or share direct contact information.
+4. Let sender and recipient read the request and replies in signed-in Messages.
+5. Allow either participant to decide whether to share direct contact information.
 
 Do not publicly display phone numbers or email addresses by default.
 
@@ -168,8 +169,9 @@ request may be stored for audit but email delivery is deferred.
 
 Contact notifications should not reveal the sender’s direct email address by
 default. They should tell the recipient a signed-in user sent the request and
-allow the recipient to decide whether to respond or share direct contact
-information later.
+link through sign-in to the message detail page. Full message and reply bodies
+should stay behind authenticated app access by default. Replies are stored with
+the original request and should be visible only to the two contact participants.
 
 ## Feedback model
 

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -189,9 +189,13 @@ validation.
 5. Pass without Resend configured: the request is stored and the user sees the
    stored/deferred notification message.
 6. Pass: recipient email address is never shown to the sender.
-7. Pass: a user cannot contact their own profile or listing.
-8. Fail: browser form accepts recipient email, recipient user ID, or direct
-   contact details as trusted input.
+7. Pass: the email notification links through sign-in to the message detail page
+   and does not include the full message body.
+8. Pass: the recipient can open Messages, read the message, and send a reply.
+9. Pass: the original sender can open Sent, read the reply, and reply again.
+10. Pass: a user cannot contact their own profile or listing.
+11. Fail: browser form accepts recipient email, recipient user ID, or direct
+    contact details as trusted input.
 
 ## Authenticated Feedback Form
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -17,6 +17,7 @@ It includes these data areas:
 - `quartet_listings`: incomplete quartet listings owned by one authenticated user.
 - `quartet_listing_parts`: voicing-aware parts currently covered or needed by a quartet.
 - `contact_requests`: app-mediated first-contact messages.
+- `contact_request_replies`: app-mediated replies attached to contact requests.
 - `feedback_submissions`: private authenticated-user feedback from the help page.
 - `singer_discovery_profiles`: privacy-safe singer discovery view.
 - `quartet_discovery_listings`: privacy-safe quartet discovery view.
@@ -132,6 +133,7 @@ RLS should enforce:
 - private fields are not exposed in public discovery views
 - contact requests require an authenticated sender
 - recipients can read contact requests addressed to them or to listings they own
+- contact request participants can read and reply inside their own message thread
 - feedback submissions require an authenticated submitter and are not readable by
   other regular users
 
@@ -170,6 +172,14 @@ After the insert, server-only service-role access may read the resolved
 `recipient_user_id` and look up the recipient auth email for a Resend
 notification. Successful notification delivery may update the request status to
 `delivered`; requests remain auditable even if email configuration is missing.
+
+The signed-in Messages area reads `contact_requests` through participant access
+and stores replies in `contact_request_replies`. A reply must be inserted by the
+authenticated sender and must reference a contact request where that user is the
+original sender or resolved recipient. Reply inserts mark the parent contact
+request as `responded`. Notification email for first-contact messages and
+replies links users back through sign-in to `/app/messages/[id]`; full message
+and reply bodies stay behind authenticated app access.
 
 Help-page feedback inserts are authenticated-only. The server action writes
 `feedback_submissions` with the authenticated user ID and, when available, the
@@ -272,6 +282,18 @@ The MVP contact flow should use app-mediated contact with Resend notifications.
 - message body
 - status
 - created and updated timestamps
+- optional sender/recipient read timestamps
+
+`contact_request_replies` stores lightweight app-mediated replies:
+
+- parent contact request
+- reply sender user
+- message body
+- notification status
+- created timestamp
+
+RLS lets only contact participants read replies and lets only participants add
+replies to their own contact requests.
 
 The app applies a basic sender-side rate limit before insert: five contact
 requests per authenticated sender per hour. Database-side rate limiting or abuse

--- a/lib/contact/contact-relay.ts
+++ b/lib/contact/contact-relay.ts
@@ -21,6 +21,13 @@ export type ContactNotification = {
   target: ContactTarget;
 };
 
+export type ContactReplyNotification = {
+  recipientEmail: string;
+  requestId: string;
+  replierDisplayName: string;
+  target: ContactTarget;
+};
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -98,12 +105,14 @@ export function getContactRelayConfig(): ContactRelayConfig | null {
 }
 
 export function buildContactNotificationEmail({
-  message,
   requestId,
   senderDisplayName,
   target,
 }: Omit<ContactNotification, "recipientEmail">) {
   const appUrl = getAppUrl();
+  const messageUrl = `${appUrl}/sign-in?next=${encodeURIComponent(
+    `/app/messages/${requestId}`,
+  )}`;
   const targetType =
     target.kind === "singer" ? "singer profile" : "quartet listing";
   const subject = `New Quartet Member Finder contact request for ${target.name}`;
@@ -112,13 +121,38 @@ export function buildContactNotificationEmail({
     "",
     `From: ${senderDisplayName}`,
     "",
-    "Message:",
-    message,
-    "",
     `Request ID: ${requestId}`,
-    `Sign in to Quartet Member Finder to decide whether to respond: ${appUrl}/app`,
+    `Sign in to Quartet Member Finder to read and reply: ${messageUrl}`,
     "",
     "Your email address was not shown to the sender.",
+    "The full message is kept behind sign-in.",
+  ].join("\n");
+
+  return { subject, text };
+}
+
+export function buildContactReplyNotificationEmail({
+  requestId,
+  replierDisplayName,
+  target,
+}: ContactReplyNotification) {
+  const appUrl = getAppUrl();
+  const messageUrl = `${appUrl}/sign-in?next=${encodeURIComponent(
+    `/app/messages/${requestId}`,
+  )}`;
+  const targetType =
+    target.kind === "singer" ? "singer profile" : "quartet listing";
+  const subject = `New Quartet Member Finder reply for ${target.name}`;
+  const text = [
+    `You have a new reply about the ${targetType}, "${target.name}".`,
+    "",
+    `From: ${replierDisplayName}`,
+    "",
+    `Request ID: ${requestId}`,
+    `Sign in to Quartet Member Finder to read and reply: ${messageUrl}`,
+    "",
+    "Private email addresses were not shown through the app.",
+    "The full reply is kept behind sign-in.",
   ].join("\n");
 
   return { subject, text };
@@ -145,5 +179,31 @@ export async function sendContactNotification(
 
   if (!response.ok) {
     throw new Error(`Resend notification failed with ${response.status}.`);
+  }
+}
+
+export async function sendContactReplyNotification(
+  config: ContactRelayConfig,
+  notification: ContactReplyNotification,
+) {
+  const { subject, text } = buildContactReplyNotificationEmail(notification);
+  const response = await fetch("https://api.resend.com/emails", {
+    body: JSON.stringify({
+      from: config.fromEmail,
+      subject,
+      text,
+      to: notification.recipientEmail,
+    }),
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Resend reply notification failed with ${response.status}.`,
+    );
   }
 }

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -51,8 +51,9 @@ export const publicHelpSections = [
   },
   {
     body: [
-      "First contact happens through the app. A signed-in user can send a short message, and the recipient can decide whether to respond or share direct contact information.",
-      "The app does not show the recipient's private email address or phone number in public search results.",
+      "First contact happens through the app. A signed-in user can send a short message, the recipient gets an email notification, and both people can read and reply in Messages.",
+      "The app does not show private email addresses or phone numbers in public search results or message pages by default.",
+      "Notification emails link back to sign-in so full message and reply text stays behind the app.",
     ],
     heading: "Contact",
   },
@@ -121,6 +122,7 @@ export const publicPrivacySections = [
     body: [
       "Public search results should not show personal email addresses or phone numbers by default.",
       "When someone sends a contact request, the app stores the request, resolves the recipient on the server/database side, and sends a notification without revealing the recipient's email address to the sender.",
+      "Replies are stored with the original contact request and are visible only to the sender and recipient participants.",
     ],
     heading: "Contact Relay",
   },

--- a/lib/dashboard/app-dashboard.ts
+++ b/lib/dashboard/app-dashboard.ts
@@ -37,6 +37,12 @@ export const quartetDashboardActions: DashboardAction[] = [
 export const supportDashboardActions: DashboardAction[] = [
   {
     description:
+      "Read contact requests and replies in the app without exposing private email addresses by default.",
+    href: "/app/messages",
+    label: "Messages",
+  },
+  {
+    description:
       "Review how optional profiles, independent visibility, discovery, and app-mediated contact work.",
     href: "/help",
     label: "Help",

--- a/lib/navigation/signed-in-nav.ts
+++ b/lib/navigation/signed-in-nav.ts
@@ -12,6 +12,10 @@ export const signedInNavigationLinks = [
     label: "Find",
   },
   {
+    href: "/app/messages",
+    label: "Messages",
+  },
+  {
     href: "/help",
     label: "Help",
   },

--- a/supabase/migrations/20260501023000_contact_request_replies.sql
+++ b/supabase/migrations/20260501023000_contact_request_replies.sql
@@ -1,0 +1,81 @@
+alter table public.contact_requests
+add column recipient_read_at timestamptz,
+add column sender_read_at timestamptz;
+
+create table public.contact_request_replies (
+  id uuid primary key default gen_random_uuid(),
+  contact_request_id uuid not null references public.contact_requests (id) on delete cascade,
+  sender_user_id uuid not null references auth.users (id) on delete cascade,
+  message_body text not null check (char_length(message_body) between 1 and 2000),
+  notification_status public.contact_request_status not null default 'pending',
+  created_at timestamptz not null default now(),
+  check (sender_user_id is not null)
+);
+
+create index contact_request_replies_request_idx
+  on public.contact_request_replies (contact_request_id, created_at);
+
+create index contact_request_replies_sender_idx
+  on public.contact_request_replies (sender_user_id, created_at desc);
+
+create function public.mark_contact_request_responded()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.contact_requests
+  set
+    status = 'responded',
+    updated_at = now()
+  where id = new.contact_request_id
+    and status <> 'closed';
+
+  return new;
+end;
+$$;
+
+create trigger contact_request_replies_mark_responded
+after insert on public.contact_request_replies
+for each row execute function public.mark_contact_request_responded();
+
+alter table public.contact_request_replies enable row level security;
+
+create policy "Contact participants can read replies"
+on public.contact_request_replies
+for select
+using (
+  exists (
+    select 1
+    from public.contact_requests
+    where contact_requests.id = contact_request_replies.contact_request_id
+      and (
+        contact_requests.sender_user_id = auth.uid()
+        or contact_requests.recipient_user_id = auth.uid()
+      )
+  )
+);
+
+create policy "Contact participants can create replies"
+on public.contact_request_replies
+for insert
+with check (
+  sender_user_id = auth.uid()
+  and exists (
+    select 1
+    from public.contact_requests
+    where contact_requests.id = contact_request_replies.contact_request_id
+      and (
+        contact_requests.sender_user_id = auth.uid()
+        or contact_requests.recipient_user_id = auth.uid()
+      )
+  )
+);
+
+revoke all on table public.contact_request_replies from anon, authenticated;
+grant select, insert on table public.contact_request_replies to authenticated;
+
+grant update (recipient_read_at, sender_read_at) on table public.contact_requests to authenticated;
+
+revoke all on function public.mark_contact_request_responded() from public;

--- a/test/app-dashboard.test.ts
+++ b/test/app-dashboard.test.ts
@@ -30,6 +30,7 @@ describe("signed-in app dashboard", () => {
       expect.objectContaining({ href: "/find?kind=quartets" }),
       expect.objectContaining({ href: "/app/listings" }),
       expect.objectContaining({ href: "/find?kind=singers" }),
+      expect.objectContaining({ href: "/app/messages" }),
       expect.objectContaining({ href: "/help" }),
       expect.objectContaining({ href: "/privacy" }),
     ]);

--- a/test/contact-relay.test.ts
+++ b/test/contact-relay.test.ts
@@ -4,6 +4,7 @@ import {
   CONTACT_RATE_LIMIT_COUNT,
   CONTACT_RATE_LIMIT_WINDOW_MINUTES,
   buildContactNotificationEmail,
+  buildContactReplyNotificationEmail,
   contactRateLimitWindowStart,
   getContactRelayConfig,
   normalizeReturnTo,
@@ -73,9 +74,30 @@ describe("contact relay helpers", () => {
     });
 
     expect(subject).toContain("Chord Harbor");
-    expect(text).toContain("We are looking for a bass.");
+    expect(text).toContain("/sign-in?next=%2Fapp%2Fmessages%2Frequest-1");
+    expect(text).toContain("The full message is kept behind sign-in.");
     expect(text).toContain("Your email address was not shown to the sender.");
+    expect(text).not.toContain("We are looking for a bass.");
     expect(text).not.toContain("@example.com");
+  });
+
+  it("builds reply notifications that keep reply content behind sign-in", () => {
+    const { subject, text } = buildContactReplyNotificationEmail({
+      recipientEmail: "sender@example.com",
+      requestId: "request-1",
+      replierDisplayName: "A signed-in Quartet Member Finder user",
+      target: {
+        id: "target-1",
+        kind: "singer",
+        name: "Avery Singer",
+      },
+    });
+
+    expect(subject).toContain("Avery Singer");
+    expect(text).toContain("new reply");
+    expect(text).toContain("/sign-in?next=%2Fapp%2Fmessages%2Frequest-1");
+    expect(text).toContain("The full reply is kept behind sign-in.");
+    expect(text).not.toContain("sender@example.com");
   });
 
   it("reads Resend configuration only from server environment", () => {

--- a/test/messages-ui.test.ts
+++ b/test/messages-ui.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("messages UI", () => {
+  it("provides inbox, sent, empty states, and message detail replies", () => {
+    const messagesPage = source("app/(protected)/app/messages/page.tsx");
+    const detailPage = source("app/(protected)/app/messages/[id]/page.tsx");
+    const replyAction = source("app/(protected)/app/messages/actions.ts");
+
+    expect(messagesPage).toContain("Messages");
+    expect(messagesPage).toContain("Inbox");
+    expect(messagesPage).toContain("Sent");
+    expect(messagesPage).toContain(
+      "Messages you receive through the app will appear here.",
+    );
+    expect(messagesPage).toContain(
+      "Messages you send to singers or quartet profiles will appear here.",
+    );
+    expect(detailPage).toContain("Original message");
+    expect(detailPage).toContain("Send reply");
+    expect(detailPage).toContain(
+      "Private email addresses and phone numbers are not shown by default.",
+    );
+    expect(replyAction).toContain("contact_request_replies");
+    expect(replyAction).toContain("sendContactReplyNotification");
+  });
+});

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -24,6 +24,7 @@ describe("public help and privacy content", () => {
     expect(helpText).toContain("Location And Privacy");
     expect(helpText).toContain("Location Defaults");
     expect(helpText).toContain("Contact");
+    expect(helpText).toContain("read and reply in Messages");
     expect(helpText).toContain("Signed-in users can send private feedback");
     expect(helpText).toContain("does not replace personal judgment");
     expect(helpText).not.toMatch(/24\/7 moderation|background checks/i);
@@ -37,6 +38,7 @@ describe("public help and privacy content", () => {
     expect(privacyText).toContain("independent visibility controls");
     expect(privacyText).toContain("Both optional profiles can be discoverable");
     expect(privacyText).toContain("email addresses or phone numbers");
+    expect(privacyText).toContain("visible only to the sender and recipient");
     expect(privacyText).toContain("global");
     expect(privacyText).toContain("not a formal legal privacy policy");
   });

--- a/test/signed-in-nav.test.ts
+++ b/test/signed-in-nav.test.ts
@@ -7,6 +7,7 @@ describe("signed-in navigation", () => {
       "My Singer Profile",
       "My Quartet Profile",
       "Find",
+      "Messages",
       "Help",
     ]);
   });
@@ -16,6 +17,7 @@ describe("signed-in navigation", () => {
       { href: "/app/profile", label: "My Singer Profile" },
       { href: "/app/listings", label: "My Quartet Profile" },
       { href: "/find", label: "Find" },
+      { href: "/app/messages", label: "Messages" },
       { href: "/help", label: "Help" },
     ]);
     expect(signedInNavigationLinks.map((link) => link.href)).not.toContain(

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -14,6 +14,7 @@ const appTables = [
   "quartet_listings",
   "quartet_listing_parts",
   "contact_requests",
+  "contact_request_replies",
   "feedback_submissions",
 ];
 
@@ -132,5 +133,21 @@ describe("initial Supabase schema migration", () => {
     expect(migration).toContain(
       "quartet_listing_parts.voicing || ':' || quartet_listing_parts.part",
     );
+  });
+
+  it("adds participant-only replies for app-mediated messages", () => {
+    expect(migration).toContain("create table public.contact_request_replies");
+    expect(migration).toContain("contact_request_replies_mark_responded");
+    expect(migration).toContain(
+      'create policy "Contact participants can read replies"',
+    );
+    expect(migration).toContain(
+      'create policy "Contact participants can create replies"',
+    );
+    expect(migration).toContain(
+      "grant select, insert on table public.contact_request_replies",
+    );
+    expect(migration).toContain("recipient_read_at");
+    expect(migration).toContain("sender_read_at");
   });
 });


### PR DESCRIPTION
Closes #42

## Summary
- add a signed-in Messages area with Inbox, Sent, message detail, and app-mediated replies
- add contact_request_replies plus participant-only RLS and response-status migration
- update first-contact and reply notification emails to link through sign-in to message detail while keeping full message text behind authenticated app access
- surface Messages in signed-in navigation and dashboard, and update Help/Privacy/docs/smoke tests

## Migration
- supabase/migrations/20260501023000_contact_request_replies.sql

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build