### PR TITLE
Audit product analytics privacy

### DIFF
--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -134,6 +134,16 @@
           "series": [{ "event": "discovery_search_submitted" }]
         },
         {
+          "key": "find-searches-by-kind",
+          "name": "Find searches by kind",
+          "description": "Unified Find page searches by singer, quartet, or combined result type.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "kind",
+          "series": [{ "event": "find_searched" }]
+        },
+        {
           "key": "map-views-by-kind",
           "name": "Map views by result type",
           "description": "Whether the privacy-safe map is used for singers, quartet openings, or both.",
@@ -149,10 +159,7 @@
           "description": "Search or map discovery leading to app-mediated contact request submission.",
           "type": "funnel",
           "dateFrom": "-30d",
-          "series": [
-            { "event": "discovery_search_submitted" },
-            { "event": "contact_request_submitted" }
-          ]
+          "series": [{ "event": "find_searched" }, { "event": "message_sent" }]
         },
         {
           "key": "contact-requests-by-target",
@@ -173,6 +180,16 @@
           "dateFrom": "-30d",
           "breakdown": "status",
           "series": [{ "event": "contact_request_submitted" }]
+        },
+        {
+          "key": "message-replies-by-status",
+          "name": "Message replies by status",
+          "description": "In-app replies grouped by notification outcome.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "status",
+          "series": [{ "event": "message_replied" }]
         }
       ]
     },

--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -56,6 +56,14 @@ export async function saveQuartetListing(formData: FormData) {
     storageMode: "permanent",
   });
   const geocodedCoordinates = geocodingResult.coordinates;
+  const { data: existingListing } = values.listingId
+    ? await supabase
+        .from("quartet_listings")
+        .select("is_visible")
+        .eq("id", values.listingId)
+        .eq("owner_user_id", user.id)
+        .maybeSingle<{ is_visible: boolean | null }>()
+    : { data: null };
   const listingPayload = {
     availability: values.availability,
     country_code: values.countryCode,
@@ -150,6 +158,22 @@ export async function saveQuartetListing(formData: FormData) {
     },
     { distinctId: pseudonymousAnalyticsUserId(user.id) },
   );
