### PR TITLE
Fix Find profile location warning

### DIFF
--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -7,8 +7,8 @@ import {
   approximateLocationLabel,
   formatApproximateDistance,
   milesToKilometers,
-  travelRadiusLabel,
   type Coordinates,
+  travelRadiusLabel,
 } from "@/lib/location/approximate-location";
 import {
   geocodeApproximateLocation,
@@ -24,6 +24,11 @@ import {
   voicingPartValue,
 } from "@/lib/parts/voicings";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
+import {
+  profileOriginState,
+  profileOriginUnavailableMessage,
+  type ProfileOriginRow,
+} from "@/lib/search/profile-origin";
 
 type SingerFindRow = {
   availability: string | null;
@@ -61,15 +66,6 @@ type QuartetFindRow = {
 
 type FindPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
-};
-
-type ProfileOriginRow = {
-  country_name: string | null;
-  latitude_private: number | string | null;
-  locality: string | null;
-  location_label_public: string | null;
-  longitude_private: number | string | null;
-  region: string | null;
 };
 
 type FindResult = DiscoveryMapItem & {
@@ -238,43 +234,6 @@ function geocodingStatusMessage(status: ApproximateGeocodingStatus) {
   return "The search origin could not be resolved right now. Try again in a moment or clear the location search.";
 }
 
-function coordinatesFromPrivateRow(
-  row: ProfileOriginRow | null,
-): Coordinates | null {
-  if (!row?.latitude_private || !row.longitude_private) {
-    return null;
-  }
-
-  const latitude = Number(row.latitude_private);
-  const longitude = Number(row.longitude_private);
-
-  if (
-    !Number.isFinite(latitude) ||
-    !Number.isFinite(longitude) ||
-    latitude < -90 ||
-    latitude > 90 ||
-    longitude < -180 ||
-    longitude > 180
-  ) {
-    return null;
-  }
-
-  return { latitude, longitude };
-}
-
-function labelForProfileOrigin(row: ProfileOriginRow | null) {
-  if (!row) {
-    return "your singer profile";
-  }
-
-  return approximateLocationLabel({
-    countryName: row.country_name,
-    locality: row.locality,
-    locationLabelPublic: row.location_label_public,
-    region: row.region,
-  });
-}
-
 export default async function FindPage({ searchParams }: FindPageProps) {
   const params = await searchParams;
   const filters = parseDiscoveryFilters(params);
@@ -289,18 +248,19 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   let geocodingResult: Awaited<
     ReturnType<typeof geocodeApproximateLocation>
   > | null = null;
+  const { data: profileOriginData } = await supabase
+    .from("singer_profiles")
+    .select(
+      "latitude_private, longitude_private, country_name, region, locality, postal_code_private, location_label_public",
+    )
+    .maybeSingle<ProfileOriginRow>();
+
+  profileOrigin = profileOriginData ?? null;
+  const profileSearchOrigin = profileOriginState(profileOrigin);
 
   if (filters.searchOrigin === "profile") {
-    const { data } = await supabase
-      .from("singer_profiles")
-      .select(
-        "latitude_private, longitude_private, country_name, region, locality, location_label_public",
-      )
-      .maybeSingle();
-
-    profileOrigin = (data ?? null) as ProfileOriginRow | null;
-    radiusSearchOrigin = coordinatesFromPrivateRow(profileOrigin);
-    radiusSearchOriginLabel = labelForProfileOrigin(profileOrigin);
+    radiusSearchOrigin = profileSearchOrigin.coordinates;
+    radiusSearchOriginLabel = profileSearchOrigin.label;
   } else if (filters.searchFrom && radiusKm) {
     geocodingResult = await geocodeApproximateLocation(
       {
@@ -315,9 +275,11 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   let errorMessage: string | null = null;
   let searchNotice: string | null = null;
 
-  if (filters.searchOrigin === "profile" && !radiusSearchOrigin) {
-    searchNotice =
-      "Your singer profile does not have a saved approximate location yet. Save My Singer Profile with country, region, city, and ZIP/postal code, or switch to a typed search origin.";
+  if (
+    filters.searchOrigin === "profile" &&
+    profileSearchOrigin.status !== "usable"
+  ) {
+    searchNotice = profileOriginUnavailableMessage(profileSearchOrigin.status);
   } else if (filters.searchOrigin === "profile" && filters.radius == null) {
     searchNotice =
       "Add a radius to search by distance from your singer profile location. Without a radius, results show all visible areas that match the other filters.";
@@ -522,8 +484,20 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                 name="searchOrigin"
               >
                 <option value="typed">Typed place</option>
-                <option value="profile">My Singer Profile</option>
+                <option
+                  disabled={profileSearchOrigin.status !== "usable"}
+                  value="profile"
+                >
+                  {profileSearchOrigin.status === "usable"
+                    ? "My Singer Profile"
+                    : "My Singer Profile (add location first)"}
+                </option>
               </select>
+              {profileSearchOrigin.status !== "usable" ? (
+                <span className="mt-2 block text-xs leading-5 text-[#596466]">
+                  {profileOriginUnavailableMessage(profileSearchOrigin.status)}
+                </span>
+              ) : null}
             </label>
 
             <label className="block">

--- a/docs/location-geocoding.md
+++ b/docs/location-geocoding.md
@@ -69,6 +69,18 @@ coordinates. They remain visible in non-radius discovery if the owner chose to
 publish them, but they cannot match radius searches until saved again after
 geocoding is configured.
 
+When `/find` uses My Singer Profile as the search origin, the app distinguishes
+three unavailable states:
+
+- no Singer Profile exists yet
+- the profile is missing one or more location text fields needed for profile
+  origin search
+- the profile has location text but no saved approximate coordinates yet
+
+Only the last state asks the user to re-save My Singer Profile so geocoding can
+prepare the location for radius search. A profile with usable saved coordinates
+can be selected without showing a missing-location warning.
+
 ## Cost and Limits
 
 Mapbox requests may be billed and rate limited according to the Mapbox account's

--- a/lib/search/profile-origin.ts
+++ b/lib/search/profile-origin.ts
@@ -1,0 +1,130 @@
+import {
+  approximateLocationLabel,
+  type Coordinates,
+} from "@/lib/location/approximate-location";
+
+export type ProfileOriginRow = {
+  country_name: string | null;
+  latitude_private: number | string | null;
+  locality: string | null;
+  location_label_public: string | null;
+  longitude_private: number | string | null;
+  postal_code_private: string | null;
+  region: string | null;
+};
+
+export type ProfileOriginStatus =
+  | "incomplete_location"
+  | "missing_profile"
+  | "needs_geocoding"
+  | "usable";
+
+export type ProfileOriginState = {
+  coordinates: Coordinates | null;
+  label: string;
+  status: ProfileOriginStatus;
+};
+
+function hasText(value: string | null) {
+  return Boolean(value?.trim());
+}
+
+export function coordinatesFromPrivateRow(
+  row: ProfileOriginRow | null,
+): Coordinates | null {
+  if (row?.latitude_private == null || row.longitude_private == null) {
+    return null;
+  }
+
+  const latitude = Number(row.latitude_private);
+  const longitude = Number(row.longitude_private);
+
+  if (
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude) ||
+    latitude < -90 ||
+    latitude > 90 ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    return null;
+  }
+
+  return { latitude, longitude };
+}
+
+export function profileOriginHasCompleteTextLocation(
+  row: ProfileOriginRow | null,
+) {
+  return Boolean(
+    row &&
+    hasText(row.country_name) &&
+    hasText(row.region) &&
+    hasText(row.locality) &&
+    hasText(row.postal_code_private),
+  );
+}
+
+export function labelForProfileOrigin(row: ProfileOriginRow | null) {
+  if (!row) {
+    return "your singer profile";
+  }
+
+  return approximateLocationLabel({
+    countryName: row.country_name,
+    locality: row.locality,
+    locationLabelPublic: row.location_label_public,
+    region: row.region,
+  });
+}
+
+export function profileOriginState(row: ProfileOriginRow | null) {
+  if (!row) {
+    return {
+      coordinates: null,
+      label: "your singer profile",
+      status: "missing_profile",
+    } satisfies ProfileOriginState;
+  }
+
+  const coordinates = coordinatesFromPrivateRow(row);
+  const label = labelForProfileOrigin(row);
+
+  if (coordinates) {
+    return {
+      coordinates,
+      label,
+      status: "usable",
+    } satisfies ProfileOriginState;
+  }
+
+  if (profileOriginHasCompleteTextLocation(row)) {
+    return {
+      coordinates: null,
+      label,
+      status: "needs_geocoding",
+    } satisfies ProfileOriginState;
+  }
+
+  return {
+    coordinates: null,
+    label,
+    status: "incomplete_location",
+  } satisfies ProfileOriginState;
+}
+
+export function profileOriginUnavailableMessage(status: ProfileOriginStatus) {
+  if (status === "missing_profile") {
+    return "Create My Singer Profile with country, region, city, and ZIP/postal code, or switch to a typed search origin.";
+  }
+
+  if (status === "incomplete_location") {
+    return "My Singer Profile needs country, region, city, and ZIP/postal code before it can be used as a search origin. Edit My Singer Profile or switch to a typed search origin.";
+  }
+
+  if (status === "needs_geocoding") {
+    return "My Singer Profile has location text but does not have saved approximate coordinates yet. Re-save My Singer Profile so the location can be prepared for radius search, or switch to a typed search origin.";
+  }
+
+  return null;
+}

--- a/test/profile-origin.test.ts
+++ b/test/profile-origin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  coordinatesFromPrivateRow,
+  profileOriginState,
+  profileOriginUnavailableMessage,
+  type ProfileOriginRow,
+} from "@/lib/search/profile-origin";
+
+const completeTextLocation: ProfileOriginRow = {
+  country_name: "United States",
+  latitude_private: null,
+  locality: "Fort Collins",
+  location_label_public: "Fort Collins, CO area",
+  longitude_private: null,
+  postal_code_private: "80521",
+  region: "Colorado",
+};
+
+describe("profile search origin state", () => {
+  it("treats saved private coordinates as a usable singer profile origin", () => {
+    const state = profileOriginState({
+      ...completeTextLocation,
+      latitude_private: "40.5853",
+      longitude_private: -105.0844,
+    });
+
+    expect(state).toEqual({
+      coordinates: { latitude: 40.5853, longitude: -105.0844 },
+      label: "Fort Collins, CO area",
+      status: "usable",
+    });
+  });
+
+  it("does not reject valid zero-valued coordinate components", () => {
+    expect(
+      coordinatesFromPrivateRow({
+        ...completeTextLocation,
+        latitude_private: 0,
+        longitude_private: 0,
+      }),
+    ).toEqual({ latitude: 0, longitude: 0 });
+  });
+
+  it("distinguishes complete text location that still needs geocoding", () => {
+    const state = profileOriginState(completeTextLocation);
+
+    expect(state.status).toBe("needs_geocoding");
+    expect(profileOriginUnavailableMessage(state.status)).toContain(
+      "has location text but does not have saved approximate coordinates",
+    );
+  });
+
+  it("distinguishes incomplete or missing profile location", () => {
+    expect(profileOriginState(null).status).toBe("missing_profile");
+    expect(
+      profileOriginState({
+        ...completeTextLocation,
+        postal_code_private: null,
+      }).status,
+    ).toBe("incomplete_location");
+    expect(profileOriginUnavailableMessage("incomplete_location")).toContain(
+      "needs country, region, city, and ZIP/postal code",
+    );
+  });
+});

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -63,6 +63,10 @@ describe("public discovery copy", () => {
     expect(findPage).toContain("InteractiveDiscoveryMap");
     expect(findPage).toContain("Search from");
     expect(findPage).toContain("My Singer Profile");
+    expect(findPage).toContain("My Singer Profile (add location first)");
+    expect(findPage).not.toContain(
+      "does not have a saved approximate location yet",
+    );
     expect(findPage).toContain("Within");
     expect(findPage).toContain("multiple");
     expect(findPage).toContain("Matching results");


### PR DESCRIPTION
Closes #113.\n\n## Summary\n- separates usable saved Singer Profile coordinates from missing, incomplete, and not-yet-geocoded profile location states\n- disables the My Singer Profile search-origin option when it cannot support profile-origin search and shows more precise guidance\n- fixes private coordinate parsing so valid zero-valued coordinates are not rejected\n- documents the profile-origin/geocoding distinction and adds focused tests\n\n## Verification\n- npm run lint\n- npm run typecheck\n- npm run test:run\n- npm run format:check\n- npm run build