### PR TITLE
Reorganize Help page and project context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,10 @@ Security:
 
 ## Barbershop-specific context
 
+Additional durable domain context lives in `docs/barbershop-context.md`. Keep
+that document aligned when changing voice-part behavior, discovery/privacy
+assumptions, or user-facing product language.
+
 - Barbershop is sung by communities around the world, including the US, Canada, UK, Ireland, Europe, Australia, New Zealand, and elsewhere.
 - Pickup and prospective quartets often form through local chapters, conventions, afterglows, coaching circles, and informal singer networks.
 - Quartet goals vary widely:

--- a/README.md
+++ b/README.md
@@ -1,30 +1,41 @@
 # Quartet Member Finder
 
-Quartet Member Finder helps barbershop singers and incomplete quartets find each other.
+Quartet Member Finder helps barbershop singers and incomplete or prospective
+quartets find each other without turning discovery into a public social network.
+The app is built around practical, privacy-conscious introductions: signed-in
+discovery, approximate location, app-mediated Messages, and independent profile
+visibility controls.
 
-The app is intended to support privacy-conscious discovery, approximate location search, singer profiles, quartet listings, and safe first contact between people who may want to sing together.
+## Product Model
+
+One account can support two optional presences:
+
+- **My Singer Profile** represents the signed-in user personally as a singer.
+- **My Quartet Profile** represents a quartet, incomplete quartet, or
+  prospective quartet the user represents.
+
+Users can fill out either profile, both profiles, or neither while getting
+oriented. Each profile has its own visibility setting, so filling out a profile
+does not automatically make it discoverable.
+
+Discovery requires sign-in. Find combines filters, approximate radius search,
+privacy-safe map context, and result cards for singer profiles and quartet
+openings. First contact happens through Messages; private email addresses and
+phone numbers are not shown in discovery by default.
 
 ## Stack
 
 - Next.js App Router
 - TypeScript
 - Tailwind CSS
-- ESLint and Prettier
-- Vercel deployments from GitHub
+- Supabase Auth/Postgres with Row Level Security
+- Resend transactional email
+- Mapbox for interactive discovery maps and server-side approximate geocoding
 - Vitest for unit tests
-- GitHub Actions for CI
-- Planned: Supabase Auth/Postgres/Row Level Security
-- Planned: Resend transactional email
+- ESLint and Prettier
+- GitHub Actions CI and Vercel deployment
 
-## Product goals
-
-- Help individual singers publish enough information to be found by compatible quartets or other singers.
-- Help incomplete quartets advertise what parts and commitment level they are looking for.
-- Support map/list discovery without exposing exact home locations.
-- Provide a safe app-mediated contact flow before personal contact details are shared.
-- Keep the experience friendly, practical, and useful for the barbershop community.
-
-## Local development path
+## Local Development
 
 Use this local repo path for Codex work:
 
@@ -32,13 +43,14 @@ Use this local repo path for Codex work:
 /Users/timpeterson/Documents/Codex/quartet-member-finder
 ```
 
-## Local setup
-
 Install dependencies:
 
 ```bash
 npm install
 ```
+
+Copy `.env.example` to `.env.local` and fill in local service values. Keep real
+secrets out of source control.
 
 Start the development server:
 
@@ -46,7 +58,7 @@ Start the development server:
 npm run dev
 ```
 
-Validate the project:
+Core validation commands:
 
 ```bash
 npm run lint
@@ -56,38 +68,30 @@ npm run format:check
 npm run build
 ```
 
-Copy `.env.example` to `.env.local` when configuring local services. Keep real
-secrets out of source control.
+## Key Docs
 
-Testing expectations and the current unit-test structure are documented in
-`docs/testing.md`.
+- `AGENTS.md` captures agent workflow, product guardrails, privacy rules, and
+  repository expectations.
+- `docs/barbershop-context.md` captures durable barbershop/domain context for
+  future contributors and Codex work.
+- `docs/supabase-contract.md` documents schema, RLS, discovery views, contact,
+  reporting, and privacy expectations.
+- `docs/privacy-model.md` documents approximate location, contact privacy,
+  reporting, and safety boundaries.
+- `docs/deployment.md` documents Vercel, Supabase, Resend, Mapbox, domain, and
+  production deployment setup.
+- `docs/environment.md` lists required public and server-only environment
+  variables.
+- `docs/smoke-test-plan.md` and `docs/launch-readiness.md` describe manual
+  verification and launch readiness.
+- `docs/admin-moderation.md` documents report review, message blocking,
+  permanent block, and manual deletion process.
+- Public user-facing Help and Privacy copy lives in `lib/content/public-pages.ts`
+  and renders at `/help` and `/privacy`.
 
