### PR TITLE
Clean up Find search controls

### DIFF
--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -27,6 +27,8 @@ import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import {
   profileOriginState,
   profileOriginUnavailableMessage,
+  profileOriginUnavailableMessageFor,
+  type ProfileOriginState,
   type ProfileOriginRow,
 } from "@/lib/search/profile-origin";
 
@@ -81,6 +83,10 @@ type FindResult = DiscoveryMapItem & {
   distanceKm: number | null;
 };
 
+type DiscoverabilityOriginRow = ProfileOriginRow & {
+  is_visible: boolean | null;
+};
+
 const kindOptions = [
   ["quartets", "Quartet openings"],
   ["singers", "Singers"],
@@ -103,6 +109,12 @@ const distanceUnitOptions = [
   ["mi", "Miles"],
   ["km", "Kilometers"],
 ];
+
+const searchFromSourceOptions = [
+  ["singer_profile", "My Singer Profile location"],
+  ["quartet_profile", "My Quartet Profile location"],
+  ["another", "Another location"],
+] as const;
 
 const filterControlClass =
   "mt-2 w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20";
@@ -153,6 +165,14 @@ function selectedPartValues(filters: ReturnType<typeof parseDiscoveryFilters>) {
   return filters.parts.map((part) => voicingPartValue(part.voicing, part.part));
 }
 
+function resultMatchesSelectedGoals(result: FindResult, goals: string[]) {
+  if (goals.length === 0) {
+    return true;
+  }
+
+  return goals.some((goal) => result.goals.includes(goal));
+}
+
 function resultMatchesSelectedParts(
   result: FindResult,
   selectedParts: string[],
@@ -200,15 +220,63 @@ function filterAnalyticsProperties(
   filters: ReturnType<typeof parseDiscoveryFilters>,
 ) {
   const flags = {
-    has_goal_filter: Boolean(filters.goal),
-    has_location_filter: Boolean(filters.searchFrom),
+    has_goal_filter: filters.goals.length > 0,
+    has_location_filter:
+      filters.searchFromSource !== "another" || Boolean(filters.searchFrom),
     has_part_filter: filters.parts.length > 0,
     has_radius_filter: filters.radius != null,
-    has_search_origin: Boolean(filters.searchFrom),
+    has_search_origin:
+      filters.searchFromSource !== "another" || Boolean(filters.searchFrom),
   };
   const filterCount = Object.values(flags).filter(Boolean).length;
 
   return { filterCount, flags };
+}
+
+function sourceLabel(
+  source: ReturnType<typeof parseDiscoveryFilters>["searchFromSource"],
+) {
+  if (source === "singer_profile") {
+    return "your Singer Profile location";
+  }
+
+  if (source === "quartet_profile") {
+    return "your Quartet Profile location";
+  }
+
+  return "the entered location";
+}
+
+function unavailableProfileStatusLine({
+  label,
+  state,
+}: {
+  label: string;
+  state: ProfileOriginState;
+}) {
+  if (state.status === "usable") {
+    return null;
+  }
+
+  return `${label} does not have enough location information for distance search.`;
+}
+
+function discoverabilityLabel({
+  isVisible,
+  state,
+}: {
+  isVisible: boolean | null | undefined;
+  state: ProfileOriginState;
+}) {
+  if (!isVisible) {
+    return "Not shown in Find";
+  }
+
+  if (state.status !== "usable") {
+    return "Shown in Find, but missing location for distance search";
+  }
+
+  return "Shown in Find";
 }
 
 function radiusToKilometers(
@@ -224,14 +292,14 @@ function radiusToKilometers(
 
 function geocodingStatusMessage(status: ApproximateGeocodingStatus) {
   if (status === "not_configured") {
-    return "Radius search needs server-side Mapbox geocoding configuration before a search origin can be resolved.";
+    return "Radius search needs server-side Mapbox geocoding configuration before that location can be resolved.";
   }
 
   if (status === "not_found") {
-    return "That search origin could not be resolved. Try a city plus region/country or a postal code plus country.";
+    return "That location could not be resolved. Try a city plus region/country or a postal code plus country.";
   }
 
-  return "The search origin could not be resolved right now. Try again in a moment or clear the location search.";
+  return "That location could not be resolved right now. Try again in a moment or clear the location search.";
 }
 
 export default async function FindPage({ searchParams }: FindPageProps) {
@@ -244,23 +312,38 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   const radiusKm = radiusToKilometers(filters.radius, filters.distanceUnit);
   let radiusSearchOrigin: Coordinates | null = null;
   let radiusSearchOriginLabel = textValue(filters.searchFrom);
-  let profileOrigin: ProfileOriginRow | null = null;
   let geocodingResult: Awaited<
     ReturnType<typeof geocodeApproximateLocation>
   > | null = null;
-  const { data: profileOriginData } = await supabase
+  const { data: singerOriginData } = await supabase
     .from("singer_profiles")
     .select(
-      "latitude_private, longitude_private, country_name, region, locality, postal_code_private, location_label_public",
+      "is_visible, latitude_private, longitude_private, country_name, region, locality, postal_code_private, location_label_public",
     )
-    .maybeSingle<ProfileOriginRow>();
+    .maybeSingle<DiscoverabilityOriginRow>();
+  const { data: quartetOriginData } = await supabase
+    .from("quartet_listings")
+    .select(
+      "is_visible, latitude_private, longitude_private, country_name, region, locality, postal_code_private, location_label_public",
+    )
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle<DiscoverabilityOriginRow>();
+  const singerOrigin = singerOriginData ?? null;
+  const quartetOrigin = quartetOriginData ?? null;
+  const singerSearchOrigin = profileOriginState(singerOrigin);
+  const quartetSearchOrigin = profileOriginState(quartetOrigin);
+  const selectedProfileOrigin =
+    filters.searchFromSource === "quartet_profile"
+      ? quartetSearchOrigin
+      : singerSearchOrigin;
 
-  profileOrigin = profileOriginData ?? null;
-  const profileSearchOrigin = profileOriginState(profileOrigin);
-
-  if (filters.searchOrigin === "profile") {
-    radiusSearchOrigin = profileSearchOrigin.coordinates;
-    radiusSearchOriginLabel = profileSearchOrigin.label;
+  if (filters.searchFromSource === "singer_profile") {
+    radiusSearchOrigin = singerSearchOrigin.coordinates;
+    radiusSearchOriginLabel = singerSearchOrigin.label;
+  } else if (filters.searchFromSource === "quartet_profile") {
+    radiusSearchOrigin = quartetSearchOrigin.coordinates;
+    radiusSearchOriginLabel = quartetSearchOrigin.label;
   } else if (filters.searchFrom && radiusKm) {
     geocodingResult = await geocodeApproximateLocation(
       {
@@ -276,25 +359,32 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   let searchNotice: string | null = null;
 
   if (
-    filters.searchOrigin === "profile" &&
-    profileSearchOrigin.status !== "usable"
+    filters.searchFromSource !== "another" &&
+    selectedProfileOrigin.status !== "usable"
   ) {
-    searchNotice = profileOriginUnavailableMessage(profileSearchOrigin.status);
-  } else if (filters.searchOrigin === "profile" && filters.radius == null) {
     searchNotice =
-      "Add a radius to search by distance from your singer profile location. Without a radius, results show all visible areas that match the other filters.";
+      filters.searchFromSource === "quartet_profile"
+        ? profileOriginUnavailableMessageFor(
+            selectedProfileOrigin.status,
+            "My Quartet Profile",
+          )
+        : profileOriginUnavailableMessage(selectedProfileOrigin.status);
+  } else if (filters.searchFromSource !== "another" && filters.radius == null) {
+    searchNotice = `Add a radius to search by distance from ${sourceLabel(
+      filters.searchFromSource,
+    )}. Without a radius, results show all visible areas that match the other filters.`;
   } else if (filters.searchFrom && filters.radius == null) {
     searchNotice =
-      "Add a radius to search by distance from the entered place. Without a radius, results show all visible areas that match the other filters.";
+      "Add a radius to search by distance from another location. Without a radius, results show all visible areas that match the other filters.";
   } else if (
     filters.radius != null &&
-    filters.searchOrigin === "typed" &&
+    filters.searchFromSource === "another" &&
     !filters.searchFrom
   ) {
     searchNotice =
-      "Add a search origin to use radius filtering. Without a search origin, results show all visible areas that match the other filters.";
+      "Add another location to use radius filtering. Without a location, results show all visible areas that match the other filters.";
   } else if (
-    filters.searchOrigin === "typed" &&
+    filters.searchFromSource === "another" &&
     filters.searchFrom &&
     radiusKm &&
     geocodingResult?.status !== "resolved"
@@ -306,22 +396,18 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     const { data, error } =
       radiusSearchOrigin && radiusKm
         ? await supabase.rpc("search_singer_discovery_profiles", {
-            goal_filter: filters.goal,
+            goal_filter: null,
             radius_km: radiusKm,
             search_latitude: radiusSearchOrigin.latitude,
             search_longitude: radiusSearchOrigin.longitude,
           })
         : await (() => {
-            let query = supabase
+            const query = supabase
               .from("singer_discovery_profiles")
               .select(
                 "id, display_name, parts, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
               )
               .order("updated_at", { ascending: false });
-
-            if (filters.goal) {
-              query = query.contains("goals", [filters.goal]);
-            }
 
             return query;
           })();
@@ -360,22 +446,18 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     const { data, error } =
       radiusSearchOrigin && radiusKm
         ? await supabase.rpc("search_quartet_discovery_listings", {
-            goal_filter: filters.goal,
+            goal_filter: null,
             radius_km: radiusKm,
             search_latitude: radiusSearchOrigin.latitude,
             search_longitude: radiusSearchOrigin.longitude,
           })
         : await (() => {
-            let query = supabase
+            const query = supabase
               .from("quartet_discovery_listings")
               .select(
                 "id, name, description, parts_covered, parts_needed, goals, experience_level, availability, travel_radius_km, country_code, country_name, region, locality, location_label_public",
               )
               .order("updated_at", { ascending: false });
-
-            if (filters.goal) {
-              query = query.contains("goals", [filters.goal]);
-            }
 
             return query;
           })();
@@ -410,8 +492,10 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     }
   }
 
-  results = results.filter((result) =>
-    resultMatchesSelectedParts(result, selectedParts),
+  results = results.filter(
+    (result) =>
+      resultMatchesSelectedParts(result, selectedParts) &&
+      resultMatchesSelectedGoals(result, filters.goals),
   );
 
   const markers = buildDiscoveryMapMarkers(results);
@@ -432,7 +516,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
     route: "/find",
     result_count: results.length,
     route_area: "discovery",
-    search_origin: filters.searchOrigin,
+    search_origin: filters.searchFromSource,
   };
 
   await captureProductEvent("find_searched", discoveryAnalyticsProperties);
@@ -456,11 +540,50 @@ export default async function FindPage({ searchParams }: FindPageProps) {
           </p>
         </header>
 
+        <section className="mt-6 max-w-4xl rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 text-sm text-[#394548]">
+          <h2 className="text-base font-bold text-[#172023]">
+            Your discoverability
+          </h2>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+            <div>
+              <dt className="font-semibold text-[#172023]">Singer Profile</dt>
+              <dd>
+                {discoverabilityLabel({
+                  isVisible: singerOrigin?.is_visible,
+                  state: singerSearchOrigin,
+                })}
+              </dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-[#172023]">Quartet Profile</dt>
+              <dd>
+                {discoverabilityLabel({
+                  isVisible: quartetOrigin?.is_visible,
+                  state: quartetSearchOrigin,
+                })}
+              </dd>
+            </div>
+          </dl>
+          <p className="mt-3 leading-6">
+            {singerOrigin?.is_visible || quartetOrigin?.is_visible
+              ? "You can search either way. These settings only control whether other people can find your profiles."
+              : "You can still search, but other users will not discover your Singer Profile or Quartet Profile until you turn visibility on."}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-3">
+            <a className="font-semibold text-[#2f6f73]" href="/app/profile">
+              Edit My Singer Profile
+            </a>
+            <a className="font-semibold text-[#2f6f73]" href="/app/listings">
+              Edit My Quartet Profile
+            </a>
+          </div>
+        </section>
+
         <form
           aria-label="Filter discovery results"
           className="mt-6 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-4 shadow-sm"
         >
-          <div className="grid gap-4 lg:grid-cols-[1fr_1fr_1.4fr_0.7fr_0.9fr]">
+          <div className="grid gap-4 lg:grid-cols-[1fr_1.6fr_1.1fr_auto]">
             <label className="block">
               <span className="text-sm font-semibold">Looking for</span>
               <select
@@ -476,106 +599,108 @@ export default async function FindPage({ searchParams }: FindPageProps) {
               </select>
             </label>
 
-            <label className="block">
-              <span className="text-sm font-semibold">Search origin</span>
-              <select
-                className={filterControlClass}
-                defaultValue={filters.searchOrigin}
-                name="searchOrigin"
-              >
-                <option value="typed">Typed place</option>
-                <option
-                  disabled={profileSearchOrigin.status !== "usable"}
-                  value="profile"
+            <div className="block">
+              <label>
+                <span className="text-sm font-semibold">Search From</span>
+                <select
+                  className={filterControlClass}
+                  defaultValue={filters.searchFromSource}
+                  name="searchFromSource"
                 >
-                  {profileSearchOrigin.status === "usable"
-                    ? "My Singer Profile"
-                    : "My Singer Profile (add location first)"}
-                </option>
-              </select>
-              {profileSearchOrigin.status !== "usable" ? (
-                <span className="mt-2 block text-xs leading-5 text-[#596466]">
-                  {profileOriginUnavailableMessage(profileSearchOrigin.status)}
-                </span>
+                  {searchFromSourceOptions.map(([value, label]) => {
+                    const sourceState =
+                      value === "quartet_profile"
+                        ? quartetSearchOrigin
+                        : singerSearchOrigin;
+                    const unavailable =
+                      value !== "another" && sourceState.status !== "usable";
+
+                    return (
+                      <option disabled={unavailable} key={value} value={value}>
+                        {unavailable ? `${label} - add location first` : label}
+                      </option>
+                    );
+                  })}
+                </select>
+              </label>
+              {filters.searchFromSource === "another" ? (
+                <label className="mt-3 block">
+                  <span className="text-sm font-semibold">
+                    Another location
+                  </span>
+                  <input
+                    className={filterControlClass}
+                    defaultValue={textValue(filters.searchFrom)}
+                    name="searchFrom"
+                    placeholder="Fort Collins, CO; Toronto, ON; M5V, Canada"
+                  />
+                  <span className="mt-2 block text-xs leading-5 text-[#596466]">
+                    City, region, country, or postal code. No street address.
+                  </span>
+                </label>
               ) : null}
-            </label>
+              <div className="mt-2 space-y-2 text-xs leading-5 text-[#596466]">
+                {unavailableProfileStatusLine({
+                  label: "Your Singer Profile",
+                  state: singerSearchOrigin,
+                }) ? (
+                  <p>
+                    {unavailableProfileStatusLine({
+                      label: "Your Singer Profile",
+                      state: singerSearchOrigin,
+                    })}{" "}
+                    <a
+                      className="font-semibold text-[#2f6f73]"
+                      href="/app/profile"
+                    >
+                      Edit My Singer Profile
+                    </a>
+                  </p>
+                ) : null}
+                {unavailableProfileStatusLine({
+                  label: "Your Quartet Profile",
+                  state: quartetSearchOrigin,
+                }) ? (
+                  <p>
+                    {unavailableProfileStatusLine({
+                      label: "Your Quartet Profile",
+                      state: quartetSearchOrigin,
+                    })}{" "}
+                    <a
+                      className="font-semibold text-[#2f6f73]"
+                      href="/app/listings"
+                    >
+                      Edit My Quartet Profile
+                    </a>
+                  </p>
+                ) : null}
+              </div>
+            </div>
 
-            <label className="block">
-              <span className="text-sm font-semibold">Search from</span>
-              <input
-                className={filterControlClass}
-                defaultValue={textValue(filters.searchFrom)}
-                name="searchFrom"
-                placeholder="Fort Collins, CO or M5V, Canada"
-              />
-              <span className="mt-2 block text-xs leading-5 text-[#596466]">
-                Used when Search origin is Typed place.
-              </span>
-            </label>
-
-            <label className="block">
-              <span className="text-sm font-semibold">Within</span>
-              <input
-                className={filterControlClass}
-                defaultValue={textValue(filters.radius)}
-                min={1}
-                name="radius"
-                placeholder="25"
-                type="number"
-              />
-            </label>
-
-            <label className="block">
-              <span className="text-sm font-semibold">Distance units</span>
-              <select
-                className={filterControlClass}
-                defaultValue={filters.distanceUnit}
-                name="distanceUnit"
-              >
-                {distanceUnitOptions.map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-
-          <div className="mt-4 grid gap-4 lg:grid-cols-[1.5fr_1fr_auto]">
-            <label className="block">
-              <span className="text-sm font-semibold">Parts</span>
-              <select
-                className={`${filterControlClass} min-h-32`}
-                defaultValue={selectedParts}
-                multiple
-                name="part"
-              >
-                {partOptions.slice(1).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-              <span className="mt-2 block text-xs leading-5 text-[#596466]">
-                Select one or more voicing-aware parts. Leave blank for any
-                part.
-              </span>
-            </label>
-
-            <label className="block">
-              <span className="text-sm font-semibold">Goal</span>
-              <select
-                className={filterControlClass}
-                defaultValue={textValue(filters.goal)}
-                name="goal"
-              >
-                {goalOptions.map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <fieldset>
+              <legend className="text-sm font-semibold">Within</legend>
+              <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+                <input
+                  className="w-full rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                  defaultValue={textValue(filters.radius)}
+                  min={1}
+                  name="radius"
+                  placeholder="100"
+                  type="number"
+                />
+                <select
+                  className="rounded-md border border-[#d7cec0] bg-white px-3 py-2 text-base text-[#172023] shadow-sm outline-none focus:border-[#2f6f73] focus:ring-2 focus:ring-[#2f6f73]/20"
+                  defaultValue={filters.distanceUnit}
+                  name="distanceUnit"
+                >
+                  {distanceUnitOptions.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </fieldset>
 
             <div className="flex flex-col gap-3 lg:justify-end">
               <button
@@ -591,6 +716,47 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                 Clear filters
               </a>
             </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-semibold">Voice Part(s)</span>
+              <select
+                className={`${filterControlClass} min-h-32`}
+                defaultValue={selectedParts}
+                multiple
+                name="part"
+              >
+                {partOptions.slice(1).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-2 block text-xs leading-5 text-[#596466]">
+                Choose one or more parts you sing or need. Leave blank for any
+                voice part.
+              </span>
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-semibold">Goal(s)</span>
+              <select
+                className={`${filterControlClass} min-h-32`}
+                defaultValue={filters.goals}
+                multiple
+                name="goal"
+              >
+                {goalOptions.slice(1).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-2 block text-xs leading-5 text-[#596466]">
+                Choose one or more goals. Leave blank for any goal.
+              </span>
+            </label>
           </div>
 
           {searchNotice ? (
@@ -642,8 +808,8 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                 <p className="mt-3 text-sm leading-6">
                   Try increasing the radius, selecting fewer parts, clearing
                   goal filters, or searching both singers and quartet openings.
-                  If no origin is entered, add a city/region/country or postal
-                  code, or use your saved singer profile location.
+                  If no location is entered, add a city/region/country or postal
+                  code, or use a saved profile location.
                 </p>
               </section>
             ) : null}

--- a/app/quartets/page.tsx
+++ b/app/quartets/page.tsx
@@ -92,7 +92,7 @@ function filterAnalyticsProperties(
     has_availability_filter: Boolean(filters.availability),
     has_country_filter: Boolean(filters.country),
     has_experience_filter: Boolean(filters.experience),
-    has_goal_filter: Boolean(filters.goal),
+    has_goal_filter: filters.goals.length > 0,
     has_locality_filter: Boolean(filters.locality),
     has_part_filter: Boolean(filters.part),
     has_region_filter: Boolean(filters.region),
@@ -152,8 +152,8 @@ export default async function QuartetSearchPage({
     ]);
   }
 
-  if (filters.goal) {
-    query = query.contains("goals", [filters.goal]);
+  if (filters.goals.length > 0) {
+    query = query.overlaps("goals", filters.goals);
   }
 
   if (filters.experience) {

--- a/app/singers/page.tsx
+++ b/app/singers/page.tsx
@@ -90,7 +90,7 @@ function filterAnalyticsProperties(
     has_availability_filter: Boolean(filters.availability),
     has_country_filter: Boolean(filters.country),
     has_experience_filter: Boolean(filters.experience),
-    has_goal_filter: Boolean(filters.goal),
+    has_goal_filter: filters.goals.length > 0,
     has_locality_filter: Boolean(filters.locality),
     has_part_filter: Boolean(filters.part),
     has_region_filter: Boolean(filters.region),
@@ -150,8 +150,8 @@ export default async function SingerSearchPage({
     ]);
   }
 
-  if (filters.goal) {
-    query = query.contains("goals", [filters.goal]);
+  if (filters.goals.length > 0) {
+    query = query.overlaps("goals", filters.goals);
   }
 
   if (filters.experience) {

--- a/lib/content/public-pages.ts
+++ b/lib/content/public-pages.ts
@@ -138,14 +138,14 @@ export const publicHelpSections: HelpGuideSection[] = [
     topics: [
       {
         body: [
-          "Choose what you are looking for: quartet openings, singers, or both. Use part filters with voicing context when a specific part matters.",
+          "Choose what you are looking for: quartet openings, singers, or both. Use Voice Part(s) and Goal(s) filters when a specific part or set of goals matters.",
           "Find combines filters, a privacy-safe interactive map, and result cards. Result cards give the practical context you need before starting contact.",
         ],
         title: "How Find works",
       },
       {
         body: [
-          "You can search from a typed place or from your saved singer profile location, choose a radius, and switch between miles and kilometers. Miles are the default display unit.",
+          "Search From can use My Singer Profile location, My Quartet Profile location, or another location you type. Choose a radius and switch between miles and kilometers. Miles are the default display unit.",
           "Radius search uses approximate geocoding and approximate distance. It is meant to answer whether a match is plausibly nearby, not provide exact navigation.",
         ],
         title: "Radius and distance",
@@ -273,7 +273,7 @@ export const publicHelpSections: HelpGuideSection[] = [
     topics: [
       {
         body: [
-          "There may not be many visible profiles yet, your filters may be too narrow, or your search origin/radius may exclude likely matches. Try clearing part filters, increasing the radius, or searching both singers and quartet openings.",
+          "There may not be many visible profiles yet, your filters may be too narrow, or your selected Search From location and radius may exclude likely matches. Try clearing part filters, increasing the radius, or searching both singers and quartet openings.",
         ],
         title: "Why can't I find any results?",
       },

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -14,17 +14,20 @@ export type DiscoveryFilters = {
   distanceUnit: DistanceUnit;
   experience: string | null;
   goal: ProfileGoal | null;
+  goals: ProfileGoal[];
   locality: string | null;
   part: VoicingPartSelection | null;
   parts: VoicingPartSelection[];
   radius: number | null;
   region: string | null;
-  searchOrigin: SearchOrigin;
+  searchFromSource: SearchFromSource;
   searchFrom: string | null;
+  searchOrigin: SearchOrigin;
   travelRadiusKm: number | null;
 };
 
 export type SearchOrigin = "profile" | "typed";
+export type SearchFromSource = "another" | "quartet_profile" | "singer_profile";
 
 function normalizeSearchText(value: string | string[] | undefined) {
   const rawValue = Array.isArray(value) ? value[0] : value;
@@ -52,6 +55,23 @@ function parseAllowedValue<T extends string>(
 
 function parseSearchOrigin(value: string | string[] | undefined): SearchOrigin {
   return normalizeSearchText(value) === "profile" ? "profile" : "typed";
+}
+
+function parseSearchFromSource(
+  value: string | string[] | undefined,
+  legacyOrigin: string | string[] | undefined,
+): SearchFromSource {
+  const normalized = normalizeSearchText(value);
+
+  if (normalized === "singer_profile" || normalized === "quartet_profile") {
+    return normalized;
+  }
+
+  if (parseSearchOrigin(legacyOrigin) === "profile") {
+    return "singer_profile";
+  }
+
+  return "another";
 }
 
 function parseTravelRadiusKm(value: string | string[] | undefined) {
@@ -94,24 +114,43 @@ function parsePartList(value: string | string[] | undefined) {
     .filter((part): part is VoicingPartSelection => part != null);
 }
 
+function parseGoalList(value: string | string[] | undefined) {
+  const values = Array.isArray(value) ? value : [value];
+
+  return values
+    .map((item) => normalizeSearchText(item))
+    .filter((item): item is ProfileGoal =>
+      item ? PROFILE_GOALS.includes(item as ProfileGoal) : false,
+    );
+}
+
 export function parseDiscoveryFilters(
   searchParams: Record<string, string | string[] | undefined>,
 ): DiscoveryFilters {
   const parts = parsePartList(searchParams.part);
+  const goals = parseGoalList(searchParams.goal);
+  const searchFromSource = parseSearchFromSource(
+    searchParams.searchFromSource,
+    searchParams.searchOrigin,
+  );
+  const searchOrigin: SearchOrigin =
+    searchFromSource === "another" ? "typed" : "profile";
 
   return {
     availability: normalizeSearchText(searchParams.availability),
     country: normalizeSearchText(searchParams.country),
     distanceUnit: parseDistanceUnit(searchParams.distanceUnit),
     experience: normalizeSearchText(searchParams.experience),
-    goal: parseAllowedValue(searchParams.goal, PROFILE_GOALS),
+    goal: goals[0] ?? parseAllowedValue(searchParams.goal, PROFILE_GOALS),
+    goals,
     locality: normalizeSearchText(searchParams.locality),
     part: parts[0] ?? null,
     parts,
     radius: parseRadius(searchParams.radius),
     region: normalizeSearchText(searchParams.region),
-    searchOrigin: parseSearchOrigin(searchParams.searchOrigin),
+    searchFromSource,
     searchFrom: normalizeSearchText(searchParams.searchFrom),
+    searchOrigin,
     travelRadiusKm: parseTravelRadiusKm(searchParams.travelRadiusKm),
   };
 }
@@ -122,8 +161,12 @@ export function hasDiscoveryFilters(filters: DiscoveryFilters) {
       return false;
     }
 
+    if (key === "searchFromSource") {
+      return value !== "another";
+    }
+
     if (key === "searchOrigin") {
-      return value !== "typed";
+      return false;
     }
 
     if (Array.isArray(value)) {

--- a/lib/search/profile-origin.ts
+++ b/lib/search/profile-origin.ts
@@ -114,16 +114,23 @@ export function profileOriginState(row: ProfileOriginRow | null) {
 }
 
 export function profileOriginUnavailableMessage(status: ProfileOriginStatus) {
+  return profileOriginUnavailableMessageFor(status, "My Singer Profile");
+}
+
+export function profileOriginUnavailableMessageFor(
+  status: ProfileOriginStatus,
+  profileName: "My Quartet Profile" | "My Singer Profile",
+) {
   if (status === "missing_profile") {
-    return "Create My Singer Profile with country, region, city, and ZIP/postal code, or switch to a typed search origin.";
+    return `Create ${profileName} with country, region, city, and ZIP/postal code, or search from another location.`;
   }
 
   if (status === "incomplete_location") {
-    return "My Singer Profile needs country, region, city, and ZIP/postal code before it can be used as a search origin. Edit My Singer Profile or switch to a typed search origin.";
+    return `${profileName} needs country, region, city, and ZIP/postal code before it can be used for distance search. Edit ${profileName} or search from another location.`;
   }
 
   if (status === "needs_geocoding") {
-    return "My Singer Profile has location text but does not have saved approximate coordinates yet. Re-save My Singer Profile so the location can be prepared for radius search, or switch to a typed search origin.";
+    return `${profileName} has location text but does not have saved approximate coordinates yet. Re-save ${profileName} so the location can be prepared for distance search, or search from another location.`;
   }
 
   return null;

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -14,7 +14,7 @@ describe("discovery filters", () => {
       part: "SATB:Soprano",
       distanceUnit: "km",
       radius: "25",
-      searchOrigin: "profile",
+      searchFromSource: "singer_profile",
       searchFrom: " Manchester, England ",
       travelRadiusKm: "50",
     });
@@ -23,11 +23,13 @@ describe("discovery filters", () => {
     expect(filters.locality).toBe("Manchester");
     expect(filters.region).toBe("Greater Manchester");
     expect(filters.goal).toBe("contest");
+    expect(filters.goals).toEqual(["contest"]);
     expect(filters.part).toEqual({ part: "Soprano", voicing: "SATB" });
     expect(filters.parts).toEqual([{ part: "Soprano", voicing: "SATB" }]);
     expect(filters.distanceUnit).toBe("km");
     expect(filters.radius).toBe(25);
     expect(filters.searchOrigin).toBe("profile");
+    expect(filters.searchFromSource).toBe("singer_profile");
     expect(filters.searchFrom).toBe("Manchester, England");
     expect(filters.travelRadiusKm).toBe(50);
     expect(hasDiscoveryFilters(filters)).toBe(true);
@@ -41,16 +43,18 @@ describe("discovery filters", () => {
     });
 
     expect(filters.goal).toBeNull();
+    expect(filters.goals).toEqual([]);
     expect(filters.part).toBeNull();
     expect(filters.parts).toEqual([]);
     expect(filters.travelRadiusKm).toBeNull();
     expect(filters.radius).toBeNull();
     expect(filters.distanceUnit).toBe("mi");
     expect(filters.searchOrigin).toBe("typed");
+    expect(filters.searchFromSource).toBe("another");
     expect(hasDiscoveryFilters(filters)).toBe(false);
   });
 
-  it("uses the first submitted query value and keeps global text filters", () => {
+  it("keeps multiple submitted goals and global text filters", () => {
     const filters = parseDiscoveryFilters({
       country: ["Ireland", "United States"],
       goal: ["pickup", "contest"],
@@ -63,6 +67,7 @@ describe("discovery filters", () => {
     expect(filters.country).toBe("Ireland");
     expect(filters.locality).toBe("Dublin");
     expect(filters.goal).toBe("pickup");
+    expect(filters.goals).toEqual(["pickup", "contest"]);
     expect(filters.part).toEqual({ part: "Tenor", voicing: "TTBB" });
     expect(filters.parts).toEqual([{ part: "Tenor", voicing: "TTBB" }]);
     expect(filters.distanceUnit).toBe("km");
@@ -85,6 +90,17 @@ describe("discovery filters", () => {
     expect(filters.distanceUnit).toBe("mi");
     expect(filters.searchFrom).toBe("Fort Collins, CO");
     expect(hasDiscoveryFilters(filters)).toBe(true);
+  });
+
+  it("supports quartet profile and legacy profile search origins", () => {
+    expect(
+      parseDiscoveryFilters({ searchFromSource: "quartet_profile" })
+        .searchFromSource,
+    ).toBe("quartet_profile");
+    expect(parseDiscoveryFilters({ searchOrigin: "profile" })).toMatchObject({
+      searchFromSource: "singer_profile",
+      searchOrigin: "profile",
+    });
   });
 
   it("rejects decimal, negative, and too-large travel radius filters", () => {

--- a/test/location-form-copy.test.ts
+++ b/test/location-form-copy.test.ts
@@ -60,8 +60,9 @@ describe("location and distance form copy", () => {
   });
 
   it("puts the miles/kilometers picker only on Find", () => {
-    expect(findPage).toContain("Distance units");
+    expect(findPage).toContain("Within");
     expect(findPage).toContain("Miles");
+    expect(findPage).not.toContain("Distance units");
     expect(profilePage).not.toContain("Distance units");
     expect(listingPage).not.toContain("Distance units");
     expect(onboardingPage).not.toContain("Distance units");

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -55,24 +55,34 @@ describe("public discovery copy", () => {
     expect(singerPage).toContain("looking for other singers nearby");
   });
 
-  it("consolidates discovery around search origin, map, cards, and details", () => {
+  it("consolidates discovery around Search From, map, cards, and details", () => {
     const findPage = source("app/find/page.tsx");
 
     expect(findPage).toContain("Search quartet openings and singers");
     expect(findPage).toContain("Filter discovery results");
     expect(findPage).toContain("InteractiveDiscoveryMap");
-    expect(findPage).toContain("Search from");
-    expect(findPage).toContain("My Singer Profile");
-    expect(findPage).toContain("My Singer Profile (add location first)");
+    expect(findPage).toContain("Search From");
+    expect(findPage).toContain("My Singer Profile location");
+    expect(findPage).toContain("My Quartet Profile location");
+    expect(findPage).toContain("Another location");
+    expect(findPage).toContain("add location first");
+    expect(findPage).toContain("Your discoverability");
+    expect(findPage).toContain("Shown in Find");
+    expect(findPage).toContain("Not shown in Find");
+    expect(findPage).toContain("Edit My Singer Profile");
+    expect(findPage).toContain("Edit My Quartet Profile");
     expect(findPage).not.toContain(
       "does not have a saved approximate location yet",
     );
     expect(findPage).toContain("Within");
+    expect(findPage).toContain("Voice Part(s)");
+    expect(findPage).toContain("Goal(s)");
     expect(findPage).toContain("multiple");
     expect(findPage).toContain("Matching results");
     expect(findPage).toContain("details and contact");
     expect(findPage).not.toContain("Detailed quartet search");
     expect(findPage).not.toContain("Detailed singer search");
     expect(findPage).not.toContain("Open detailed search");
+    expect(findPage).not.toContain("Search origin");
   });
 });


### PR DESCRIPTION
Closes #112.\nCloses #115.\n\n## Summary\n- replaces separate Find location controls with one Search From group for Singer Profile, Quartet Profile, or Another location\n- disables unavailable profile-location choices with edit links and keeps Another location available\n- groups radius and units under Within, renames parts to Voice Part(s), and makes Goal(s) multi-select with inclusive filtering\n- adds a subtle Find discoverability card for Singer Profile and Quartet Profile visibility status\n- updates Help/Privacy-adjacent Find copy and tests\n\n## Verification\n- npm run lint\n- npm run typecheck\n- npm run test:run\n- npm run format:check\n- npm run build