+  if (
+    existingListing &&
+    existingListing.is_visible !== null &&
+    existingListing.is_visible !== values.isVisible
+  ) {
+    await captureProductEvent(
+      "quartet_listing_visibility_changed",
+      {
+        is_visible: values.isVisible,
+        route: "/app/listings",
+        route_area: "signed_in_app",
+        visibility_enabled: values.isVisible,
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
+  }
   const locationWarning = discoverabilityLocationWarning(values);
   redirectWithListingMessage(
     "message",

--- a/app/(protected)/app/messages/[id]/page.tsx
+++ b/app/(protected)/app/messages/[id]/page.tsx
@@ -4,6 +4,10 @@ import {
   reportMessage,
   sendMessageReply,
 } from "@/app/(protected)/app/messages/actions";
+import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
 import { messageReportCategories } from "@/lib/messages/moderation";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -161,6 +165,19 @@ export default async function MessageDetailPage({
   const replyStatus = replyStatusMessage(query.reply);
   const reportStatus = reportStatusMessage(query.report);
   const userIsOriginalSender = request.sender_user_id === user.id;
+
+  await captureProductEvent(
+    "message_viewed",
+    {
+      participant_role: userIsOriginalSender ? "sender" : "recipient",
+      reply_count: (replies ?? []).length,
+      route: "/app/messages/[id]",
+      route_area: "signed_in_app",
+      status: request.status,
+      target_kind: request.singer_profile_id ? "singer" : "quartet",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
 
   return (
     <div className="max-w-3xl">

--- a/app/(protected)/app/messages/actions.ts
+++ b/app/(protected)/app/messages/actions.ts
@@ -3,6 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
+import {
   CONTACT_MESSAGE_MAX_LENGTH,
   getContactRelayConfig,
   sendContactReplyNotification,
@@ -63,6 +67,31 @@ function trimMessage(value: FormDataEntryValue | null) {
   const trimmed = value.trim();
 
   return trimmed ? trimmed : null;
+}
+
+function messageParticipantRole(request: ContactRequestRow, userId: string) {
+  return request.sender_user_id === userId ? "sender" : "recipient";
+}
+
+async function captureMessageReply({
+  request,
+  status,
+  userId,
+}: {
+  request: ContactRequestRow;
+  status: "sent" | "stored";
+  userId: string;
+}) {
+  await captureProductEvent(
+    "message_replied",
+    {
+      participant_role: messageParticipantRole(request, userId),
+      route: "/app/messages/[id]",
+      route_area: "signed_in_app",
+      status,
+    },
+    { distinctId: pseudonymousAnalyticsUserId(userId) },
+  );
 }
 
 async function resolveContactTarget(
@@ -194,6 +223,11 @@ export async function sendMessageReply(formData: FormData) {
 
   if (!admin || !relayConfig || !otherUserId) {
     revalidatePath(`/app/messages/${requestId}`);
+    await captureMessageReply({
+      request: contactRequest,
+      status: "stored",
+      userId: user.id,
+    });
     redirectWithReplyStatus(requestId, "stored");
   }
 
@@ -202,6 +236,11 @@ export async function sendMessageReply(formData: FormData) {
 
   if (recipientError || !recipient.user?.email) {
     revalidatePath(`/app/messages/${requestId}`);
+    await captureMessageReply({
+      request: contactRequest,
+      status: "stored",
+      userId: user.id,
+    });
     redirectWithReplyStatus(requestId, "stored");
   }
 
@@ -218,10 +257,20 @@ export async function sendMessageReply(formData: FormData) {
       .eq("id", reply.id);
   } catch {
     revalidatePath(`/app/messages/${requestId}`);
+    await captureMessageReply({
+      request: contactRequest,
+      status: "stored",
+      userId: user.id,
+    });
     redirectWithReplyStatus(requestId, "stored");
   }
 
   revalidatePath(`/app/messages/${requestId}`);
+  await captureMessageReply({
+    request: contactRequest,
+    status: "sent",
+    userId: user.id,
+  });
   redirectWithReplyStatus(requestId, "sent");
 }
 
@@ -300,6 +349,16 @@ export async function reportMessage(formData: FormData) {
 
   if (!config) {
     revalidatePath(`/app/messages/${requestId}`);
+    await captureProductEvent(
+      "message_report_submitted",
+      {
+        report_category: category,
+        route: "/app/messages/[id]",
+        route_area: "signed_in_app",
+        status: "stored",
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
     redirectWithReportStatus(requestId, "stored");
   }
 
@@ -316,9 +375,29 @@ export async function reportMessage(formData: FormData) {
     });
   } catch {
     revalidatePath(`/app/messages/${requestId}`);
+    await captureProductEvent(
+      "message_report_submitted",
+      {
+        report_category: category,
+        route: "/app/messages/[id]",
+        route_area: "signed_in_app",
+        status: "stored",
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
     redirectWithReportStatus(requestId, "stored");
   }
 
   revalidatePath(`/app/messages/${requestId}`);
+  await captureProductEvent(
+    "message_report_submitted",
+    {
+      report_category: category,
+      route: "/app/messages/[id]",
+      route_area: "signed_in_app",
+      status: "sent",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
   redirectWithReportStatus(requestId, "sent");
 }

--- a/app/(protected)/app/onboarding/actions.ts
+++ b/app/(protected)/app/onboarding/actions.ts
@@ -117,6 +117,15 @@ export async function completeOnboarding(formData: FormData) {
   }
 
   await captureProductEvent(
+    "onboarding_intent_selected",
+    {
+      onboarding_choice: choiceId,
+      route: "/app/onboarding",
+      route_area: "signed_in_app",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
+  await captureProductEvent(
     "onboarding_completed",
     {
       has_country: Boolean(

--- a/app/(protected)/app/onboarding/page.tsx
+++ b/app/(protected)/app/onboarding/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from "next/navigation";
 import { completeOnboarding } from "@/app/(protected)/app/onboarding/actions";
+import {
+  captureProductEvent,
+  pseudonymousAnalyticsUserId,
+} from "@/lib/analytics/product-analytics";
 import { onboardingChoices } from "@/lib/onboarding/app-onboarding";
 import {
   ensureAccountProfileForOnboarding,
@@ -54,6 +58,15 @@ export default async function OnboardingPage({
   if (onboardingIsDone(onboardingStatus)) {
     redirect("/app");
   }
+
+  await captureProductEvent(
+    "onboarding_viewed",
+    {
+      route: "/app/onboarding",
+      route_area: "signed_in_app",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
 
   const { data: accountProfile } = await supabase
     .from("account_profiles")

--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -62,6 +62,11 @@ export async function saveSingerProfile(formData: FormData) {
     storageMode: "permanent",
   });
   const geocodedCoordinates = geocodingResult.coordinates;
+  const { data: existingProfile } = await supabase
+    .from("singer_profiles")
+    .select("is_visible")
+    .eq("user_id", user.id)
+    .maybeSingle<{ is_visible: boolean | null }>();
 
   const { data: profile, error: profileError } = await supabase
     .from("singer_profiles")
@@ -137,6 +142,22 @@ export async function saveSingerProfile(formData: FormData) {
     },
     { distinctId: pseudonymousAnalyticsUserId(user.id) },
   );
+  if (
+    existingProfile &&
+    existingProfile.is_visible !== null &&
+    existingProfile.is_visible !== values.isVisible
+  ) {
+    await captureProductEvent(
+      "singer_profile_visibility_changed",
+      {
+        is_visible: values.isVisible,
+        route: "/app/profile",
+        route_area: "signed_in_app",
+        visibility_enabled: values.isVisible,
+      },
+      { distinctId: pseudonymousAnalyticsUserId(user.id) },
+    );
+  }
   const locationWarning = discoverabilityLocationWarning(values);
   redirectWithProfileMessage(
     "message",

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -47,6 +47,12 @@ export async function signInWithEmail(formData: FormData) {
     redirectWithMessage("/sign-in", "error", error.message);
   }
 
+  await captureProductEvent("sign_in_started", {
+    route: "/sign-in",
+    route_area: "auth",
+    status: "sent",
+  });
+
   redirect(
     `/sign-in?email=${encodeURIComponent(email)}&next=${encodeURIComponent(
       safeNext,
@@ -113,6 +119,15 @@ export async function verifyEmailOtp(formData: FormData) {
     {
       route: "/sign-in",
       route_area: "auth",
+    },
+    { distinctId: pseudonymousAnalyticsUserId(user.id) },
+  );
+  await captureProductEvent(
+    "sign_in_completed",
+    {
+      route: "/sign-in",
+      route_area: "auth",
+      status: "verified",
     },
     { distinctId: pseudonymousAnalyticsUserId(user.id) },
   );

--- a/app/contact/actions.ts
+++ b/app/contact/actions.ts
@@ -68,6 +68,29 @@ async function fetchContactTarget(
   return data ? { id: data.id, kind: "quartet", name: data.name } : null;
 }
 
+async function captureContactRequestSubmitted({
+  returnTo,
+  status,
+  targetKind,
+  userId,
+}: {
+  returnTo: string;
+  status: "sent" | "stored";
+  targetKind: "quartet" | "singer";
+  userId: string;
+}) {
+  const properties = {
+    route: returnTo.split("?")[0] || returnTo,
+    route_area: "discovery",
+    status,
+    target_kind: targetKind,
+  };
+  const options = { distinctId: pseudonymousAnalyticsUserId(userId) };
+
+  await captureProductEvent("contact_request_submitted", properties, options);
+  await captureProductEvent("message_sent", properties, options);
+}
+
 export async function sendContactRequest(formData: FormData) {
   let values;
 
@@ -155,16 +178,12 @@ export async function sendContactRequest(formData: FormData) {
 
   if (!admin || !relayConfig) {
     revalidatePath(values.returnTo);
-    await captureProductEvent(
-      "contact_request_submitted",
-      {
-        route: values.returnTo.split("?")[0] || values.returnTo,
-        route_area: "discovery",
-        status: "stored",
-        target_kind: values.targetKind,
-      },
-      { distinctId: pseudonymousAnalyticsUserId(user.id) },
-    );
+    await captureContactRequestSubmitted({
+      returnTo: values.returnTo,
+      status: "stored",
+      targetKind: values.targetKind,
+      userId: user.id,
+    });
     redirectWithContactStatus(values.returnTo, "stored");
   }
 
@@ -173,16 +192,12 @@ export async function sendContactRequest(formData: FormData) {
 
   if (recipientError || !recipient.user?.email) {
     revalidatePath(values.returnTo);
-    await captureProductEvent(
-      "contact_request_submitted",
-      {
-        route: values.returnTo.split("?")[0] || values.returnTo,
-        route_area: "discovery",
-        status: "stored",
-        target_kind: values.targetKind,
-      },
-      { distinctId: pseudonymousAnalyticsUserId(user.id) },
-    );
+    await captureContactRequestSubmitted({
+      returnTo: values.returnTo,
+      status: "stored",
+      targetKind: values.targetKind,
+      userId: user.id,
+    });
     redirectWithContactStatus(values.returnTo, "stored");
   }
 
@@ -200,29 +215,21 @@ export async function sendContactRequest(formData: FormData) {
       .eq("id", contactRequest.id);
   } catch {
     revalidatePath(values.returnTo);
-    await captureProductEvent(
-      "contact_request_submitted",
-      {
-        route: values.returnTo.split("?")[0] || values.returnTo,
-        route_area: "discovery",
-        status: "stored",
-        target_kind: values.targetKind,
-      },
-      { distinctId: pseudonymousAnalyticsUserId(user.id) },
-    );
+    await captureContactRequestSubmitted({
+      returnTo: values.returnTo,
+      status: "stored",
+      targetKind: values.targetKind,
+      userId: user.id,
+    });
     redirectWithContactStatus(values.returnTo, "stored");
   }
 
   revalidatePath(values.returnTo);
-  await captureProductEvent(
-    "contact_request_submitted",
-    {
-      route: values.returnTo.split("?")[0] || values.returnTo,
-      route_area: "discovery",
-      status: "sent",
-      target_kind: values.targetKind,
-    },
-    { distinctId: pseudonymousAnalyticsUserId(user.id) },
-  );
+  await captureContactRequestSubmitted({
+    returnTo: values.returnTo,
+    status: "sent",
+    targetKind: values.targetKind,
+    userId: user.id,
+  });
   redirectWithContactStatus(values.returnTo, "sent");
 }

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -205,8 +205,9 @@ function filterAnalyticsProperties(
 ) {
   const flags = {
     has_goal_filter: Boolean(filters.goal),
+    has_location_filter: Boolean(filters.searchFrom),
     has_part_filter: filters.parts.length > 0,
-    has_radius: filters.radius != null,
+    has_radius_filter: filters.radius != null,
     has_search_origin: Boolean(filters.searchFrom),
   };
   const filterCount = Object.values(flags).filter(Boolean).length;
@@ -461,14 +462,19 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     radiusSearchOrigin ? "; sorted by approximate distance" : ""
   }`;
 
-  await captureProductEvent("map_viewed", {
+  const discoveryAnalyticsProperties = {
     ...flags,
+    distance_unit: filters.distanceUnit,
     filter_count: filterCount,
     kind,
     route: "/find",
     result_count: results.length,
     route_area: "discovery",
-  });
+    search_origin: filters.searchOrigin,
+  };
+
+  await captureProductEvent("find_searched", discoveryAnalyticsProperties);
+  await captureProductEvent("map_viewed", discoveryAnalyticsProperties);
 
   return (
     <>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -489,7 +489,9 @@ a non-default PostHog region.
 The app sends only allowlisted privacy-safe product events through
 `/api/analytics` or trusted server actions. Do not configure session replay,
 autocapture of form fields, advertising pixels, or direct user identification
-without a separate privacy review and documentation update.
+without a separate privacy review and documentation update. Event properties
+must stay limited to coarse categories, counts, route areas, normalized route
+paths, booleans, and generic statuses.
 
 ## Production readiness checklist
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -136,7 +136,8 @@ blank.
 When enabled, analytics uses an internal app endpoint that accepts only
 allowlisted product events and safe properties. The app may track route views and
 high-level funnel events such as onboarding completion, profile/listing saves,
-discovery searches, map views, contact request submission, and feedback
+profile/listing visibility changes, discovery searches, map views, contact
+request/message submission, message views/replies/reports, and feedback
 submission.
 
 Do not send email addresses, display names, profile/listing text, contact or

--- a/docs/posthog-analytics.md
+++ b/docs/posthog-analytics.md
@@ -38,19 +38,33 @@ Current events:
 
 - `analytics_client_ready`
 - `app_route_viewed`
+- `sign_in_started`
+- `sign_in_completed`
 - `user_logged_in`
+- `onboarding_viewed`
+- `onboarding_intent_selected`
 - `onboarding_completed`
 - `onboarding_skipped`
 - `singer_profile_saved`
+- `singer_profile_visibility_changed`
 - `quartet_listing_saved`
+- `quartet_listing_visibility_changed`
 - `discovery_search_submitted`
+- `find_searched`
 - `map_viewed`
 - `contact_request_submitted`
+- `message_sent`
+- `message_viewed`
+- `message_replied`
+- `message_report_submitted`
 - `feedback_submitted`
 
 Allowed properties are intentionally narrow. They include route area, public
-route path, filter-presence booleans, result counts, target kind, visibility
-enabled flags, feedback type, generic status, and onboarding choice.
+route path, filter-presence booleans, distance unit, result counts, search
+origin type, target kind, participant role, reply count, visibility enabled
+flags, feedback type, report category, generic status, and onboarding choice.
+Route values are stripped of query strings and hash fragments, and UUID-looking
+path segments are normalized to `[id]`.
 
 Never send:
 
@@ -66,6 +80,17 @@ Never send:
 Signed-in server events may use a pseudonymous hash of the authenticated user ID
 so funnel steps can be understood without identifying users by direct personal
 information.
+
+When adding or changing analytics:
+
+1. Add the event name and each safe property key to
+   `lib/analytics/product-analytics.ts`.
+2. Prefer booleans, counts, coarse categories, and enum-like values.
+3. Do not add raw IDs, user-entered text, contact details, precise location
+   fields, or query strings.
+4. Add or update tests in `test/product-analytics.test.ts`.
+5. Update this document and `docs/privacy-model.md` if the event changes the
+   privacy contract.
 
 ## Dashboards
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -201,8 +201,11 @@ internal app endpoint, and server actions send high-level funnel events after
 successful actions.
 
 Allowed analytics properties are intentionally narrow, such as route area,
-public route path, result counts, filter-presence booleans, target kind,
-visibility enabled flags, generic status, feedback type, and onboarding choice.
+public route path, result counts, filter-presence booleans, distance unit,
+search origin type, target kind, participant role, reply count, visibility
+enabled flags, generic status, feedback type, report category, and onboarding
+choice. Route values must not include query strings or hash fragments, and
+ID-like route segments are normalized before capture.
 
 Analytics must not send:
 
@@ -218,6 +221,10 @@ Analytics must not send:
 Signed-in server events may use a pseudonymous hash of the authenticated user ID
 so funnel steps can be understood without identifying users by direct personal
 information.
+
+New analytics events must be added through the event/property allowlist in
+`lib/analytics/product-analytics.ts`, covered by tests, and documented before
+they are used by app code.
 
 ## Onboarding model
 

--- a/lib/analytics/product-analytics.ts
+++ b/lib/analytics/product-analytics.ts
@@ -3,14 +3,25 @@ import { createHash, randomUUID } from "node:crypto";
 export const PRODUCT_ANALYTICS_EVENTS = [
   "analytics_client_ready",
   "app_route_viewed",
+  "sign_in_started",
+  "sign_in_completed",
   "user_logged_in",
+  "onboarding_viewed",
+  "onboarding_intent_selected",
   "onboarding_completed",
   "onboarding_skipped",
   "singer_profile_saved",
+  "singer_profile_visibility_changed",
   "quartet_listing_saved",
+  "quartet_listing_visibility_changed",
   "discovery_search_submitted",
+  "find_searched",
   "map_viewed",
   "contact_request_submitted",
+  "message_sent",
+  "message_viewed",
+  "message_replied",
+  "message_report_submitted",
   "feedback_submitted",
 ] as const;
 
@@ -28,6 +39,7 @@ type AnalyticsConfig = {
 
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 const SAFE_PROPERTY_KEYS = new Set([
+  "distance_unit",
   "feedback_type",
   "filter_count",
   "has_availability_filter",
@@ -35,22 +47,60 @@ const SAFE_PROPERTY_KEYS = new Set([
   "has_experience_filter",
   "has_goal_filter",
   "has_country",
+  "has_location_filter",
   "has_locality_filter",
   "has_locality",
   "has_part_filter",
   "has_public_location_label",
+  "has_radius_filter",
   "has_region_filter",
+  "has_search_origin",
   "has_travel_filter",
   "is_visible",
   "kind",
   "onboarding_choice",
+  "participant_role",
+  "reply_count",
+  "report_category",
   "route",
   "result_count",
   "route_area",
+  "search_origin",
   "status",
   "target_kind",
   "visibility_enabled",
 ]);
+const SENSITIVE_PROPERTY_KEY_PATTERN =
+  /(address|bio|body|coordinate|description|email|id|latitude|longitude|message|name|note|phone|postal|recipient|sender|token|user|zip)/i;
+const UUID_SEGMENT_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function sanitizeRoute(value: string) {
+  const [withoutHash] = value.split("#");
+  const [pathname] = withoutHash.split("?");
+  const safePathname = pathname.startsWith("/") ? pathname : "/";
+  const segments = safePathname.split("/").map((segment, index) => {
+    if (index === 0) {
+      return segment;
+    }
+
+    if (UUID_SEGMENT_PATTERN.test(segment)) {
+      return "[id]";
+    }
+
+    return segment;
+  });
+
+  return segments.join("/").slice(0, 160);
+}
+
+function sanitizeStringProperty(key: string, value: string) {
+  if (key === "route") {
+    return sanitizeRoute(value);
+  }
+
+  return value.slice(0, 160);
+}
 
 export function productAnalyticsIsConfigured() {
   return Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
@@ -83,7 +133,11 @@ export function sanitizeAnalyticsProperties(
   const sanitized: Record<string, boolean | number | string | null> = {};
 
   for (const [key, value] of Object.entries(properties)) {
-    if (!SAFE_PROPERTY_KEYS.has(key) || value === undefined) {
+    if (
+      !SAFE_PROPERTY_KEYS.has(key) ||
+      SENSITIVE_PROPERTY_KEY_PATTERN.test(key) ||
+      value === undefined
+    ) {
       continue;
     }
 
@@ -93,7 +147,8 @@ export function sanitizeAnalyticsProperties(
       typeof value === "string" ||
       value === null
     ) {
-      sanitized[key] = typeof value === "string" ? value.slice(0, 160) : value;
+      sanitized[key] =
+        typeof value === "string" ? sanitizeStringProperty(key, value) : value;
     }
   }
 

--- a/test/product-analytics.test.ts
+++ b/test/product-analytics.test.ts
@@ -11,6 +11,9 @@ describe("product analytics helpers", () => {
   it("only accepts allowlisted analytics events", () => {
     expect(isProductAnalyticsEvent("analytics_client_ready")).toBe(true);
     expect(isProductAnalyticsEvent("app_route_viewed")).toBe(true);
+    expect(isProductAnalyticsEvent("find_searched")).toBe(true);
+    expect(isProductAnalyticsEvent("message_replied")).toBe(true);
+    expect(isProductAnalyticsEvent("sign_in_started")).toBe(true);
     expect(isProductAnalyticsEvent("user_logged_in")).toBe(true);
     expect(isProductAnalyticsEvent("contact_request_submitted")).toBe(true);
     expect(isProductAnalyticsEvent("profile_bio_changed")).toBe(false);
@@ -22,19 +25,32 @@ describe("product analytics helpers", () => {
         email: "singer@example.com",
         feedback_type: "bug",
         has_country: true,
+        has_radius_filter: true,
         has_locality: false,
         latitude_private: 40.5,
         message_body: "private message",
-        route: "/help",
+        recipient_user_id: "123e4567-e89b-12d3-a456-426614174000",
+        route: "/help?email=singer@example.com#private",
         postal_code_private: "M1 TEST",
         result_count: 2,
       }),
     ).toEqual({
       feedback_type: "bug",
       has_country: true,
+      has_radius_filter: true,
       has_locality: false,
       route: "/help",
       result_count: 2,
+    });
+  });
+
+  it("normalizes id-like route segments before capture", () => {
+    expect(
+      sanitizeAnalyticsProperties({
+        route: "/app/messages/123e4567-e89b-12d3-a456-426614174000",
+      }),
+    ).toEqual({
+      route: "/app/messages/[id]",
     });
   });
 


### PR DESCRIPTION
Closes #93.\n\n## Summary\n- expands privacy-safe analytics events for sign-in, onboarding, visibility changes, Find search, contact/message flow, reports, and feedback-adjacent dashboards\n- hardens analytics property sanitization by allowlisting coarse keys, stripping route query/hash values, and normalizing UUID path segments\n- updates PostHog dashboard definitions, analytics/privacy docs, and sanitizer tests\n\n## Verification\n- npm run lint\n- npm run typecheck\n- npm run test:run\n- npm run format:check\n- npm run posthog:dashboards:check\n- npm run build