-Local and staging demo data is documented in `docs/seed-data.md`; the seed file
-is intentionally opt-in and must not be run against production.
+## Workflow
 
-Manual launch and deployment validation steps are documented in
-`docs/smoke-test-plan.md`.
-
-The final production-readiness and privacy launch checklist is documented in
-`docs/launch-readiness.md`.
-
-Privacy-safe PostHog event capture and launch dashboard setup are documented in
-`docs/posthog-analytics.md`.
-
-Vercel, Supabase, Resend, Namecheap DNS, and `quartetmemberfinder.org`
-deployment steps are documented in `docs/deployment.md`.
-
-## Repository workflow
-
-Normal work should happen on short-lived feature branches and merge to `main`
-through pull requests. The protected `main` branch requires the `guardrails`,
-`validate`, and `Vercel` checks before merge.
-
-Squash merge is the preferred merge strategy, auto-merge may be used once a PR
-is ready and checks are expected to pass, and feature branches should be deleted
-after merge.
-
-## Early project notes
-
-Project context, privacy expectations, workflow rules, and implementation
-guardrails are captured in `AGENTS.md` and the `docs/` folder.
+Normal work happens on short-lived feature branches and merges to `main` through
+pull requests. The protected `main` branch expects `guardrails`, `validate`, and
+`Vercel` checks. Squash merge is preferred, and auto-merge may be enabled once a
+PR is ready and checks are expected to pass.

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -29,26 +29,78 @@ export default async function HelpPage({ searchParams }: HelpPageProps) {
             How Quartet Member Finder Works
           </h1>
           <p className="mt-5 max-w-3xl text-lg leading-8 text-[#394548]">
-            A practical guide for singers and quartets using the app before,
-            during, and after first contact.
+            A practical guide for getting oriented, creating optional profiles,
+            searching with Find, and using Messages without exposing private
+            contact details by default.
           </p>
         </header>
 
-        <section className="mt-10 grid gap-5">
-          {publicHelpSections.map((section) => (
-            <article
-              className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
-              key={section.heading}
+        <nav
+          aria-label="On this page"
+          className="mt-10 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+        >
+          <h2 className="text-xl font-bold text-[#172023]">On this page</h2>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+            {publicHelpSections.map((section) => (
+              <a
+                className="rounded-md px-3 py-2 text-sm font-semibold text-[#2f6f73] hover:bg-white"
+                href={`#${section.id}`}
+                key={section.id}
+              >
+                {section.title}
+              </a>
+            ))}
+            <a
+              className="rounded-md px-3 py-2 text-sm font-semibold text-[#2f6f73] hover:bg-white"
+              href="#feedback"
             >
-              <h2 className="text-xl font-bold text-[#172023]">
-                {section.heading}
+              Send Feedback
+            </a>
+          </div>
+        </nav>
+
+        <section className="mt-10 space-y-10">
+          {publicHelpSections.map((section) => (
+            <section
+              className="scroll-mt-6 border-t border-[#d7cec0] pt-8"
+              id={section.id}
+              key={section.id}
+            >
+              <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#2f6f73]">
+                {section.eyebrow}
+              </p>
+              <h2 className="mt-3 text-3xl font-bold text-[#172023]">
+                {section.title}
               </h2>
-              <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
-                {section.body.map((paragraph) => (
-                  <p key={paragraph}>{paragraph}</p>
+              <p className="mt-3 max-w-3xl text-base leading-7 text-[#394548]">
+                {section.intro}
+              </p>
+
+              <div className="mt-6 grid gap-4">
+                {section.topics.map((topic) => (
+                  <article
+                    className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5"
+                    key={topic.title}
+                  >
+                    <h3 className="text-xl font-bold text-[#172023]">
+                      {topic.title}
+                    </h3>
+                    <div className="mt-3 space-y-3 text-base leading-7 text-[#394548]">
+                      {topic.body.map((paragraph) => (
+                        <p key={paragraph}>{paragraph}</p>
+                      ))}
+                    </div>
+                    {topic.bullets ? (
+                      <ul className="mt-4 list-disc space-y-2 pl-5 text-sm leading-6 text-[#394548]">
+                        {topic.bullets.map((bullet) => (
+                          <li key={bullet}>{bullet}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </article>
                 ))}
               </div>
-            </article>
+            </section>
           ))}
         </section>
 

--- a/docs/barbershop-context.md
+++ b/docs/barbershop-context.md
@@ -1,0 +1,72 @@
+# Barbershop And Product Context
+
+Quartet Member Finder is for practical introductions between barbershop singers
+and incomplete or prospective quartets. It should feel like a helpful community
+tool, not a dating app, recruiting marketplace, or public social network.
+
+## Community Context
+
+Barbershop quartet opportunities often form through chapters, rehearsals,
+conventions, afterglows, coaching circles, and informal singer networks. People
+may arrive as an individual singer, as someone representing a quartet, or as
+both. The app should support that flexibility without forcing users into one
+permanent role.
+
+Barbershop is global. Early users may be concentrated in the United States and
+Canada, but product language, location fields, and data models should remain
+globally tolerant.
+
+## Voice Parts And Voicings
+
+TTBB barbershop parts are Tenor, Lead, Baritone, and Bass. Lead is the melody
+part in most TTBB barbershop arrangements; do not rename it to Melody.
+
+The app preserves voicing context:
+
+- TTBB parts: Tenor, Lead, Baritone, Bass.
+- SATB or mixed support should keep SATB context instead of treating shared part
+  names as automatically equivalent.
+- SSAA support should follow the app's current model and should not casually mix
+  TTBB labels into SSAA behavior unless the product explicitly changes.
+
+Part filters, profile fields, and matching/search behavior should preserve
+voicing plus part together. A TTBB Tenor and a SATB Tenor are not automatically
+the same product signal.
+
+## Discovery And Privacy
+
+One account can support two independent optional presences:
+
+- My Singer Profile, for the signed-in user personally as a singer.
+- My Quartet Profile, for a quartet or prospective quartet the user represents.
+
+Each profile has its own visibility/discoverability setting. Filling out one or
+both profiles does not mean either one must be discoverable. Hiding one profile
+does not hide the other.
+
+Discovery requires sign-in. Discovery should show practical matching context,
+not private personal data. Public/result UI should not show exact home
+addresses, exact coordinates, private postal codes, private email addresses, or
+phone numbers.
+
+Location is approximate and privacy-sensitive. ZIP or postal code may support
+geocoding and radius search, but discovery should show only approximate area and
+distance context.
+
+Contact is app-mediated through Messages. Private email and phone are not
+exposed by default. Users can report inappropriate, spammy, suspicious, or
+concerning messages; reports are reviewed as the project team is able.
+
+## Product Tone
+
+Prefer clear, practical language over formal, legalistic, or marketing-heavy
+language. Explain limitations plainly:
+
+- distance and map placement are approximate
+- discovery requires sign-in
+- reports are reviewed as able, not in real time
+- users should use personal judgment before sharing direct contact details
+
+Avoid overpromising safety, moderation, exact map precision, or verified
+compatibility. The app should help people start better-informed conversations,
+not make guarantees about fit or behavior.

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -1,97 +1,329 @@
-export const publicHelpSections = [
+export type HelpGuideTopic = {
+  body: string[];
+  bullets?: string[];
+  title: string;
+};
+
+export type HelpGuideSection = {
+  eyebrow: string;
+  id: string;
+  intro: string;
+  title: string;
+  topics: HelpGuideTopic[];
+};
+
+export const publicHelpSections: HelpGuideSection[] = [
   {
-    body: [
-      "Quartet Member Finder helps barbershop singers and incomplete quartets find each other. It is for practical discovery and safer introductions, not for building a public social network.",
-      "One account can support My Singer Profile, My Quartet Profile, or both. You can use either optional profile without choosing a permanent role.",
+    eyebrow: "Start here",
+    id: "getting-started",
+    intro:
+      "Quartet Member Finder helps barbershop singers and incomplete quartets find each other through practical, privacy-conscious introductions.",
+    title: "Getting Started",
+    topics: [
+      {
+        body: [
+          "Use QMF when you want to find quartet openings, find singers for an incomplete quartet, or understand who nearby might be open to singing together.",
+          "The app is not a public social network or a directory of personal contact details. It is meant to support safer introductions and enough context for people to decide whether a conversation makes sense.",
+        ],
+        title: "What the app is for",
+      },
+      {
+        body: [
+          "Most people arrive with one immediate goal: they are a singer looking for opportunities, or they represent a quartet looking for one or more singers.",
+          "Start with the profile that matches your current goal, or use Find first to understand how discovery works. Your first choice does not lock you into a permanent role.",
+        ],
+        bullets: [
+          "Use My Singer Profile when you personally want quartet opportunities.",
+          "Use My Quartet Profile when you represent an incomplete or prospective quartet.",
+          "Use Find when you want to search visible profiles and openings after signing in.",
+        ],
+        title: "What to do first",
+      },
+      {
+        body: [
+          "Discovery requires sign-in so browsing, contact, reporting, and feedback are tied to accountable accounts. Help and Privacy remain available before sign-in so you can understand the app before creating a session.",
+          "Privacy starts with approximate location, independent visibility controls, and app-mediated Messages instead of exposing private email addresses or phone numbers in discovery.",
+        ],
+        title: "Why sign-in and privacy matter",
+      },
     ],
-    heading: "What It Is For",
   },
   {
-    body: [
-      "A singer profile describes who you are as a singer: your name, parts, goals, experience, availability, travel willingness, and approximate location.",
-      "Parts are grouped by voicing, so TTBB Tenor, SATB Tenor, and SSAA part labels stay distinct in discovery.",
-      "Only display name is required; the optional details help others decide whether a contact request makes sense.",
-      "You choose whether My Singer Profile appears in discovery. Hidden singer profiles stay out of singer search and Find, and hiding it does not hide My Quartet Profile.",
+    eyebrow: "Profiles",
+    id: "optional-profiles",
+    intro:
+      "One account can support two independent optional presences: My Singer Profile and My Quartet Profile.",
+    title: "One Account, Two Optional Profiles",
+    topics: [
+      {
+        body: [
+          "You can fill out My Singer Profile, My Quartet Profile, both profiles, or neither while you get oriented. You do not need to publish both profiles just because both options exist.",
+          "The two profiles are independent. Hiding My Singer Profile does not hide My Quartet Profile, and hiding My Quartet Profile does not hide My Singer Profile.",
+        ],
+        title: "Use either profile, both, or neither",
+      },
+      {
+        body: [
+          "Each profile has its own visibility control. Filling out a profile does not make it discoverable unless you turn visibility on.",
+          "Both profiles can be discoverable at the same time if that matches your situation, such as when you personally sing and also represent a quartet looking for another part.",
+        ],
+        bullets: [
+          "Discoverable profiles can appear in Find.",
+          "Hidden profiles stay out of discovery.",
+          "You can hide a profile when you are no longer looking.",
+        ],
+        title: "Independent visibility",
+      },
     ],
-    heading: "Singer Profiles",
   },
   {
-    body: [
-      "After sign-in, onboarding first asks for basic profile context like display name, country, and approximate location.",
-      "Then you choose what you are here to do first. That choice is not permanent; you can use My Singer Profile, My Quartet Profile, Find, and Help later.",
+    eyebrow: "Your singer presence",
+    id: "singer-profile",
+    intro:
+      "My Singer Profile represents you personally as a singer and helps quartets or other singers decide whether to contact you.",
+    title: "My Singer Profile",
+    topics: [
+      {
+        body: [
+          "A singer profile can include your display name, parts, goals, experience, availability, travel willingness, and approximate location.",
+          "Only display name is required to save the form, but parts, goals, availability, and location make discovery and first contact more useful.",
+        ],
+        title: "What to include",
+      },
+      {
+        body: [
+          "Parts are stored with voicing context. TTBB Tenor, SATB Tenor, and SSAA part labels are not casually treated as the same thing.",
+          "Use every part you would be comfortable being contacted about. That helps people avoid guessing from a short bio.",
+        ],
+        title: "Parts and voicing",
+      },
+      {
+        body: [
+          "Keep the profile hidden while it is incomplete, while you are not open to opportunities, or while you are only using the app as a quartet representative.",
+          "If important discovery or location fields are incomplete, your profile can be harder to interpret and may not place well in map or radius search context.",
+        ],
+        title: "When to hide it",
+      },
     ],
-    heading: "First Sign-In",
   },
   {
-    body: [
-      "My Quartet Profile is for a quartet or prospective quartet that has some parts covered and is looking for one or more singers.",
-      "It keeps covered parts and needed parts separate within the quartet's voicing so searchers can quickly understand what the group needs.",
-      "You choose whether My Quartet Profile appears in discovery. Hidden quartet profiles stay out of quartet search and Find, and hiding it does not hide My Singer Profile.",
+    eyebrow: "Your quartet presence",
+    id: "quartet-profile",
+    intro:
+      "My Quartet Profile is for a quartet, incomplete quartet, or prospective quartet you represent.",
+    title: "My Quartet Profile",
+    topics: [
+      {
+        body: [
+          "Use My Quartet Profile when the group has some parts covered and is looking for one or more singers. The profile should explain enough for a singer to decide whether to start a conversation.",
+          "Useful details include covered parts, needed parts, goals, rehearsal expectations, commitment level, availability, travel willingness, and approximate location.",
+        ],
+        title: "What it represents",
+      },
+      {
+        body: [
+          "Covered parts and needed parts are separate. That lets a Lead, Bass, Baritone, or Tenor see whether the opening actually fits before contacting you.",
+          "Like My Singer Profile, My Quartet Profile has its own visibility setting. Hide it when the opening is filled, paused, or not ready for people to find.",
+        ],
+        title: "Covered and needed parts",
+      },
     ],
-    heading: "Quartet Profiles",
   },
   {
-    body: [
-      "Find is the main discovery page. It combines filters, a privacy-safe interactive map, and result cards for quartet openings and singer profiles.",
-      "Use the looking-for filter to focus on quartet openings when you are a singer, or singer profiles when you are representing a quartet or looking for other singers.",
-      "Part filters include voicing context, including TTBB, SSAA, and SATB / mixed labels.",
-      "Search from a typed place or your saved singer profile location, choose a radius, and switch between miles and kilometers. Radius search uses approximate distance when geocoding is configured.",
-      "The map is part of Find rather than a separate first step. It helps you scan approximate activity, then the result cards give names, parts, type, distance when available, and contact links.",
-      "Detailed singer and quartet search pages remain available when you need more specific filters like availability, experience, or travel willingness.",
-      "Search results are useful even when a profile is incomplete, but more complete profiles are easier for others to evaluate.",
+    eyebrow: "Discovery",
+    id: "find",
+    intro:
+      "Find is the shared discovery surface for quartet openings and singer profiles.",
+    title: "Find Quartet Openings And Find Singers",
+    topics: [
+      {
+        body: [
+          "Choose what you are looking for: quartet openings, singers, or both. Use part filters with voicing context when a specific part matters.",
+          "Find combines filters, a privacy-safe interactive map, and result cards. Result cards give the practical context you need before starting contact.",
+        ],
+        title: "How Find works",
+      },
+      {
+        body: [
+          "You can search from a typed place or from your saved singer profile location, choose a radius, and switch between miles and kilometers. Miles are the default display unit.",
+          "Radius search uses approximate geocoding and approximate distance. It is meant to answer whether a match is plausibly nearby, not provide exact navigation.",
+        ],
+        title: "Radius and distance",
+      },
+      {
+        body: [
+          "The map is part of Find. It shows privacy-safe approximate regions rather than exact home pins.",
+          "Use the map to understand broad geography, then use result cards and Messages for actual introductions.",
+        ],
+        title: "Map and results",
+      },
     ],
-    heading: "Search",
   },
   {
-    body: [
-      "Discovery results show approximate places, such as a city or regional area. They do not show exact home addresses, exact coordinates, private postal codes, email addresses, or phone numbers.",
-      "Location fields are designed for a global barbershop community, so they are not limited to US ZIP codes or US states.",
+    eyebrow: "Location",
+    id: "location",
+    intro:
+      "Location helps people judge practical singing distance without exposing exact home-location details.",
+    title: "Location, Radius Search, And Approximate Maps",
+    topics: [
+      {
+        body: [
+          "No street address is required. Profile and listing forms ask for globally tolerant fields such as country, state/province/region, city/locality, and ZIP/postal code.",
+          "ZIP or postal code can help approximate search and map placement, but it is not shown publicly.",
+        ],
+        title: "What location fields are for",
+      },
+      {
+        body: [
+          "Discovery can show approximate area labels such as a city or region. It should not show exact coordinates, private postal codes, street addresses, private emails, or phone numbers.",
+          "Global support is intended. Early defaults are most polished for the United States and Canada, but the app avoids assuming US-only address formats.",
+        ],
+        title: "What discovery shows",
+      },
+      {
+        body: [
+          "Approximate geocoding supports radius search and map placement. If a profile or listing has incomplete location data, it may still be useful but may not place well on the map.",
+          "Distance search defaults to miles, with kilometers available when that is more useful.",
+        ],
+        title: "Limits of approximate search",
+      },
     ],
-    heading: "Location And Privacy",
   },
   {
-    body: [
-      "First contact happens through the app. A signed-in user can send a short message, the recipient gets an email notification, and both people can read and reply in Messages.",
-      "The app does not show private email addresses or phone numbers in public search results or message pages by default.",
-      "Notification emails link back to sign-in so full message and reply text stays behind the app.",
+    eyebrow: "Contact",
+    id: "messages",
+    intro:
+      "First contact happens through app-mediated Messages instead of exposing private contact details in discovery.",
+    title: "Messages And Contacting Someone",
+    topics: [
+      {
+        body: [
+          "When you send a message from a profile or opening, the recipient receives an email notification and signs in to read it. The full message stays behind authenticated app access.",
+          "Messages includes Inbox and Sent views so both sides can keep track of contact requests and replies.",
+        ],
+        title: "What happens when you send a message",
+      },
+      {
+        body: [
+          "Users can reply through the app without revealing private email addresses or phone numbers by default. Either person can choose to share direct contact details later if they are comfortable.",
+          "Use the same judgment you would use in a singing community: meet in public or group settings when possible, and do not share private details until you are ready.",
+        ],
+        title: "Replying safely",
+      },
     ],
-    heading: "Contact",
   },
   {
-    body: [
-      "Discoverable means a profile can appear in Find results and approximate map discovery inside Find. Hidden means it stays out of discovery.",
-      "My Singer Profile and My Quartet Profile have independent visibility controls. You can make either one discoverable, both discoverable, or neither discoverable.",
-      "Filling out a profile does not require making it discoverable. If you are no longer looking personally, hide My Singer Profile; if the quartet opening is no longer active, hide My Quartet Profile.",
+    eyebrow: "Safety",
+    id: "privacy-safety",
+    intro:
+      "Visibility, privacy, and safety controls are built around practical discovery rather than public exposure.",
+    title: "Visibility, Privacy, And Safety",
+    topics: [
+      {
+        body: [
+          "Visible profiles can appear in Find. Hidden profiles stay out of discovery. My Singer Profile and My Quartet Profile have separate visibility controls.",
+          "Do not put private contact details or exact home-location information in public bio, description, availability, or goal fields.",
+        ],
+        title: "Visible versus hidden",
+      },
+      {
+        body: [
+          "Discovery should show enough to evaluate a possible match: display names, parts, goals, experience, availability, travel willingness, approximate area, and contact links.",
+          "Discovery should not show exact home addresses, exact coordinates, private postal codes, private email addresses, or phone numbers.",
+        ],
+        title: "What stays private",
+      },
+      {
+        body: [
+          "The Privacy page explains the public/private boundary in more detail. Help and Privacy are both available before sign-in.",
+        ],
+        title: "Where to learn more",
+      },
     ],
-    heading: "Visibility Controls",
   },
   {
-    body: [
-      "Country is the first location cue because it helps the app use sensible labels, such as ZIP code, postcode, state, province, or region, without strict address validation.",
-      "Profile and listing forms ask for country, state/province/region, city/locality, and ZIP/postal code instead of country codes or street addresses. ZIP/postal codes are not shown in discovery.",
-      "Find defaults distance display to miles and lets you switch to kilometers when that is more useful. If your singer profile has a saved approximate location, Find can use it as the search origin.",
+    eyebrow: "Reports",
+    id: "reporting",
+    intro:
+      "Message reports give users a private way to flag spam, harassment, suspicious requests, or other safety concerns.",
+    title: "Reporting Bad Behavior",
+    topics: [
+      {
+        body: [
+          "Use Report this message from a message detail page when something is inappropriate, spammy, suspicious, or concerning.",
+          "Reports are private and are reviewed as the project team is able. The app does not promise real-time moderation or background checks.",
+        ],
+        title: "When to report",
+      },
+      {
+        body: [
+          "Reported behavior may lead to a profile being hidden from discovery or an account being blocked from sending additional messages.",
+          "Ordinary users do not see admin review notes, report history, or internal action details.",
+        ],
+        title: "What can happen after a report",
+      },
     ],
-    heading: "Location Defaults",
   },
   {
-    body: [
-      "Use the same judgment you would use when meeting someone through a singing community. Start with app-mediated messages, meet in public or group settings when possible, and do not share private contact details until you are comfortable.",
-      "Message detail pages include a private report action for spam, harassment, suspicious requests, or other safety concerns. Reports are reviewed as the project team is able.",
-      "The app helps reduce public exposure of personal data, but it does not replace personal judgment or guarantee real-time moderation.",
+    eyebrow: "FAQ",
+    id: "faq",
+    intro:
+      "These are the most common reasons discovery or contact might feel confusing at first.",
+    title: "Troubleshooting And FAQ",
+    topics: [
+      {
+        body: [
+          "There may not be many visible profiles yet, your filters may be too narrow, or your search origin/radius may exclude likely matches. Try clearing part filters, increasing the radius, or searching both singers and quartet openings.",
+        ],
+        title: "Why can't I find any results?",
+      },
+      {
+        body: [
+          "Your profile may be hidden, incomplete, or missing useful location details. Filling out a profile does not publish it; check the visibility setting before expecting it to appear in Find.",
+        ],
+        title: "Why does my profile not show up?",
+      },
+      {
+        body: [
+          "Map and distance search are intentionally approximate. The app avoids exact home-location pins and uses broad area placement for privacy.",
+        ],
+        title: "Why does my map location look approximate?",
+      },
+      {
+        body: [
+          "Yes. One account can have both optional profiles, and neither profile has to be discoverable until you choose to make it visible.",
+        ],
+        title: "Can I be both a singer and a quartet representative?",
+      },
+      {
+        body: [
+          "The recipient gets an email notification, signs in, reads the message in Messages, and can reply through the app. Private email and phone are not shown by default.",
+        ],
+        title: "What happens when I send a message?",
+      },
+      {
+        body: [
+          "Open the message detail page and use Report this message. Choose the closest reason and add a short note if it helps explain the concern.",
+        ],
+        title: "How do I report a bad message?",
+      },
     ],
-    heading: "First Contact Safety",
   },
   {
-    body: [
-      "The public privacy overview explains what is shown, what is kept private, and how approximate location and contact relay behavior work.",
+    eyebrow: "Feedback",
+    id: "feedback-guide",
+    intro:
+      "Feedback helps improve the app while it is still early and practical workflows are being refined.",
+    title: "Feedback",
+    topics: [
+      {
+        body: [
+          "Useful feedback includes bug reports, confusing behavior, unclear copy, missing location formats, search problems, and suggestions for safer contact workflows.",
+          "Signed-in users can send feedback from the bottom of this page. Signed-out users are invited to sign in first so feedback can be tied to an account for follow-up and abuse prevention.",
+        ],
+        title: "What to send",
+      },
     ],
-    heading: "Privacy Page",
-  },
-  {
-    body: [
-      "Signed-in users can send private feedback, bug reports, and suggestions from this help page. Feedback is tied to the signed-in account server-side and is not shown publicly.",
-    ],
-    heading: "Feedback",
   },
 ];
 

--- a/test/empty-states.test.ts
+++ b/test/empty-states.test.ts
@@ -41,7 +41,7 @@ describe("empty and first-time states", () => {
     expect(contactForm).toContain("Contact starts through the app");
     expect(contactForm).toContain("personal email addresses and phone");
     expect(contactForm).toContain("asked to sign in");
-    expect(helpPage).toContain("Sign in if you want to send private feedback");
+    expect(helpPage).toContain("Send feedback after signing in");
     expect(helpPage).toContain("prevent spam");
   });
 });

--- a/test/help-page-structure.test.ts
+++ b/test/help-page-structure.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("help page structure", () => {
+  it("renders a guide with anchor navigation and nested topics", () => {
+    const helpPage = source("app/help/page.tsx");
+    const helpContent = source("lib/content/public-pages.ts");
+
+    expect(helpPage).toContain('aria-label="On this page"');
+    expect(helpPage).toContain("publicHelpSections.map");
+    expect(helpPage).toContain("section.topics.map");
+    expect(helpPage).toContain("topic.bullets");
+    expect(helpPage).toContain("HelpFeedbackForm");
+    expect(helpContent).toContain("type HelpGuideSection");
+    expect(helpContent).toContain("Troubleshooting And FAQ");
+    expect(helpContent).toContain("Reporting Bad Behavior");
+  });
+});

--- a/test/public-pages.test.ts
+++ b/test/public-pages.test.ts
@@ -10,25 +10,50 @@ function pageText(sections: Array<{ body: string[]; heading: string }>) {
     .join("\n");
 }
 
+function helpText() {
+  return publicHelpSections
+    .flatMap((section) => [
+      section.eyebrow,
+      section.title,
+      section.intro,
+      ...section.topics.flatMap((topic) => [
+        topic.title,
+        ...topic.body,
+        ...(topic.bullets ?? []),
+      ]),
+    ])
+    .join("\n");
+}
+
 describe("public help and privacy content", () => {
   it("covers practical help topics without overpromising moderation", () => {
-    const helpText = pageText(publicHelpSections);
+    const text = helpText();
 
-    expect(helpText).toContain("Singer Profiles");
-    expect(helpText).toContain("Quartet Profiles");
-    expect(helpText).toContain("One account can support My Singer Profile");
-    expect(helpText).toContain("independent visibility controls");
-    expect(helpText).toContain("Search");
-    expect(helpText).toContain("Find is the main discovery page");
-    expect(helpText).toContain("result cards");
-    expect(helpText).toContain("Location And Privacy");
-    expect(helpText).toContain("Location Defaults");
-    expect(helpText).toContain("Contact");
-    expect(helpText).toContain("read and reply in Messages");
-    expect(helpText).toContain("private report action");
-    expect(helpText).toContain("Signed-in users can send private feedback");
-    expect(helpText).toContain("does not replace personal judgment");
-    expect(helpText).not.toMatch(/24\/7 moderation|background checks/i);
+    expect(publicHelpSections.map((section) => section.id)).toEqual([
+      "getting-started",
+      "optional-profiles",
+      "singer-profile",
+      "quartet-profile",
+      "find",
+      "location",
+      "messages",
+      "privacy-safety",
+      "reporting",
+      "faq",
+      "feedback-guide",
+    ]);
+    expect(text).toContain("One Account, Two Optional Profiles");
+    expect(text).toContain("My Singer Profile");
+    expect(text).toContain("My Quartet Profile");
+    expect(text).toContain("Find Quartet Openings And Find Singers");
+    expect(text).toContain("Location, Radius Search, And Approximate Maps");
+    expect(text).toContain("Messages And Contacting Someone");
+    expect(text).toContain("Reporting Bad Behavior");
+    expect(text).toContain("Why can't I find any results?");
+    expect(text).toContain("Miles are the default display unit");
+    expect(text).toContain("read it. The full message stays behind");
+    expect(text).toContain("Report this message");
+    expect(text).not.toMatch(/24\/7 moderation|provides background checks/i);
   });
 
   it("keeps privacy overview plainspoken and aligned with app behavior", () => {

--- a/test/readme-context.test.ts
+++ b/test/readme-context.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("README and barbershop context", () => {
+  it("orients contributors to product model, setup, and docs", () => {
+    const readme = source("README.md");
+
+    expect(readme).toContain("My Singer Profile");
+    expect(readme).toContain("My Quartet Profile");
+    expect(readme).toContain("Discovery requires sign-in");
+    expect(readme).toContain("npm run lint");
+    expect(readme).toContain("npm run typecheck");
+    expect(readme).toContain("npm run test:run");
+    expect(readme).toContain("npm run format:check");
+    expect(readme).toContain("npm run build");
+    expect(readme).toContain("docs/barbershop-context.md");
+    expect(readme).toContain("docs/supabase-contract.md");
+    expect(readme).toContain("docs/deployment.md");
+  });
+
+  it("keeps durable barbershop context linked from AGENTS", () => {
+    const agents = source("AGENTS.md");
+    const context = source("docs/barbershop-context.md");
+
+    expect(agents).toContain("docs/barbershop-context.md");
+    expect(context).toContain("chapters, rehearsals");
+    expect(context).toContain("conventions, afterglows");
+    expect(context).toContain("TTBB barbershop parts are Tenor");
+    expect(context).toContain("Baritone, and Bass");
+    expect(context).toContain("Lead is the melody");
+    expect(context).toContain("preserves voicing context");
+    expect(context).toContain("Discovery requires sign-in");
+    expect(context).toContain("not a dating app");
+    expect(context).toContain("reports are reviewed as able");
+    expect(context).toContain("not in real time");
+  });
+});


### PR DESCRIPTION
Closes #87

## Summary
- rework Help into a guide-style page with intro, On this page navigation, anchored sections, nested topics, FAQ, and feedback preserved at the bottom
- expand Help coverage for optional profiles, Find/radius/map behavior, Messages, reporting, privacy/safety, and feedback
- rewrite README with product model, setup, validation scripts, deployment/docs pointers
- add docs/barbershop-context.md and link it from AGENTS.md for durable domain/product grounding

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build