### PR TITLE
Improve profile visibility messaging

### DIFF
--- a/app/(protected)/app/listings/page.tsx
+++ b/app/(protected)/app/listings/page.tsx
@@ -52,6 +52,16 @@ function fieldValue(value: string | number | null | undefined) {
   return value == null ? "" : String(value);
 }
 
+function quartetProfileNeedsLocation(listing: QuartetListingRow | null) {
+  return Boolean(
+    listing?.is_visible &&
+    (!listing.country_name ||
+      !listing.region ||
+      !listing.locality ||
+      !listing.postal_code_private),
+  );
+}
+
 export default async function ManageListingsPage({
   searchParams,
 }: ManageListingsPageProps) {
@@ -106,8 +116,8 @@ export default async function ManageListingsPage({
         </h1>
         <p className="mt-4 text-base leading-7 text-[#394548]">
           This profile is for a quartet or prospective quartet you represent.
-          Make it discoverable when you are looking for one or more singers;
-          hide it any time without affecting your singer profile.
+          Show it in Find when you are looking for one or more singers; turn it
+          off any time without affecting your Singer Profile.
         </p>
       </div>
 
@@ -138,7 +148,7 @@ export default async function ManageListingsPage({
             My Quartet Profile is for a quartet or prospective quartet looking
             for singers. Create a profile with covered parts, missing parts, and
             an approximate location so singers can judge whether it might fit.
-            You can keep it hidden until the opening is active.
+            You can keep it out of Find until the opening is active.
           </p>
           <Link
             className="mt-4 inline-flex font-semibold text-[#2f6f73]"
@@ -147,22 +157,53 @@ export default async function ManageListingsPage({
             Browse singers in Find first
           </Link>
         </section>
-      ) : listing.is_visible ? null : (
-        <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
-          <h2 className="text-xl font-bold text-[#172023]">
-            My Quartet Profile is hidden
-          </h2>
-          <p className="mt-3 text-sm leading-6 text-[#394548]">
-            Hidden listings do not appear in Find or detailed quartet search, so
-            singers cannot discover them yet. Turn on visibility below when the
-            opening is active. This does not change your singer profile
-            visibility.
-          </p>
-        </section>
-      )}
+      ) : null}
 
       <form action={saveQuartetListing} className="mt-8 max-w-3xl space-y-8">
         <input name="listingId" type="hidden" value={fieldValue(listing?.id)} />
+
+        <section className="space-y-4">
+          <div className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+            <h2 className="text-xl font-bold text-[#172023]">
+              {listing?.is_visible
+                ? "Your Quartet Profile is shown in Find"
+                : "Your Quartet Profile is not shown in Find"}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-[#394548]">
+              {listing?.is_visible
+                ? "Singers can discover your Quartet Profile in Find using approximate location, needed parts, goals, and other details you choose to share. This does not change your Singer Profile visibility."
+                : "Singers cannot discover your Quartet Profile right now. Turn on visibility when this opening is active and you want it to appear in Find. This does not change your Singer Profile visibility."}
+            </p>
+          </div>
+
+          {quartetProfileNeedsLocation(listing) ? (
+            <p className="rounded-lg border border-[#d7cec0] bg-white p-4 text-sm leading-6 text-[#394548]">
+              Your Quartet Profile can be saved, but it may be harder to find
+              without country, state/province/region, city, and ZIP/postal code.
+              These are used only for approximate map placement and search;
+              ZIP/postal code is not shown publicly.
+            </p>
+          ) : null}
+
+          <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
+            <input
+              className="mt-1"
+              defaultChecked={listing?.is_visible ?? false}
+              name="isVisible"
+              type="checkbox"
+            />
+            <span>
+              <span className="block font-semibold text-[#172023]">
+                Show this Quartet Profile in Find
+              </span>
+              <span className="mt-1 block text-sm leading-6 text-[#596466]">
+                Find can include the profile name, covered and needed parts,
+                goals, availability, and approximate location. Turn this off
+                when the opening is filled, paused, or not ready.
+              </span>
+            </span>
+          </label>
+        </section>
 
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Basics</h2>
@@ -325,32 +366,6 @@ export default async function ManageListingsPage({
               maxLength={500}
               name="availability"
             />
-          </label>
-        </section>
-
-        <section className="space-y-4">
-          <h2 className="text-xl font-bold text-[#172023]">Visibility</h2>
-          <p className="text-sm leading-6 text-[#394548]">
-            Discoverable means this profile can appear in Find results and
-            approximate map discovery inside Find. Hidden means it stays out of
-            discovery.
-          </p>
-          <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
-            <input
-              className="mt-1"
-              defaultChecked={listing?.is_visible ?? false}
-              name="isVisible"
-              type="checkbox"
-            />
-            <span>
-              <span className="block font-semibold text-[#172023]">
-                Show My Quartet Profile in discovery
-              </span>
-              <span className="mt-1 block text-sm leading-6 text-[#596466]">
-                Discovery views include the name, parts covered and needed,
-                goals, and approximate location only.
-              </span>
-            </span>
           </label>
         </section>
 

--- a/app/(protected)/app/profile/page.tsx
+++ b/app/(protected)/app/profile/page.tsx
@@ -66,6 +66,16 @@ function FieldNote({ children, id }: { children: ReactNode; id?: string }) {
   );
 }
 
+function singerProfileNeedsLocation(profile: SingerProfileRow | null) {
+  return Boolean(
+    profile?.is_visible &&
+    (!profile.country_name ||
+      !profile.region ||
+      !profile.locality ||
+      !profile.postal_code_private),
+  );
+}
+
 export default async function ManageProfilePage({
   searchParams,
 }: ManageProfilePageProps) {
@@ -109,9 +119,9 @@ export default async function ManageProfilePage({
           Manage your singer profile
         </h1>
         <p className="mt-4 text-base leading-7 text-[#394548]">
-          This profile is for you as an individual singer. Make it discoverable
-          if you want quartets or other singers to find you; hide it any time
-          without affecting your quartet profile.
+          This profile is for you as an individual singer. Show it in Find when
+          you want quartets or other singers to discover you; turn it off any
+          time without affecting your Quartet Profile.
         </p>
         <p className="mt-3 text-sm leading-6 text-[#596466]">
           Only display name is required. Everything else is optional, but parts,
@@ -146,8 +156,8 @@ export default async function ManageProfilePage({
           <p className="mt-3 text-sm leading-6 text-[#394548]">
             A singer profile helps quartet openings and other singers find you.
             Start with your parts, goals, and approximate location; you can keep
-            it hidden until you are ready. Filling it out does not require
-            making it discoverable.
+            it out of Find until you are ready. Filling it out does not require
+            showing it in discovery.
           </p>
           <Link
             className="mt-4 inline-flex font-semibold text-[#2f6f73]"
@@ -156,21 +166,52 @@ export default async function ManageProfilePage({
             Browse quartet openings in Find first
           </Link>
         </section>
-      ) : profile.is_visible ? null : (
-        <section className="mt-8 max-w-3xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
-          <h2 className="text-xl font-bold text-[#172023]">
-            Your profile is hidden
-          </h2>
-          <p className="mt-3 text-sm leading-6 text-[#394548]">
-            Hidden profiles do not appear in Find or detailed singer search.
-            Turn on the visibility checkbox below when you want discovery to
-            show your public singer details. This does not change your quartet
-            profile visibility.
-          </p>
-        </section>
-      )}
+      ) : null}
 
       <form action={saveSingerProfile} className="mt-8 max-w-3xl space-y-8">
+        <section className="space-y-4">
+          <div className="rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5">
+            <h2 className="text-xl font-bold text-[#172023]">
+              {profile?.is_visible
+                ? "Your Singer Profile is shown in Find"
+                : "Your Singer Profile is not shown in Find"}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-[#394548]">
+              {profile?.is_visible
+                ? "Other users can discover your Singer Profile in Find using approximate location, voice parts, goals, and other profile details you choose to share. This does not change your Quartet Profile visibility."
+                : "Other users cannot discover your Singer Profile right now. Turn on visibility when you want singers or quartets to find you. This does not change your Quartet Profile visibility."}
+            </p>
+          </div>
+
+          {singerProfileNeedsLocation(profile) ? (
+            <p className="rounded-lg border border-[#d7cec0] bg-white p-4 text-sm leading-6 text-[#394548]">
+              Your Singer Profile can be saved, but it may be harder to find
+              without country, state/province/region, city, and ZIP/postal code.
+              These are used only for approximate map placement and search; your
+              ZIP/postal code is not shown publicly.
+            </p>
+          ) : null}
+
+          <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
+            <input
+              className="mt-1"
+              defaultChecked={profile?.is_visible ?? false}
+              name="isVisible"
+              type="checkbox"
+            />
+            <span>
+              <span className="block font-semibold text-[#172023]">
+                Show this profile in Find
+              </span>
+              <span className="mt-1 block text-sm leading-6 text-[#596466]">
+                Find can include your display name, parts, goals, availability,
+                and approximate location. Turn this off when you do not want
+                other users to discover your Singer Profile.
+              </span>
+            </span>
+          </label>
+        </section>
+
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-[#172023]">Basics</h2>
           <label className="block">
@@ -407,33 +448,6 @@ export default async function ManageProfilePage({
               Mention useful constraints: weeknights or weekends, rehearsal
               frequency, contest interest, pickup singing, or travel limits.
             </FieldNote>
-          </label>
-        </section>
-
-        <section className="space-y-4">
-          <h2 className="text-xl font-bold text-[#172023]">Visibility</h2>
-          <p className="text-sm leading-6 text-[#394548]">
-            Discoverable means this profile can appear in Find results and
-            approximate map discovery inside Find. Hidden means it stays out of
-            discovery.
-          </p>
-          <label className="flex items-start gap-3 rounded-md border border-[#d7cec0] bg-[#fffaf2] p-4">
-            <input
-              className="mt-1"
-              defaultChecked={profile?.is_visible ?? false}
-              name="isVisible"
-              type="checkbox"
-            />
-            <span>
-              <span className="block font-semibold text-[#172023]">
-                Show my singer profile in discovery
-              </span>
-              <span className="mt-1 block text-sm leading-6 text-[#596466]">
-                Discovery views include your display name, parts, goals, and
-                approximate location only. Turn this off if the profile is not
-                ready for people to find.
-              </span>
-            </span>
           </label>
         </section>
 

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -58,7 +58,7 @@ export const publicHelpSections: HelpGuideSection[] = [
       {
         body: [
           "You can fill out My Singer Profile, My Quartet Profile, both profiles, or neither while you get oriented. You do not need to publish both profiles just because both options exist.",
-          "The two profiles are independent. Hiding My Singer Profile does not hide My Quartet Profile, and hiding My Quartet Profile does not hide My Singer Profile.",
+          "The two profiles are independent. Taking My Singer Profile out of Find does not take My Quartet Profile out of Find, and taking My Quartet Profile out of Find does not take My Singer Profile out of Find.",
         ],
         title: "Use either profile, both, or neither",
       },
@@ -68,9 +68,9 @@ export const publicHelpSections: HelpGuideSection[] = [
           "Both profiles can be discoverable at the same time if that matches your situation, such as when you personally sing and also represent a quartet looking for another part.",
         ],
         bullets: [
-          "Discoverable profiles can appear in Find.",
-          "Hidden profiles stay out of discovery.",
-          "You can hide a profile when you are no longer looking.",
+          "Profiles shown in Find can appear in discovery.",
+          "Profiles not shown in Find stay out of discovery.",
+          "You can turn off Find visibility when you are no longer looking.",
         ],
         title: "Independent visibility",
       },
@@ -99,10 +99,10 @@ export const publicHelpSections: HelpGuideSection[] = [
       },
       {
         body: [
-          "Keep the profile hidden while it is incomplete, while you are not open to opportunities, or while you are only using the app as a quartet representative.",
+          "Keep the profile out of Find while it is incomplete, while you are not open to opportunities, or while you are only using the app as a quartet representative.",
           "If important discovery or location fields are incomplete, your profile can be harder to interpret and may not place well in map or radius search context.",
         ],
-        title: "When to hide it",
+        title: "When not to show it in Find",
       },
     ],
   },
@@ -123,7 +123,7 @@ export const publicHelpSections: HelpGuideSection[] = [
       {
         body: [
           "Covered parts and needed parts are separate. That lets a Lead, Bass, Baritone, or Tenor see whether the opening actually fits before contacting you.",
-          "Like My Singer Profile, My Quartet Profile has its own visibility setting. Hide it when the opening is filled, paused, or not ready for people to find.",
+          "Like My Singer Profile, My Quartet Profile has its own visibility setting. Keep it out of Find when the opening is filled, paused, or not ready for people to discover.",
         ],
         title: "Covered and needed parts",
       },
@@ -221,10 +221,10 @@ export const publicHelpSections: HelpGuideSection[] = [
     topics: [
       {
         body: [
-          "Visible profiles can appear in Find. Hidden profiles stay out of discovery. My Singer Profile and My Quartet Profile have separate visibility controls.",
+          "Profiles shown in Find can appear in discovery. Profiles not shown in Find stay out of discovery. My Singer Profile and My Quartet Profile have separate visibility controls.",
           "Do not put private contact details or exact home-location information in public bio, description, availability, or goal fields.",
         ],
-        title: "Visible versus hidden",
+        title: "Shown in Find",
       },
       {
         body: [
@@ -279,7 +279,7 @@ export const publicHelpSections: HelpGuideSection[] = [
       },
       {
         body: [
-          "Your profile may be hidden, incomplete, or missing useful location details. Filling out a profile does not publish it; check the visibility setting before expecting it to appear in Find.",
+          "Your profile may not be shown in Find, may be incomplete, or may be missing useful location details. Filling out a profile does not publish it; check the visibility setting before expecting it to appear in Find.",
         ],
         title: "Why does my profile not show up?",
       },
@@ -345,7 +345,7 @@ export const publicPrivacySections = [
   },
   {
     body: [
-      "Singer profiles and quartet profiles have independent visibility controls. Discoverable and active profiles can appear in search and Find. Hidden profiles should stay out of those discovery views.",
+      "Singer profiles and quartet profiles have independent visibility controls. Active profiles shown in Find can appear in search and discovery. Profiles not shown in Find should stay out of those discovery views.",
       "Both optional profiles can be discoverable at once when that matches your situation, but neither one has to be discoverable just because it has been filled out.",
       "The database uses privacy-safe discovery views for public search rather than exposing private base tables directly.",
     ],

--- a/test/empty-states.test.ts
+++ b/test/empty-states.test.ts
@@ -15,11 +15,11 @@ describe("empty and first-time states", () => {
     const listingPage = source("app/(protected)/app/listings/page.tsx");
 
     expect(profilePage).toContain("Create My Singer Profile");
-    expect(profilePage).toContain("Your profile is hidden");
-    expect(profilePage).toContain("Find or detailed singer search");
+    expect(profilePage).toContain("Your Singer Profile is not shown in Find");
+    expect(profilePage).toContain("Show this profile in Find");
     expect(listingPage).toContain("Create My Quartet Profile");
-    expect(listingPage).toContain("My Quartet Profile is hidden");
-    expect(listingPage).toContain("Find or detailed quartet search");
+    expect(listingPage).toContain("Your Quartet Profile is not shown in Find");
+    expect(listingPage).toContain("Show this Quartet Profile in Find");
   });
 
   it("turns public discovery no-results states into next actions", () => {

--- a/test/profile-guidance-copy.test.ts
+++ b/test/profile-guidance-copy.test.ts
@@ -22,8 +22,8 @@ describe("profile form guidance copy", () => {
     expect(profilePage).toContain("weeknights or weekends");
     expect(profilePage).toContain("how far you would travel");
     expect(profilePage).toContain("Travel willingness in miles");
-    expect(profilePage).toContain("profile is not");
-    expect(profilePage).toContain("ready for people to find");
+    expect(profilePage).toContain("Your Singer Profile is not shown in Find");
+    expect(profilePage).toContain("Show this profile in Find");
   });
 
   it("uses simple location fields without exposing country code input", () => {


### PR DESCRIPTION
Closes #114.\n\n## Summary\n- moves Singer Profile and Quartet Profile visibility controls near the top of each form\n- replaces hidden/detailed-search copy with shown/not shown in Find language\n- adds near-visibility location completeness warnings when a visible profile is missing location context\n- updates Help/Privacy visibility wording and copy tests\n\n## Verification\n- npm run lint\n- npm run typecheck\n- npm run test:run\n- npm run format:check\n- npm run build