### PR TITLE
Add message reporting and admin moderation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
 
+# Server-only comma-separated admin allowlist for /app/admin.
+ADMIN_EMAILS=
+
 # Optional server-side approximate geocoding for radius search. Profile/listing
 # coordinates are persisted only when MAPBOX_GEOCODING_PERMANENT=true.
 MAPBOX_GEOCODING_TOKEN=

--- a/app/(protected)/app/admin/actions.ts
+++ b/app/(protected)/app/admin/actions.ts
@@ -1,0 +1,164 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  createRequiredAdminClient,
+  isAdminUser,
+} from "@/lib/admin/admin-access";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const reportStatuses = ["action_taken", "dismissed", "reviewed"] as const;
+type ReportStatus = (typeof reportStatuses)[number];
+
+async function requireAdmin() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  if (!isAdminUser(user)) {
+    redirect("/app");
+  }
+
+  return createRequiredAdminClient();
+}
+
+function formString(formData: FormData, key: string) {
+  const value = formData.get(key);
+
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export async function updateReportStatus(formData: FormData) {
+  const admin = await requireAdmin();
+  const reportId = formString(formData, "reportId");
+  const status = formString(formData, "status") as ReportStatus;
+  const adminNotes = formString(formData, "adminNotes") || null;
+
+  if (!reportId || !reportStatuses.includes(status)) {
+    redirect("/app/admin?admin=error");
+  }
+
+  await admin
+    .from("message_reports")
+    .update({
+      admin_notes: adminNotes,
+      status,
+      ...(status === "action_taken"
+        ? { action_taken_at: new Date().toISOString() }
+        : {}),
+    })
+    .eq("id", reportId);
+
+  revalidatePath("/app/admin");
+  revalidatePath(`/app/admin/reports/${reportId}`);
+  redirect(`/app/admin/reports/${reportId}?admin=updated`);
+}
+
+export async function blockReportedAccount(formData: FormData) {
+  const admin = await requireAdmin();
+  const reportId = formString(formData, "reportId");
+  const reportedUserId = formString(formData, "reportedUserId");
+  const reason =
+    formString(formData, "reason") ||
+    "Blocked from messaging after report review.";
+
+  if (!reportId || !reportedUserId) {
+    redirect("/app/admin?admin=error");
+  }
+
+  await admin.from("user_moderation_status").upsert({
+    account_status: "message_blocked",
+    messaging_block_reason: reason,
+    messaging_blocked_at: new Date().toISOString(),
+    user_id: reportedUserId,
+  });
+
+  await admin
+    .from("message_reports")
+    .update({
+      action_taken_at: new Date().toISOString(),
+      status: "action_taken",
+    })
+    .eq("id", reportId);
+
+  revalidatePath("/app/admin");
+  revalidatePath(`/app/admin/reports/${reportId}`);
+  redirect(`/app/admin/reports/${reportId}?admin=blocked`);
+}
+
+export async function permanentlyBlockReportedAccount(formData: FormData) {
+  const admin = await requireAdmin();
+  const reportId = formString(formData, "reportId");
+  const reportedUserId = formString(formData, "reportedUserId");
+
+  if (!reportId || !reportedUserId) {
+    redirect("/app/admin?admin=error");
+  }
+
+  await admin.from("user_moderation_status").upsert({
+    account_status: "permanently_blocked",
+    admin_notes:
+      "Permanent block set from admin console. Account deletion remains a manual Supabase Auth action.",
+    messaging_block_reason: "Permanently blocked after report review.",
+    messaging_blocked_at: new Date().toISOString(),
+    user_id: reportedUserId,
+  });
+
+  await admin
+    .from("singer_profiles")
+    .update({ is_visible: false })
+    .eq("user_id", reportedUserId);
+  await admin
+    .from("quartet_listings")
+    .update({ is_visible: false })
+    .eq("owner_user_id", reportedUserId);
+  await admin
+    .from("message_reports")
+    .update({
+      action_taken_at: new Date().toISOString(),
+      status: "action_taken",
+    })
+    .eq("id", reportId);
+
+  revalidatePath("/app/admin");
+  revalidatePath(`/app/admin/reports/${reportId}`);
+  redirect(`/app/admin/reports/${reportId}?admin=permanently-blocked`);
+}
+
+export async function hideReportedSingerProfile(formData: FormData) {
+  const admin = await requireAdmin();
+  const reportId = formString(formData, "reportId");
+  const singerProfileId = formString(formData, "singerProfileId");
+
+  if (!reportId || !singerProfileId) {
+    redirect("/app/admin?admin=error");
+  }
+
+  await admin
+    .from("singer_profiles")
+    .update({ is_visible: false })
+    .eq("id", singerProfileId);
+
+  revalidatePath(`/app/admin/reports/${reportId}`);
+  redirect(`/app/admin/reports/${reportId}?admin=hidden`);
+}
+
+export async function hideReportedQuartetProfile(formData: FormData) {
+  const admin = await requireAdmin();
+  const reportId = formString(formData, "reportId");
+  const quartetListingId = formString(formData, "quartetListingId");
+
+  if (!reportId || !quartetListingId) {
+    redirect("/app/admin?admin=error");
+  }
+
+  await admin
+    .from("quartet_listings")
+    .update({ is_visible: false })
+    .eq("id", quartetListingId);
+
+  revalidatePath(`/app/admin/reports/${reportId}`);
+  redirect(`/app/admin/reports/${reportId}?admin=hidden`);
+}

--- a/app/(protected)/app/admin/page.tsx
+++ b/app/(protected)/app/admin/page.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+import {
+  createRequiredAdminClient,
+  isAdminUser,
+} from "@/lib/admin/admin-access";
+import { reportCategoryLabel } from "@/lib/messages/moderation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type MessageReportRow = {
+  category: string;
+  contact_request_id: string;
+  created_at: string;
+  id: string;
+  reported_user_id: string | null;
+  reporter_user_id: string;
+  status: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+export default async function AdminPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  if (!isAdminUser(user)) {
+    return (
+      <div className="max-w-2xl">
+        <h1 className="text-3xl font-bold text-[#172023]">Not authorized</h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          This admin area is limited to authorized project administrators.
+        </p>
+        <Link
+          className="mt-6 inline-flex font-semibold text-[#2f6f73]"
+          href="/app"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const admin = createRequiredAdminClient();
+  const { data: reports, error } = await admin
+    .from("message_reports")
+    .select(
+      "id, contact_request_id, reporter_user_id, reported_user_id, category, status, created_at",
+    )
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  return (
+    <div>
+      <header className="max-w-3xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Admin
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          Message reports
+        </h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          Review private message reports, hide problematic profiles, and block
+          accounts from sending additional messages.
+        </p>
+      </header>
+
+      {error ? (
+        <p
+          className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+          role="alert"
+        >
+          Unable to load reports.
+        </p>
+      ) : null}
+
+      {!error && (reports ?? []).length === 0 ? (
+        <section className="mt-8 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">No reports yet</h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Message reports submitted by users will appear here.
+          </p>
+        </section>
+      ) : null}
+
+      <section className="mt-8 grid gap-4">
+        {((reports ?? []) as MessageReportRow[]).map((report) => (
+          <Link
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 shadow-sm hover:border-[#2f6f73]"
+            href={`/app/admin/reports/${report.id}`}
+            key={report.id}
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-xl font-bold text-[#172023]">
+                  {reportCategoryLabel(report.category)}
+                </h2>
+                <p className="mt-1 text-sm text-[#596466]">
+                  Status: {report.status}
+                </p>
+              </div>
+              <p className="text-sm text-[#596466]">
+                {formatDate(report.created_at)}
+              </p>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-[#394548]">
+              Contact request: {report.contact_request_id}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[#394548]">
+              Reporter: {report.reporter_user_id}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[#394548]">
+              Reported account: {report.reported_user_id ?? "Unavailable"}
+            </p>
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/app/(protected)/app/admin/reports/[id]/page.tsx
+++ b/app/(protected)/app/admin/reports/[id]/page.tsx
@@ -1,0 +1,392 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  blockReportedAccount,
+  hideReportedQuartetProfile,
+  hideReportedSingerProfile,
+  permanentlyBlockReportedAccount,
+  updateReportStatus,
+} from "@/app/(protected)/app/admin/actions";
+import {
+  createRequiredAdminClient,
+  isAdminUser,
+} from "@/lib/admin/admin-access";
+import { reportCategoryLabel } from "@/lib/messages/moderation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type AdminReportPageProps = {
+  params: Promise<{
+    id: string;
+  }>;
+  searchParams: Promise<{
+    admin?: string;
+  }>;
+};
+
+type MessageReportRow = {
+  admin_notes: string | null;
+  category: string;
+  contact_request_id: string;
+  created_at: string;
+  id: string;
+  note: string | null;
+  reported_user_id: string | null;
+  reporter_user_id: string;
+  status: string;
+};
+
+type ContactRequestRow = {
+  created_at: string;
+  id: string;
+  message_body: string;
+  quartet_listing_id: string | null;
+  recipient_user_id: string | null;
+  sender_user_id: string;
+  singer_profile_id: string | null;
+  status: string;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function adminStatusMessage(value: string | undefined) {
+  if (value === "updated") return "Report status updated.";
+  if (value === "blocked") return "Reported account blocked from messaging.";
+  if (value === "permanently-blocked") {
+    return "Reported account permanently blocked and public profiles hidden.";
+  }
+  if (value === "hidden") return "Reported profile hidden from discovery.";
+  return null;
+}
+
+export default async function AdminReportDetailPage({
+  params,
+  searchParams,
+}: AdminReportPageProps) {
+  const [{ id }, query] = await Promise.all([params, searchParams]);
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = supabase ? await supabase.auth.getUser() : { data: { user: null } };
+
+  if (!isAdminUser(user)) {
+    return (
+      <div className="max-w-2xl">
+        <h1 className="text-3xl font-bold text-[#172023]">Not authorized</h1>
+        <p className="mt-4 text-base leading-7 text-[#394548]">
+          This admin area is limited to authorized project administrators.
+        </p>
+        <Link
+          className="mt-6 inline-flex font-semibold text-[#2f6f73]"
+          href="/app"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const admin = createRequiredAdminClient();
+  const [{ data: report }, { data: contactRequest }] = await Promise.all([
+    admin
+      .from("message_reports")
+      .select(
+        "id, contact_request_id, reporter_user_id, reported_user_id, category, note, status, admin_notes, created_at",
+      )
+      .eq("id", id)
+      .maybeSingle<MessageReportRow>(),
+    admin
+      .from("message_reports")
+      .select("contact_request_id")
+      .eq("id", id)
+      .maybeSingle()
+      .then(async ({ data }) => {
+        if (!data?.contact_request_id) return { data: null };
+
+        return admin
+          .from("contact_requests")
+          .select(
+            "id, sender_user_id, recipient_user_id, singer_profile_id, quartet_listing_id, message_body, status, created_at",
+          )
+          .eq("id", data.contact_request_id)
+          .maybeSingle<ContactRequestRow>();
+      }),
+  ]);
+
+  if (!report || !contactRequest) {
+    notFound();
+  }
+
+  const [
+    { data: moderationStatus },
+    { count: priorReportCount },
+    { data: singerProfile },
+    { data: quartetListing },
+  ] = await Promise.all([
+    report.reported_user_id
+      ? admin
+          .from("user_moderation_status")
+          .select(
+            "account_status, messaging_blocked_at, messaging_block_reason",
+          )
+          .eq("user_id", report.reported_user_id)
+          .maybeSingle()
+      : { data: null },
+    report.reported_user_id
+      ? admin
+          .from("message_reports")
+          .select("id", { count: "exact", head: true })
+          .eq("reported_user_id", report.reported_user_id)
+      : { count: 0 },
+    contactRequest.singer_profile_id
+      ? admin
+          .from("singer_profiles")
+          .select("id, display_name, is_visible")
+          .eq("id", contactRequest.singer_profile_id)
+          .maybeSingle()
+      : { data: null },
+    contactRequest.quartet_listing_id
+      ? admin
+          .from("quartet_listings")
+          .select("id, name, is_visible")
+          .eq("id", contactRequest.quartet_listing_id)
+          .maybeSingle()
+      : { data: null },
+  ]);
+  const statusMessage = adminStatusMessage(query.admin);
+
+  return (
+    <div className="max-w-4xl">
+      <Link className="font-semibold text-[#2f6f73]" href="/app/admin">
+        Back to admin reports
+      </Link>
+      <header className="mt-6">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+          Admin report detail
+        </p>
+        <h1 className="mt-4 text-3xl font-bold text-[#172023]">
+          {reportCategoryLabel(report.category)}
+        </h1>
+        <p className="mt-3 text-base leading-7 text-[#394548]">
+          Report ID: {report.id}
+        </p>
+      </header>
+
+      {statusMessage ? (
+        <p
+          className="mt-6 rounded-lg border border-[#b7d7ce] bg-[#eef8f4] p-4 text-sm text-[#174b4f]"
+          role="status"
+        >
+          {statusMessage}
+        </p>
+      ) : null}
+
+      <section className="mt-8 grid gap-4 md:grid-cols-2">
+        <article className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">Report</h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Status: {report.status}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#394548]">
+            Submitted: {formatDate(report.created_at)}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#394548]">
+            Reporter: {report.reporter_user_id}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#394548]">
+            Reported account: {report.reported_user_id ?? "Unavailable"}
+          </p>
+          <p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-[#394548]">
+            {report.note || "No reporter note provided."}
+          </p>
+        </article>
+
+        <article className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+          <h2 className="text-xl font-bold text-[#172023]">Reported account</h2>
+          <p className="mt-3 text-sm leading-6 text-[#394548]">
+            Moderation status: {moderationStatus?.account_status ?? "active"}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#394548]">
+            Message block:{" "}
+            {moderationStatus?.messaging_blocked_at
+              ? formatDate(moderationStatus.messaging_blocked_at)
+              : "not blocked"}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[#394548]">
+            Prior reports for this account: {priorReportCount ?? 0}
+          </p>
+        </article>
+      </section>
+
+      <section className="mt-8 rounded-lg border border-[#d7cec0] bg-white p-5">
+        <h2 className="text-xl font-bold text-[#172023]">Message context</h2>
+        <p className="mt-3 text-sm leading-6 text-[#394548]">
+          Contact request: {contactRequest.id}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[#394548]">
+          Sender: {contactRequest.sender_user_id}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[#394548]">
+          Recipient: {contactRequest.recipient_user_id ?? "Unavailable"}
+        </p>
+        <p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-[#394548]">
+          {contactRequest.message_body}
+        </p>
+      </section>
+
+      <section className="mt-8 grid gap-4 md:grid-cols-2">
+        {singerProfile ? (
+          <form
+            action={hideReportedSingerProfile}
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+          >
+            <input name="reportId" type="hidden" value={report.id} />
+            <input
+              name="singerProfileId"
+              type="hidden"
+              value={singerProfile.id}
+            />
+            <h2 className="text-xl font-bold text-[#172023]">Singer profile</h2>
+            <p className="mt-3 text-sm leading-6 text-[#394548]">
+              {singerProfile.display_name}; visible:{" "}
+              {singerProfile.is_visible ? "yes" : "no"}
+            </p>
+            <button
+              className="mt-4 rounded-md border border-[#8a3b12] px-4 py-2.5 text-sm font-semibold text-[#8a3b12] hover:bg-white"
+              type="submit"
+            >
+              Hide singer profile
+            </button>
+          </form>
+        ) : null}
+
+        {quartetListing ? (
+          <form
+            action={hideReportedQuartetProfile}
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+          >
+            <input name="reportId" type="hidden" value={report.id} />
+            <input
+              name="quartetListingId"
+              type="hidden"
+              value={quartetListing.id}
+            />
+            <h2 className="text-xl font-bold text-[#172023]">
+              Quartet profile
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-[#394548]">
+              {quartetListing.name}; visible:{" "}
+              {quartetListing.is_visible ? "yes" : "no"}
+            </p>
+            <button
+              className="mt-4 rounded-md border border-[#8a3b12] px-4 py-2.5 text-sm font-semibold text-[#8a3b12] hover:bg-white"
+              type="submit"
+            >
+              Hide quartet profile
+            </button>
+          </form>
+        ) : null}
+      </section>
+
+      {report.reported_user_id ? (
+        <section className="mt-8 grid gap-4 md:grid-cols-2">
+          <form
+            action={blockReportedAccount}
+            className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+          >
+            <input name="reportId" type="hidden" value={report.id} />
+            <input
+              name="reportedUserId"
+              type="hidden"
+              value={report.reported_user_id}
+            />
+            <h2 className="text-xl font-bold text-[#172023]">
+              Block messaging
+            </h2>
+            <label className="mt-4 block">
+              <span className="text-sm font-semibold text-[#172023]">
+                Internal reason
+              </span>
+              <textarea
+                className="mt-2 min-h-20 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023]"
+                name="reason"
+              />
+            </label>
+            <button
+              className="mt-4 rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+              type="submit"
+            >
+              Block from messaging
+            </button>
+          </form>
+
+          <form
+            action={permanentlyBlockReportedAccount}
+            className="rounded-lg border border-red-200 bg-red-50 p-5"
+          >
+            <input name="reportId" type="hidden" value={report.id} />
+            <input
+              name="reportedUserId"
+              type="hidden"
+              value={report.reported_user_id}
+            />
+            <h2 className="text-xl font-bold text-[#172023]">
+              Permanent block
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-[#394548]">
+              Use for serious or repeated abuse. This hides the account&apos;s
+              public profiles and blocks future messaging. Account deletion
+              remains a separate manual Supabase Auth step.
+            </p>
+            <button
+              className="mt-4 rounded-md border border-red-700 px-4 py-2.5 text-sm font-semibold text-red-800"
+              type="submit"
+            >
+              Permanently block account
+            </button>
+          </form>
+        </section>
+      ) : null}
+
+      <form
+        action={updateReportStatus}
+        className="mt-8 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+      >
+        <input name="reportId" type="hidden" value={report.id} />
+        <h2 className="text-xl font-bold text-[#172023]">Resolve report</h2>
+        <label className="mt-4 block">
+          <span className="text-sm font-semibold text-[#172023]">Status</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023]"
+            defaultValue={report.status}
+            name="status"
+          >
+            <option value="reviewed">Reviewed</option>
+            <option value="action_taken">Action taken</option>
+            <option value="dismissed">Dismissed</option>
+          </select>
+        </label>
+        <label className="mt-4 block">
+          <span className="text-sm font-semibold text-[#172023]">
+            Admin notes
+          </span>
+          <textarea
+            className="mt-2 min-h-24 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023]"
+            defaultValue={report.admin_notes ?? ""}
+            name="adminNotes"
+          />
+        </label>
+        <button
+          className="mt-4 rounded-md bg-[#174b4f] px-4 py-2.5 text-sm font-semibold text-white"
+          type="submit"
+        >
+          Save report status
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/(protected)/app/messages/[id]/page.tsx
+++ b/app/(protected)/app/messages/[id]/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { sendMessageReply } from "@/app/(protected)/app/messages/actions";
+import {
+  reportMessage,
+  sendMessageReply,
+} from "@/app/(protected)/app/messages/actions";
+import { messageReportCategories } from "@/lib/messages/moderation";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type MessageDetailPageProps = {
@@ -8,6 +12,7 @@ type MessageDetailPageProps = {
     id: string;
   }>;
   searchParams: Promise<{
+    report?: string;
     reply?: string;
   }>;
 };
@@ -48,6 +53,26 @@ function replyStatusMessage(value: string | undefined) {
 
   if (value === "error") {
     return "Unable to send that reply. Check the message and try again.";
+  }
+
+  if (value === "blocked") {
+    return "This account is not currently allowed to send messages.";
+  }
+
+  return null;
+}
+
+function reportStatusMessage(value: string | undefined) {
+  if (value === "sent") {
+    return "Report submitted. The project team has been notified.";
+  }
+
+  if (value === "stored") {
+    return "Report saved. Admin email notification is waiting on Resend or server email configuration.";
+  }
+
+  if (value === "error") {
+    return "Unable to submit that report. Check the form and try again.";
   }
 
   return null;
@@ -134,6 +159,7 @@ export default async function MessageDetailPage({
     targetName(supabase, request),
   ]);
   const replyStatus = replyStatusMessage(query.reply);
+  const reportStatus = reportStatusMessage(query.report);
   const userIsOriginalSender = request.sender_user_id === user.id;
 
   return (
@@ -167,6 +193,19 @@ export default async function MessageDetailPage({
           role={query.reply === "error" ? "alert" : "status"}
         >
           {replyStatus}
+        </p>
+      ) : null}
+
+      {reportStatus ? (
+        <p
+          className={`mt-6 rounded-lg border p-4 text-sm ${
+            query.report === "error"
+              ? "border-red-200 bg-red-50 text-red-800"
+              : "border-[#b7d7ce] bg-[#eef8f4] text-[#174b4f]"
+          }`}
+          role={query.report === "error" ? "alert" : "status"}
+        >
+          {reportStatus}
         </p>
       ) : null}
 
@@ -241,6 +280,52 @@ export default async function MessageDetailPage({
           type="submit"
         >
           Send reply
+        </button>
+      </form>
+
+      <form
+        action={reportMessage}
+        className="mt-8 rounded-lg border border-[#d7cec0] bg-white p-5"
+      >
+        <input name="requestId" type="hidden" value={request.id} />
+        <h2 className="text-xl font-bold text-[#172023]">
+          Report this message
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-[#394548]">
+          Use this for spam, harassment, suspicious requests, or other safety
+          concerns. Reports are private and reviewed as the project team is
+          able.
+        </p>
+        <label className="mt-4 block">
+          <span className="text-sm font-semibold text-[#172023]">Reason</span>
+          <select
+            className="mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            name="category"
+            required
+          >
+            {messageReportCategories.map((category) => (
+              <option key={category.value} value={category.value}>
+                {category.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="mt-4 block">
+          <span className="text-sm font-semibold text-[#172023]">
+            Optional note
+          </span>
+          <textarea
+            className="mt-2 min-h-24 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+            maxLength={2000}
+            name="note"
+            placeholder="Add any context that will help the project team review this report."
+          />
+        </label>
+        <button
+          className="mt-4 w-full rounded-md border border-[#8a3b12] px-4 py-2.5 text-sm font-semibold text-[#8a3b12] hover:bg-[#fffaf2] sm:w-fit"
+          type="submit"
+        >
+          Submit report
         </button>
       </form>
     </div>

--- a/app/(protected)/app/messages/actions.ts
+++ b/app/(protected)/app/messages/actions.ts
@@ -9,6 +9,13 @@ import {
   type ContactTarget,
 } from "@/lib/contact/contact-relay";
 import {
+  MESSAGE_REPORT_NOTE_MAX_LENGTH,
+  getAdminNotificationConfig,
+  messageReportCategories,
+  sendAdminReportNotification,
+  type MessageReportCategory,
+} from "@/lib/messages/moderation";
+import {
   createSupabaseAdminClient,
   createSupabaseServerClient,
 } from "@/lib/supabase/server";
@@ -25,14 +32,27 @@ type ContactReplyRow = {
   id: string;
 };
 
+type MessageReportRow = {
+  created_at: string;
+  id: string;
+  reported_user_id: string | null;
+};
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function redirectWithReplyStatus(
   requestId: string,
-  status: "error" | "sent" | "stored",
+  status: "blocked" | "error" | "sent" | "stored",
 ): never {
   redirect(`/app/messages/${requestId}?reply=${status}`);
+}
+
+function redirectWithReportStatus(
+  requestId: string,
+  status: "error" | "sent" | "stored",
+): never {
+  redirect(`/app/messages/${requestId}?report=${status}`);
 }
 
 function trimMessage(value: FormDataEntryValue | null) {
@@ -119,6 +139,21 @@ export async function sendMessageReply(formData: FormData) {
     );
   }
 
+  const { data: moderationStatus } = await supabase
+    .from("user_moderation_status")
+    .select("account_status, messaging_blocked_at")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (
+    moderationStatus?.messaging_blocked_at ||
+    moderationStatus?.account_status === "message_blocked" ||
+    moderationStatus?.account_status === "suspended" ||
+    moderationStatus?.account_status === "permanently_blocked"
+  ) {
+    redirectWithReplyStatus(requestId, "blocked");
+  }
+
   const { data: contactRequest, error: requestError } = await supabase
     .from("contact_requests")
     .select(
@@ -188,4 +223,102 @@ export async function sendMessageReply(formData: FormData) {
 
   revalidatePath(`/app/messages/${requestId}`);
   redirectWithReplyStatus(requestId, "sent");
+}
+
+function parseReportCategory(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return messageReportCategories.some((option) => option.value === value)
+    ? (value as MessageReportCategory)
+    : null;
+}
+
+export async function reportMessage(formData: FormData) {
+  const requestId = String(formData.get("requestId") ?? "").trim();
+  const category = parseReportCategory(formData.get("category"));
+  const note = trimMessage(formData.get("note"));
+
+  if (!UUID_PATTERN.test(requestId) || !category) {
+    redirect("/app/messages?report=error");
+  }
+
+  if (note && note.length > MESSAGE_REPORT_NOTE_MAX_LENGTH) {
+    redirectWithReportStatus(requestId, "error");
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
+    redirectWithReportStatus(requestId, "error");
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(
+      `/sign-in?next=${encodeURIComponent(`/app/messages/${requestId}`)}`,
+    );
+  }
+
+  const { data: contactRequest, error: requestError } = await supabase
+    .from("contact_requests")
+    .select("id, sender_user_id, recipient_user_id")
+    .eq("id", requestId)
+    .maybeSingle<
+      Pick<ContactRequestRow, "id" | "recipient_user_id" | "sender_user_id">
+    >();
+
+  if (
+    requestError ||
+    !contactRequest ||
+    (contactRequest.sender_user_id !== user.id &&
+      contactRequest.recipient_user_id !== user.id)
+  ) {
+    redirect("/app/messages?report=error");
+  }
+
+  const { data: report, error: reportError } = await supabase
+    .from("message_reports")
+    .insert({
+      category,
+      contact_request_id: requestId,
+      note,
+      reporter_user_id: user.id,
+    })
+    .select("id, reported_user_id, created_at")
+    .single<MessageReportRow>();
+
+  if (reportError || !report) {
+    redirectWithReportStatus(requestId, "error");
+  }
+
+  const config = getAdminNotificationConfig();
+
+  if (!config) {
+    revalidatePath(`/app/messages/${requestId}`);
+    redirectWithReportStatus(requestId, "stored");
+  }
+
+  try {
+    await sendAdminReportNotification(config, {
+      category,
+      contactRequestId: requestId,
+      createdAt: report.created_at,
+      note,
+      reportedUserId: report.reported_user_id,
+      reporterEmail: user.email ?? null,
+      reporterUserId: user.id,
+      reportId: report.id,
+    });
+  } catch {
+    revalidatePath(`/app/messages/${requestId}`);
+    redirectWithReportStatus(requestId, "stored");
+  }
+
+  revalidatePath(`/app/messages/${requestId}`);
+  redirectWithReportStatus(requestId, "sent");
 }

--- a/app/contact/actions.ts
+++ b/app/contact/actions.ts
@@ -27,7 +27,7 @@ type ContactRequestRow = {
 
 function redirectWithContactStatus(
   returnTo: string,
-  status: "auth" | "error" | "sent" | "stored",
+  status: "auth" | "blocked" | "error" | "sent" | "stored",
 ): never {
   const separator = returnTo.includes("?") ? "&" : "?";
 
@@ -89,6 +89,21 @@ export async function sendContactRequest(formData: FormData) {
 
   if (!user) {
     redirect(`/sign-in?next=${encodeURIComponent(values.returnTo)}`);
+  }
+
+  const { data: moderationStatus } = await supabase
+    .from("user_moderation_status")
+    .select("account_status, messaging_blocked_at")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (
+    moderationStatus?.messaging_blocked_at ||
+    moderationStatus?.account_status === "message_blocked" ||
+    moderationStatus?.account_status === "suspended" ||
+    moderationStatus?.account_status === "permanently_blocked"
+  ) {
+    redirectWithContactStatus(values.returnTo, "blocked");
   }
 
   const rateLimitWindowStart = contactRateLimitWindowStart();

--- a/docs/admin-moderation.md
+++ b/docs/admin-moderation.md
@@ -1,0 +1,60 @@
+# Admin Moderation
+
+Quartet Member Finder has a minimal signed-in admin console for launch safety
+workflows.
+
+## Access
+
+Open `/app/admin` after signing in. Admin access is granted with the server-only
+`ADMIN_EMAILS` environment variable, a comma-separated list of account email
+addresses.
+
+To grant or revoke access:
+
+1. Update `ADMIN_EMAILS` in Vercel Production.
+2. Redeploy the app so the server runtime reads the new allowlist.
+3. Keep `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, and
+   `ADMIN_EMAILS` out of browser code and public logs.
+
+Unauthorized signed-in users see a generic not-authorized page.
+
+## Review A Report
+
+1. Open `/app/admin`.
+2. Select a report.
+3. Review the report category, reporter note, message/contact request context,
+   reporter user ID, reported user ID, reported profile/listing context, and
+   prior report count for the reported account.
+4. Use the action forms only after reviewing the report context.
+
+## Admin Actions
+
+The console supports launch-level actions:
+
+- Hide the reported singer profile from discovery.
+- Hide the reported quartet profile/opening from discovery.
+- Block the reported account from sending additional first-contact messages or
+  replies.
+- Mark a report reviewed, action taken, or dismissed with admin notes.
+- Permanently block an account, which hides the account's public profiles and
+  blocks future messaging.
+
+Blocked users receive only a generic message-send error. Do not expose private
+moderation notes or report history to ordinary users.
+
+## Permanent Block And Deletion
+
+Permanent block is the strongest in-app action. It should be used for serious or
+repeated abuse after review. Account deletion is not the default response and is
+not performed directly by the app.
+
+If deletion is warranted:
+
+1. Preserve report IDs and any action notes needed for audit context.
+2. Confirm public profiles have been hidden and messaging is blocked.
+3. Delete the auth user manually in Supabase Auth using project-owner access.
+4. Record the manual action in the relevant report admin notes when practical.
+
+Do not delete user data casually. Prefer the action ladder: review, hide public
+content if needed, block messaging if needed, mark action taken, permanently
+block for serious abuse, then delete only when appropriate.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -437,6 +437,7 @@ The contact relay requires these server-side values in production:
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
 - `SUPABASE_SERVICE_ROLE_KEY`
+- `ADMIN_EMAILS`
 
 `SUPABASE_SERVICE_ROLE_KEY` is used only in server code to look up the resolved
 recipient email after RLS and the contact-request trigger have accepted the
@@ -446,9 +447,15 @@ delivery is deferred.
 
 Help-page feedback stores authenticated submissions in Supabase and sends a
 Resend notification to the project-team inbox at `cubuff98@gmail.com`. Admin
-review should use service-role/server access or a future protected admin
-surface; feedback must not be exposed through public routes or browser-side
-service-role code.
+review should use service-role/server access; feedback must not be exposed
+through public routes or browser-side service-role code.
+
+Message reports also send Resend notifications to `cubuff98@gmail.com`.
+Authorized admins can review them at `/app/admin`. Grant or revoke admin access
+by changing the server-only `ADMIN_EMAILS` allowlist in Vercel and redeploying.
+For severe abuse, use the admin console to hide public profiles and set a
+message or permanent block, then perform any account deletion manually in
+Supabase Auth after preserving the report/audit context needed for review.
 
 ## Maps and geocoding
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -11,6 +11,7 @@ The app will need environment variables for:
 - server-only Supabase administrative value, if needed for scripts or trusted server tasks
 - Resend API access
 - Resend sender email
+- server-only admin email allowlist
 - map/geocoding provider configuration
 
 The current scaffold includes `.env.example` with safe placeholder keys:
@@ -23,6 +24,7 @@ The current scaffold includes `.env.example` with safe placeholder keys:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
+- `ADMIN_EMAILS` server-only comma-separated allowlist for `/app/admin`
 - `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` optional public Mapbox browser token for
   the interactive discovery map
 - `NEXT_PUBLIC_MAPBOX_STYLE_URL` optional Mapbox style URL
@@ -56,6 +58,7 @@ build/deploy:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
+- `ADMIN_EMAILS`
 
 ## Supabase Auth
 
@@ -101,6 +104,10 @@ Required server-only values for notification delivery:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `RESEND_API_KEY`
 - `RESEND_FROM_EMAIL`
+
+Message reports and the admin console also require:
+
+- `ADMIN_EMAILS`, a comma-separated list of signed-in admin email addresses
 
 For production, use a verified sender on the project domain, such as:
 

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -150,12 +150,12 @@ Record before launch:
 
 ## Abuse and Spam Protections
 
-| Status    | Item                                                                                       | Verification                                             |
-| --------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
-| Complete  | Contact requests require sign-in.                                                          | `docs/privacy-model.md#contact-model`.                   |
-| Complete  | Contact relay has a basic sender-side rate limit.                                          | `docs/supabase-contract.md#contact-data-expectations`.   |
-| Complete  | Feedback requires sign-in and has a basic authenticated rate limit.                        | `docs/privacy-model.md#feedback-model`.                  |
-| Follow-up | Add reporting, blocking, and stronger admin abuse workflows when real usage requires them. | `docs/privacy-model.md#abuse-and-safety-considerations`. |
+| Status   | Item                                                                           | Verification                                                                                       |
+| -------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Complete | Contact requests require sign-in.                                              | `docs/privacy-model.md#contact-model`.                                                             |
+| Complete | Contact relay has a basic sender-side rate limit.                              | `docs/supabase-contract.md#contact-data-expectations`.                                             |
+| Complete | Feedback requires sign-in and has a basic authenticated rate limit.            | `docs/privacy-model.md#feedback-model`.                                                            |
+| Complete | Add reporting, message blocking, and minimal admin abuse workflows for launch. | `/app/admin`; `docs/admin-moderation.md`; `docs/privacy-model.md#abuse-and-safety-considerations`. |
 
 ## Final Launch Sign-Off
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -268,15 +268,16 @@ address validation or a street address.
 
 ## Abuse and safety considerations
 
-Future work may include:
+Users can report inappropriate, spammy, suspicious, or concerning Messages from
+the signed-in message detail page. Reports are private: ordinary users see only
+confirmation that a report was submitted, while authorized admins can review
+report context in the admin console.
 
-- reporting inappropriate profiles/messages
-- blocking users
-- rate limits on contact messages
-- admin feedback triage tools
-- audit logs for contact attempts
-- admin tools for handling abuse reports
+Admins can hide reported singer or quartet profiles from discovery, block a
+reported account from sending additional messages, mark reports reviewed or
+action taken, and permanently block an account when warranted. Account deletion
+is a careful manual Supabase Auth action, not the default response to a report.
 
 The MVP should at least avoid public exposure of private location/contact data,
-avoid unauthenticated contact spam, and rate-limit authenticated feedback
-submissions.
+avoid unauthenticated contact spam, rate-limit authenticated feedback
+submissions, and provide a report/block path for abusive message behavior.

--- a/docs/smoke-test-plan.md
+++ b/docs/smoke-test-plan.md
@@ -197,6 +197,25 @@ validation.
 11. Fail: browser form accepts recipient email, recipient user ID, or direct
     contact details as trusted input.
 
+## Message Reporting And Admin Review
+
+1. Sign in as a user who can view a message detail page.
+2. Submit Report this message with category `Spam` and an optional note.
+3. Pass: the user sees a report-submitted confirmation.
+4. Pass: the report is stored in Supabase and ordinary message participants
+   cannot browse all reports.
+5. Pass with Resend configured: an admin notification is sent to
+   `cubuff98@gmail.com` with a link to `/app/admin/reports/[id]`.
+6. Sign in with an email that is not in `ADMIN_EMAILS` and open `/app/admin`.
+7. Pass: the user sees a generic not-authorized page.
+8. Sign in as an allowlisted admin and open `/app/admin`.
+9. Pass: reports are listed and report detail shows message context, reporter,
+   reported account, status, and available actions.
+10. Use Block from messaging on the reported account.
+11. Pass: that account cannot send new contact requests or message replies and
+    sees only a generic message-send block error.
+12. Use hide-profile or permanent-block actions only after reviewing context.
+
 ## Authenticated Feedback Form
 
 1. Sign in and open `/help#feedback`.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -18,6 +18,9 @@ It includes these data areas:
 - `quartet_listing_parts`: voicing-aware parts currently covered or needed by a quartet.
 - `contact_requests`: app-mediated first-contact messages.
 - `contact_request_replies`: app-mediated replies attached to contact requests.
+- `message_reports`: private reports for inappropriate or concerning messages.
+- `user_moderation_status`: private account-level moderation status used for
+  message blocking and permanent blocks.
 - `feedback_submissions`: private authenticated-user feedback from the help page.
 - `singer_discovery_profiles`: privacy-safe singer discovery view.
 - `quartet_discovery_listings`: privacy-safe quartet discovery view.
@@ -134,6 +137,8 @@ RLS should enforce:
 - contact requests require an authenticated sender
 - recipients can read contact requests addressed to them or to listings they own
 - contact request participants can read and reply inside their own message thread
+- message participants can create private reports for messages they can view
+- blocked accounts cannot send new first-contact messages or replies
 - feedback submissions require an authenticated submitter and are not readable by
   other regular users
 
@@ -180,6 +185,19 @@ original sender or resolved recipient. Reply inserts mark the parent contact
 request as `responded`. Notification email for first-contact messages and
 replies links users back through sign-in to `/app/messages/[id]`; full message
 and reply bodies stay behind authenticated app access.
+
+Message reports are inserted into `message_reports` by authenticated message
+participants only. A database trigger resolves the reported account as the other
+participant on the contact request, rejecting unrelated report attempts. Reports
+are not readable by ordinary authenticated users. The app's admin console uses
+server-side service-role access only after the signed-in account passes the
+server-only `ADMIN_EMAILS` allowlist.
+
+`user_moderation_status` stores account-level moderation state. Ordinary users
+may read only their own status so server actions can enforce message blocks
+without exposing other accounts' moderation history. Admin actions can mark an
+account `message_blocked` or `permanently_blocked`; first-contact and reply
+actions must reject blocked senders with a generic message-send error.
 
 Help-page feedback inserts are authenticated-only. The server action writes
 `feedback_submissions` with the authenticated user ID and, when available, the
@@ -294,6 +312,28 @@ The MVP contact flow should use app-mediated contact with Resend notifications.
 
 RLS lets only contact participants read replies and lets only participants add
 replies to their own contact requests.
+
+`message_reports` stores private report data:
+
+- parent contact request
+- reporting user
+- reported user resolved by trigger
+- category
+- optional reporter note
+- review status
+- admin notes and action timestamp
+- created and updated timestamps
+
+`user_moderation_status` stores:
+
+- account status
+- message-block timestamp and reason
+- admin notes
+- created and updated timestamps
+
+Admin access is controlled by the server-only `ADMIN_EMAILS` allowlist. Account
+deletion remains a manual Supabase Auth process documented in
+`docs/admin-moderation.md`.
 
 The app applies a basic sender-side rate limit before insert: five contact
 requests per authenticated sender per hour. Database-side rate limiting or abuse

--- a/lib/admin/admin-access.ts
+++ b/lib/admin/admin-access.ts
@@ -1,0 +1,25 @@
+import type { User } from "@supabase/supabase-js";
+import { createSupabaseAdminClient } from "@/lib/supabase/server";
+
+export function adminEmailAllowlist() {
+  return (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAdminUser(user: User | null) {
+  const email = user?.email?.trim().toLowerCase();
+
+  return Boolean(email && adminEmailAllowlist().includes(email));
+}
+
+export function createRequiredAdminClient() {
+  const admin = createSupabaseAdminClient();
+
+  if (!admin) {
+    throw new Error("Admin Supabase client is not configured.");
+  }
+
+  return admin;
+}

--- a/lib/contact/contact-status.ts
+++ b/lib/contact/contact-status.ts
@@ -1,4 +1,4 @@
-export type ContactStatus = "auth" | "error" | "sent" | "stored";
+export type ContactStatus = "auth" | "blocked" | "error" | "sent" | "stored";
 
 export function contactStatusMessage(status: string | string[] | undefined) {
   const value = Array.isArray(status) ? status[0] : status;
@@ -21,6 +21,13 @@ export function contactStatusMessage(status: string | string[] | undefined) {
     return {
       tone: "notice" as const,
       text: "Sign in with an email one-time code before sending a contact request.",
+    };
+  }
+
+  if (value === "blocked") {
+    return {
+      tone: "error" as const,
+      text: "This account is not currently allowed to send messages.",
     };
   }
 

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -76,7 +76,8 @@ export const publicHelpSections = [
   {
     body: [
       "Use the same judgment you would use when meeting someone through a singing community. Start with app-mediated messages, meet in public or group settings when possible, and do not share private contact details until you are comfortable.",
-      "The app helps reduce public exposure of personal data, but it does not replace personal judgment or formal moderation.",
+      "Message detail pages include a private report action for spam, harassment, suspicious requests, or other safety concerns. Reports are reviewed as the project team is able.",
+      "The app helps reduce public exposure of personal data, but it does not replace personal judgment or guarantee real-time moderation.",
     ],
     heading: "First Contact Safety",
   },
@@ -123,6 +124,7 @@ export const publicPrivacySections = [
       "Public search results should not show personal email addresses or phone numbers by default.",
       "When someone sends a contact request, the app stores the request, resolves the recipient on the server/database side, and sends a notification without revealing the recipient's email address to the sender.",
       "Replies are stored with the original contact request and are visible only to the sender and recipient participants.",
+      "Message reports are private. They are visible only to authorized project administrators for review and safety action.",
     ],
     heading: "Contact Relay",
   },

--- a/lib/messages/moderation.ts
+++ b/lib/messages/moderation.ts
@@ -1,0 +1,116 @@
+import { getAppUrl } from "@/lib/supabase/env";
+
+export type MessageReportCategory =
+  | "harassment"
+  | "other"
+  | "spam"
+  | "unsafe_request";
+
+export const messageReportCategories: Array<{
+  label: string;
+  value: MessageReportCategory;
+}> = [
+  { label: "Spam", value: "spam" },
+  { label: "Harassment or inappropriate behavior", value: "harassment" },
+  { label: "Suspicious or unsafe request", value: "unsafe_request" },
+  { label: "Other", value: "other" },
+];
+
+export const MESSAGE_REPORT_NOTE_MAX_LENGTH = 2000;
+
+export function reportCategoryLabel(category: string) {
+  return (
+    messageReportCategories.find((option) => option.value === category)
+      ?.label ?? "Other"
+  );
+}
+
+export type AdminReportNotification = {
+  category: string;
+  contactRequestId: string;
+  createdAt: string;
+  note: string | null;
+  reportId: string;
+  reportedUserId: string | null;
+  reporterEmail: string | null;
+  reporterUserId: string;
+};
+
+export function getAdminNotificationConfig() {
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.RESEND_FROM_EMAIL;
+
+  if (!apiKey || !fromEmail) {
+    return null;
+  }
+
+  return {
+    apiKey,
+    fromEmail,
+    toEmail: "cubuff98@gmail.com",
+  };
+}
+
+export function buildAdminReportNotificationEmail({
+  category,
+  contactRequestId,
+  createdAt,
+  note,
+  reportId,
+  reportedUserId,
+  reporterEmail,
+  reporterUserId,
+}: AdminReportNotification) {
+  const appUrl = getAppUrl();
+  const adminUrl = `${appUrl}/sign-in?next=${encodeURIComponent(
+    `/app/admin/reports/${reportId}`,
+  )}`;
+  const subject = `Quartet Member Finder message report: ${reportCategoryLabel(
+    category,
+  )}`;
+  const text = [
+    "A message/contact request was reported on Quartet Member Finder.",
+    "",
+    `Report ID: ${reportId}`,
+    `Category: ${reportCategoryLabel(category)}`,
+    `Contact request ID: ${contactRequestId}`,
+    `Reporter user ID: ${reporterUserId}`,
+    `Reporter email: ${reporterEmail ?? "Unavailable"}`,
+    `Reported user ID: ${reportedUserId ?? "Unavailable"}`,
+    `Reported at: ${createdAt}`,
+    "",
+    "Reporter note:",
+    note || "No note provided.",
+    "",
+    `Review in the admin console: ${adminUrl}`,
+    "If the admin console is unavailable, review the message_reports and contact_requests tables in Supabase with service-role/admin access.",
+  ].join("\n");
+
+  return { subject, text };
+}
+
+export async function sendAdminReportNotification(
+  config: NonNullable<ReturnType<typeof getAdminNotificationConfig>>,
+  notification: AdminReportNotification,
+) {
+  const { subject, text } = buildAdminReportNotificationEmail(notification);
+  const response = await fetch("https://api.resend.com/emails", {
+    body: JSON.stringify({
+      from: config.fromEmail,
+      subject,
+      text,
+      to: config.toEmail,
+    }),
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Resend report notification failed with ${response.status}.`,
+    );
+  }
+}

--- a/supabase/migrations/20260501024500_message_reports_and_moderation.sql
+++ b/supabase/migrations/20260501024500_message_reports_and_moderation.sql
@@ -1,0 +1,141 @@
+create table public.user_moderation_status (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  account_status text not null default 'active' check (
+    account_status in (
+      'active',
+      'message_blocked',
+      'suspended',
+      'permanently_blocked',
+      'deletion_requested'
+    )
+  ),
+  messaging_blocked_at timestamptz,
+  messaging_block_reason text check (
+    messaging_block_reason is null
+    or char_length(messaging_block_reason) <= 500
+  ),
+  admin_notes text check (
+    admin_notes is null
+    or char_length(admin_notes) <= 2000
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.message_reports (
+  id uuid primary key default gen_random_uuid(),
+  contact_request_id uuid not null references public.contact_requests (id) on delete cascade,
+  reporter_user_id uuid not null references auth.users (id) on delete cascade,
+  reported_user_id uuid references auth.users (id) on delete set null,
+  category text not null check (
+    category in (
+      'spam',
+      'harassment',
+      'unsafe_request',
+      'other'
+    )
+  ),
+  note text check (
+    note is null
+    or char_length(note) <= 2000
+  ),
+  status text not null default 'new' check (
+    status in (
+      'new',
+      'reviewed',
+      'action_taken',
+      'dismissed'
+    )
+  ),
+  admin_notes text check (
+    admin_notes is null
+    or char_length(admin_notes) <= 2000
+  ),
+  action_taken_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index message_reports_request_idx
+  on public.message_reports (contact_request_id, created_at desc);
+
+create index message_reports_reported_user_idx
+  on public.message_reports (reported_user_id, created_at desc);
+
+create index message_reports_status_idx
+  on public.message_reports (status, created_at desc);
+
+create trigger user_moderation_status_set_updated_at
+before update on public.user_moderation_status
+for each row execute function public.set_updated_at();
+
+create trigger message_reports_set_updated_at
+before update on public.message_reports
+for each row execute function public.set_updated_at();
+
+create function public.set_message_report_reported_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  request_sender uuid;
+  request_recipient uuid;
+begin
+  select sender_user_id, recipient_user_id
+  into request_sender, request_recipient
+  from public.contact_requests
+  where id = new.contact_request_id;
+
+  if request_sender is null or request_recipient is null then
+    raise exception 'message report target is not available';
+  end if;
+
+  if new.reporter_user_id = request_sender then
+    new.reported_user_id = request_recipient;
+  elsif new.reporter_user_id = request_recipient then
+    new.reported_user_id = request_sender;
+  else
+    raise exception 'reporter cannot report unrelated messages';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger message_reports_set_reported_user
+before insert on public.message_reports
+for each row execute function public.set_message_report_reported_user();
+
+alter table public.user_moderation_status enable row level security;
+alter table public.message_reports enable row level security;
+
+create policy "Users can read their own moderation status"
+on public.user_moderation_status
+for select
+using (auth.uid() = user_id);
+
+create policy "Message participants can create private reports"
+on public.message_reports
+for insert
+with check (
+  reporter_user_id = auth.uid()
+  and exists (
+    select 1
+    from public.contact_requests
+    where contact_requests.id = message_reports.contact_request_id
+      and (
+        contact_requests.sender_user_id = auth.uid()
+        or contact_requests.recipient_user_id = auth.uid()
+      )
+  )
+);
+
+revoke all on table public.user_moderation_status from anon, authenticated;
+revoke all on table public.message_reports from anon, authenticated;
+
+grant select on table public.user_moderation_status to authenticated;
+grant insert on table public.message_reports to authenticated;
+
+revoke all on function public.set_message_report_reported_user() from public;

--- a/test/contact-status.test.ts
+++ b/test/contact-status.test.ts
@@ -6,6 +6,9 @@ describe("contact status messages", () => {
     expect(contactStatusMessage("sent")).toMatchObject({ tone: "success" });
     expect(contactStatusMessage("stored")).toMatchObject({ tone: "notice" });
     expect(contactStatusMessage("error")).toMatchObject({ tone: "error" });
+    expect(contactStatusMessage("blocked")?.text).toContain(
+      "not currently allowed",
+    );
     expect(contactStatusMessage(undefined)).toBeNull();
   });
 

--- a/test/message-moderation.test.ts
+++ b/test/message-moderation.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAdminReportNotificationEmail,
+  getAdminNotificationConfig,
+  messageReportCategories,
+  reportCategoryLabel,
+} from "@/lib/messages/moderation";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("message moderation", () => {
+  it("defines simple report categories and private admin notification content", () => {
+    expect(messageReportCategories.map((category) => category.value)).toEqual([
+      "spam",
+      "harassment",
+      "unsafe_request",
+      "other",
+    ]);
+    expect(reportCategoryLabel("unsafe_request")).toBe(
+      "Suspicious or unsafe request",
+    );
+
+    const { subject, text } = buildAdminReportNotificationEmail({
+      category: "spam",
+      contactRequestId: "request-1",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      note: "This looked automated.",
+      reportedUserId: "reported-user",
+      reporterEmail: "reporter@example.com",
+      reporterUserId: "reporter-user",
+      reportId: "report-1",
+    });
+
+    expect(subject).toBe("Quartet Member Finder message report: Spam");
+    expect(text).toContain("Report ID: report-1");
+    expect(text).toContain("Reporter email: reporter@example.com");
+    expect(text).toContain("/sign-in?next=%2Fapp%2Fadmin%2Freports%2Freport-1");
+    expect(text).toContain("message_reports and contact_requests");
+  });
+
+  it("keeps admin notification config server-only", () => {
+    vi.stubEnv("RESEND_API_KEY", "resend-key");
+    vi.stubEnv("RESEND_FROM_EMAIL", "messages@example.com");
+
+    expect(getAdminNotificationConfig()).toEqual({
+      apiKey: "resend-key",
+      fromEmail: "messages@example.com",
+      toEmail: "cubuff98@gmail.com",
+    });
+
+    vi.unstubAllEnvs();
+    expect(getAdminNotificationConfig()).toBeNull();
+  });
+
+  it("adds an allowlisted admin console with report actions", () => {
+    const adminList = source("app/(protected)/app/admin/page.tsx");
+    const adminDetail = source(
+      "app/(protected)/app/admin/reports/[id]/page.tsx",
+    );
+    const adminActions = source("app/(protected)/app/admin/actions.ts");
+    const adminAccess = source("lib/admin/admin-access.ts");
+    const contactAction = source("app/contact/actions.ts");
+    const messageActions = source("app/(protected)/app/messages/actions.ts");
+
+    expect(adminAccess).toContain("ADMIN_EMAILS");
+    expect(adminList).toContain("Not authorized");
+    expect(adminList).toContain("message_reports");
+    expect(adminDetail).toContain("Block from messaging");
+    expect(adminDetail).toContain("Permanently block account");
+    expect(adminActions).toContain("message_blocked");
+    expect(adminActions).toContain("permanently_blocked");
+    expect(adminActions).toContain("is_visible: false");
+    expect(contactAction).toContain("user_moderation_status");
+    expect(contactAction).toContain("blocked");
+    expect(messageActions).toContain("user_moderation_status");
+    expect(messageActions).toContain("reportMessage");
+  });
+});

--- a/test/messages-ui.test.ts
+++ b/test/messages-ui.test.ts
@@ -22,10 +22,14 @@ describe("messages UI", () => {
     );
     expect(detailPage).toContain("Original message");
     expect(detailPage).toContain("Send reply");
+    expect(detailPage).toContain("Report this message");
+    expect(detailPage).toContain("messageReportCategories");
     expect(detailPage).toContain(
       "Private email addresses and phone numbers are not shown by default.",
     );
     expect(replyAction).toContain("contact_request_replies");
     expect(replyAction).toContain("sendContactReplyNotification");
+    expect(replyAction).toContain("message_reports");
+    expect(replyAction).toContain("sendAdminReportNotification");
   });
 });

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -25,6 +25,7 @@ describe("public help and privacy content", () => {
     expect(helpText).toContain("Location Defaults");
     expect(helpText).toContain("Contact");
     expect(helpText).toContain("read and reply in Messages");
+    expect(helpText).toContain("private report action");
     expect(helpText).toContain("Signed-in users can send private feedback");
     expect(helpText).toContain("does not replace personal judgment");
     expect(helpText).not.toMatch(/24\/7 moderation|background checks/i);
@@ -39,6 +40,7 @@ describe("public help and privacy content", () => {
     expect(privacyText).toContain("Both optional profiles can be discoverable");
     expect(privacyText).toContain("email addresses or phone numbers");
     expect(privacyText).toContain("visible only to the sender and recipient");
+    expect(privacyText).toContain("authorized project administrators");
     expect(privacyText).toContain("global");
     expect(privacyText).toContain("not a formal legal privacy policy");
   });

--- a/test/supabase-schema.test.ts
+++ b/test/supabase-schema.test.ts
@@ -15,6 +15,8 @@ const appTables = [
   "quartet_listing_parts",
   "contact_requests",
   "contact_request_replies",
+  "message_reports",
+  "user_moderation_status",
   "feedback_submissions",
 ];
 
@@ -149,5 +151,23 @@ describe("initial Supabase schema migration", () => {
     );
     expect(migration).toContain("recipient_read_at");
     expect(migration).toContain("sender_read_at");
+  });
+
+  it("adds private message reports and account moderation status", () => {
+    expect(migration).toContain("create table public.message_reports");
+    expect(migration).toContain("create table public.user_moderation_status");
+    expect(migration).toContain("set_message_report_reported_user");
+    expect(migration).toContain(
+      'create policy "Message participants can create private reports"',
+    );
+    expect(migration).toContain(
+      'create policy "Users can read their own moderation status"',
+    );
+    expect(migration).toContain("grant insert on table public.message_reports");
+    expect(migration).toContain(
+      "grant select on table public.user_moderation_status",
+    );
+    expect(migration).toContain("'message_blocked'");
+    expect(migration).toContain("'permanently_blocked'");
   });
 });


### PR DESCRIPTION
Closes #94

## Summary
- add private message reports from message detail pages with admin Resend notification to cubuff98@gmail.com
- add /app/admin report list/detail protected by server-only ADMIN_EMAILS allowlist
- add admin actions to hide reported profiles, block messaging, permanently block accounts, and mark reports reviewed/action taken/dismissed
- add user_moderation_status checks before first-contact messages and replies
- document admin access, report review, message blocking, permanent block, and manual deletion process

## Migration
- supabase/migrations/20260501024500_message_reports_and_moderation.sql

## Runtime config
- ADMIN_EMAILS must be set server-side in Vercel for /app/admin access
- existing RESEND_API_KEY, RESEND_FROM_EMAIL, and SUPABASE_SERVICE_ROLE_KEY are used for notifications/admin review

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build