### PR TITLE
Minimize Mapbox usage and document cost controls

### DIFF
--- a/app/(protected)/app/listings/actions.ts
+++ b/app/(protected)/app/listings/actions.ts
@@ -13,6 +13,10 @@ import {
   parseQuartetListingFormData,
 } from "@/lib/quartets/quartet-listing-form";
 import { distanceUnitForCountry } from "@/lib/location/country-location-defaults";
+import {
+  shouldGeocodeApproximateLocation,
+  storedApproximateCoordinates,
+} from "@/lib/location/geocoding-decision";
 import { geocodeApproximateLocation } from "@/lib/location/geocoding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -52,18 +56,52 @@ export async function saveQuartetListing(formData: FormData) {
     );
   }
 
-  const geocodingResult = await geocodeApproximateLocation(values, {
-    storageMode: "permanent",
-  });
-  const geocodedCoordinates = geocodingResult.coordinates;
   const { data: existingListing } = values.listingId
     ? await supabase
         .from("quartet_listings")
-        .select("is_visible")
+        .select(
+          "country_code, country_name, is_visible, latitude_private, locality, location_precision, longitude_private, postal_code_private, region",
+        )
         .eq("id", values.listingId)
         .eq("owner_user_id", user.id)
-        .maybeSingle<{ is_visible: boolean | null }>()
+        .maybeSingle<{
+          country_code: string | null;
+          country_name: string | null;
+          is_visible: boolean | null;
+          latitude_private: number | null;
+          locality: string | null;
+          location_precision: string | null;
+          longitude_private: number | null;
+          postal_code_private: string | null;
+          region: string | null;
+        }>()
     : { data: null };
+  const storedLocation = existingListing
+    ? {
+        countryCode: existingListing.country_code,
+        countryName: existingListing.country_name,
+        latitudePrivate: existingListing.latitude_private,
+        locality: existingListing.locality,
+        locationPrecision: existingListing.location_precision,
+        longitudePrivate: existingListing.longitude_private,
+        postalCodePrivate: existingListing.postal_code_private,
+        region: existingListing.region,
+      }
+    : null;
+  const shouldGeocode = shouldGeocodeApproximateLocation({
+    input: values,
+    storageMode: "permanent",
+    stored: storedLocation,
+  });
+  const geocodingResult = shouldGeocode
+    ? await geocodeApproximateLocation(values, {
+        storageMode: "permanent",
+      })
+    : null;
+  const preservedCoordinates = storedApproximateCoordinates(storedLocation);
+  const geocodedCoordinates =
+    geocodingResult?.coordinates ??
+    (shouldGeocode ? null : preservedCoordinates);
   const listingPayload = {
     availability: values.availability,
     country_code: values.countryCode,

--- a/app/(protected)/app/profile/actions.ts
+++ b/app/(protected)/app/profile/actions.ts
@@ -13,6 +13,10 @@ import {
   parseSingerProfileFormData,
 } from "@/lib/profiles/singer-profile-form";
 import { distanceUnitForCountry } from "@/lib/location/country-location-defaults";
+import {
+  shouldGeocodeApproximateLocation,
+  storedApproximateCoordinates,
+} from "@/lib/location/geocoding-decision";
 import { geocodeApproximateLocation } from "@/lib/location/geocoding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -58,15 +62,49 @@ export async function saveSingerProfile(formData: FormData) {
     values.countryCode,
     values.countryName,
   );
-  const geocodingResult = await geocodeApproximateLocation(values, {
-    storageMode: "permanent",
-  });
-  const geocodedCoordinates = geocodingResult.coordinates;
   const { data: existingProfile } = await supabase
     .from("singer_profiles")
-    .select("is_visible")
+    .select(
+      "country_code, country_name, is_visible, latitude_private, locality, location_precision, longitude_private, postal_code_private, region",
+    )
     .eq("user_id", user.id)
-    .maybeSingle<{ is_visible: boolean | null }>();
+    .maybeSingle<{
+      country_code: string | null;
+      country_name: string | null;
+      is_visible: boolean | null;
+      latitude_private: number | null;
+      locality: string | null;
+      location_precision: string | null;
+      longitude_private: number | null;
+      postal_code_private: string | null;
+      region: string | null;
+    }>();
+  const storedLocation = existingProfile
+    ? {
+        countryCode: existingProfile.country_code,
+        countryName: existingProfile.country_name,
+        latitudePrivate: existingProfile.latitude_private,
+        locality: existingProfile.locality,
+        locationPrecision: existingProfile.location_precision,
+        longitudePrivate: existingProfile.longitude_private,
+        postalCodePrivate: existingProfile.postal_code_private,
+        region: existingProfile.region,
+      }
+    : null;
+  const shouldGeocode = shouldGeocodeApproximateLocation({
+    input: values,
+    storageMode: "permanent",
+    stored: storedLocation,
+  });
+  const geocodingResult = shouldGeocode
+    ? await geocodeApproximateLocation(values, {
+        storageMode: "permanent",
+      })
+    : null;
+  const preservedCoordinates = storedApproximateCoordinates(storedLocation);
+  const geocodedCoordinates =
+    geocodingResult?.coordinates ??
+    (shouldGeocode ? null : preservedCoordinates);
 
   const { data: profile, error: profileError } = await supabase
     .from("singer_profiles")

--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -1,6 +1,6 @@
 import { ContactRequestForm } from "@/components/contact/contact-request-form";
-import { InteractiveDiscoveryMap } from "@/components/discovery/interactive-discovery-map";
 import { SignedInSiteHeader } from "@/components/navigation/signed-in-site-header";
+import { InteractiveDiscoveryMap } from "@/components/discovery/interactive-discovery-map";
 import { captureProductEvent } from "@/lib/analytics/product-analytics";
 import { requireAuthenticatedDiscovery } from "@/lib/auth/require-authenticated-discovery";
 import {
@@ -209,6 +209,35 @@ function returnToPath(params: Record<string, string | string[] | undefined>) {
         query.append(key, item);
       }
     }
+  }
+
+  const queryString = query.toString();
+
+  return queryString ? `/find?${queryString}` : "/find";
+}
+
+function findPathWithView(
+  params: Record<string, string | string[] | undefined>,
+  view: ReturnType<typeof parseDiscoveryFilters>["view"],
+) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (key === "view") {
+      continue;
+    }
+
+    const values = Array.isArray(value) ? value : [value];
+
+    for (const item of values) {
+      if (item) {
+        query.append(key, item);
+      }
+    }
+  }
+
+  if (view === "map") {
+    query.set("view", "map");
   }
 
   const queryString = query.toString();
@@ -499,6 +528,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   );
 
   const markers = buildDiscoveryMapMarkers(results);
+  const showMap = filters.view === "map";
   const { filterCount, flags } = filterAnalyticsProperties(filters);
   const radiusLabel =
     filters.radius == null
@@ -520,7 +550,10 @@ export default async function FindPage({ searchParams }: FindPageProps) {
   };
 
   await captureProductEvent("find_searched", discoveryAnalyticsProperties);
-  await captureProductEvent("map_viewed", discoveryAnalyticsProperties);
+
+  if (showMap) {
+    await captureProductEvent("map_viewed", discoveryAnalyticsProperties);
+  }
 
   return (
     <>
@@ -718,6 +751,8 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             </div>
           </div>
 
+          <input name="view" type="hidden" value={filters.view} />
+
           <div className="mt-4 grid gap-4 lg:grid-cols-2">
             <label className="block">
               <span className="text-sm font-semibold">Voice Part(s)</span>
@@ -775,31 +810,58 @@ export default async function FindPage({ searchParams }: FindPageProps) {
           </p>
         ) : null}
 
-        <section className="mt-6 grid gap-6 xl:grid-cols-[minmax(22rem,0.9fr)_minmax(0,1.1fr)]">
-          <InteractiveDiscoveryMap
-            emptyMessage="No approximate map regions match. Try increasing the radius, clearing part filters, or changing what you are looking for."
-            markers={markers}
-            resultLabel="Interactive map scope"
-            scopeLabel={searchScopeLabel}
-            totalResults={results.length}
-          />
-
-          <section aria-labelledby="results-heading">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-              <div>
-                <h2
-                  className="text-2xl font-bold text-[#172023]"
-                  id="results-heading"
-                >
-                  Matching results
-                </h2>
-                <p className="mt-1 text-sm text-[#394548]">
-                  Cards and detail panels show only privacy-safe discovery
-                  fields.
-                </p>
-              </div>
+        <section className="mt-6" aria-labelledby="results-heading">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2
+                className="text-2xl font-bold text-[#172023]"
+                id="results-heading"
+              >
+                Matching results
+              </h2>
+              <p className="mt-1 text-sm text-[#394548]">
+                Cards and detail panels show only privacy-safe discovery fields.
+              </p>
             </div>
+            <div className="flex flex-wrap gap-2">
+              <a
+                aria-current={showMap ? undefined : "page"}
+                className={`inline-flex min-h-11 items-center justify-center rounded-md px-4 py-2 text-sm font-semibold ${
+                  showMap
+                    ? "border border-[#d7cec0] bg-white text-[#174b4f] hover:border-[#174b4f]"
+                    : "bg-[#174b4f] text-white"
+                }`}
+                href={findPathWithView(params, "list")}
+              >
+                List
+              </a>
+              <a
+                aria-current={showMap ? "page" : undefined}
+                className={`inline-flex min-h-11 items-center justify-center rounded-md px-4 py-2 text-sm font-semibold ${
+                  showMap
+                    ? "bg-[#174b4f] text-white"
+                    : "border border-[#d7cec0] bg-white text-[#174b4f] hover:border-[#174b4f]"
+                }`}
+                href={findPathWithView(params, "map")}
+              >
+                Map
+              </a>
+            </div>
+          </div>
 
+          {showMap ? (
+            <div className="mt-5">
+              <InteractiveDiscoveryMap
+                emptyMessage="No approximate map regions match. Try increasing the radius, clearing part filters, or changing what you are looking for."
+                markers={markers}
+                resultLabel="Interactive map scope"
+                scopeLabel={searchScopeLabel}
+                totalResults={results.length}
+              />
+            </div>
+          ) : null}
+
+          <div className="mt-6">
             {results.length === 0 && !errorMessage ? (
               <section className="mt-5 rounded-lg border border-[#d7cec0] bg-[#fffaf2] p-5 text-[#394548]">
                 <h3 className="text-xl font-bold text-[#172023]">
@@ -935,7 +997,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
                 </article>
               ))}
             </div>
-          </section>
+          </div>
         </section>
 
         {markers.length > 0 ? (

--- a/components/discovery/interactive-discovery-map.tsx
+++ b/components/discovery/interactive-discovery-map.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   LngLatBoundsLike,
   Map as MapboxMap,
   MapOptions,
   Marker as MapboxMarker,
+  Popup as MapboxPopup,
 } from "mapbox-gl";
 import { groupVoicingParts } from "@/lib/parts/voicings";
 import type { DiscoveryMapMarker } from "@/lib/location/map-markers";
@@ -134,6 +135,9 @@ export function InteractiveDiscoveryMap({
 }: InteractiveDiscoveryMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<MapboxMap | null>(null);
+  const mapboxglRef = useRef<typeof import("mapbox-gl").default | null>(null);
+  const markerInstancesRef = useRef<MapboxMarker[]>([]);
+  const [mapReady, setMapReady] = useState(false);
 
   useEffect(() => {
     if (!containerRef.current || !MAPBOX_TOKEN) {
@@ -141,8 +145,6 @@ export function InteractiveDiscoveryMap({
     }
 
     let canceled = false;
-    let map: MapboxMap | null = null;
-    let markerInstances: MapboxMarker[] = [];
 
     async function initializeMap() {
       const mapboxgl = (await import("mapbox-gl")).default;
@@ -152,15 +154,16 @@ export function InteractiveDiscoveryMap({
       }
 
       mapboxgl.accessToken = MAPBOX_TOKEN;
+      mapboxglRef.current = mapboxgl;
 
-      map = new mapboxgl.Map({
+      const map = new mapboxgl.Map({
         attributionControl: false,
-        center: centerForMarkers(markers),
+        center: DEFAULT_CENTER,
         container: containerRef.current,
         cooperativeGestures: true,
         projection: MAP_PROJECTION as MapOptions["projection"],
         style: MAPBOX_STYLE,
-        zoom: markers.length > 1 ? 2.2 : 4,
+        zoom: 2.2,
       });
 
       map.addControl(
@@ -181,31 +184,8 @@ export function InteractiveDiscoveryMap({
         });
       });
 
-      markerInstances = markers.map((marker) => {
-        const popup = new mapboxgl.Popup({
-          closeButton: true,
-          closeOnClick: true,
-          maxWidth: "320px",
-          offset: 18,
-        }).setDOMContent(createPopupNode(marker, resultBasePath));
-
-        return new mapboxgl.Marker({
-          element: createMarkerElement(marker),
-        })
-          .setLngLat([marker.longitude, marker.latitude])
-          .setPopup(popup)
-          .addTo(map as MapboxMap);
-      });
-
-      if (markers.length > 1) {
-        map.fitBounds(boundsForMarkers(markers, mapboxgl), {
-          duration: 0,
-          maxZoom: 5,
-          padding: 70,
-        });
-      }
-
       mapRef.current = map;
+      setMapReady(true);
     }
 
     void initializeMap();
@@ -213,14 +193,59 @@ export function InteractiveDiscoveryMap({
     return () => {
       canceled = true;
 
-      for (const marker of markerInstances) {
+      for (const marker of markerInstancesRef.current) {
         marker.remove();
       }
 
-      map?.remove();
+      markerInstancesRef.current = [];
+      mapRef.current?.remove();
       mapRef.current = null;
+      mapboxglRef.current = null;
+      setMapReady(false);
     };
-  }, [markers, resultBasePath]);
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const mapboxgl = mapboxglRef.current;
+
+    if (!mapReady || !map || !mapboxgl) {
+      return;
+    }
+
+    for (const marker of markerInstancesRef.current) {
+      marker.remove();
+    }
+
+    markerInstancesRef.current = markers.map((marker) => {
+      const popup: MapboxPopup = new mapboxgl.Popup({
+        closeButton: true,
+        closeOnClick: true,
+        maxWidth: "320px",
+        offset: 18,
+      }).setDOMContent(createPopupNode(marker, resultBasePath));
+
+      return new mapboxgl.Marker({
+        element: createMarkerElement(marker),
+      })
+        .setLngLat([marker.longitude, marker.latitude])
+        .setPopup(popup)
+        .addTo(map);
+    });
+
+    if (markers.length > 1) {
+      map.fitBounds(boundsForMarkers(markers, mapboxgl), {
+        duration: 0,
+        maxZoom: 5,
+        padding: 70,
+      });
+    } else {
+      map.jumpTo({
+        center: centerForMarkers(markers),
+        zoom: markers.length === 1 ? 4 : 2.2,
+      });
+    }
+  }, [markers, mapReady, resultBasePath]);
 
   return (
     <section

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -469,11 +469,42 @@ The browser map requires `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`. Use a public
 `pk...` token with no secret scopes. Do not put an `sk...` secret token in a
 `NEXT_PUBLIC_` variable.
 
+Restrict the public token in Mapbox to QMF origins where possible:
+
+- `https://quartetmemberfinder.org/*`
+- `https://www.quartetmemberfinder.org/*`
+- the Vercel preview/deployment host patterns needed for pull-request testing
+- `http://localhost:3000/*` for local development, preferably on a separate
+  development token
+
+Mapbox GL JS usage is billed by web map loads. Current Mapbox documentation
+defines a map load as initializing a Mapbox GL JS `Map` object. QMF therefore
+keeps list results as the default `/find` view, loads the interactive map only
+when Map view is selected, and updates marker data without recreating the map
+instance during routine result changes.
+
 Approximate radius search can use server-side Mapbox geocoding. Keep
 `MAPBOX_GEOCODING_TOKEN` server-only. Set `MAPBOX_GEOCODING_PERMANENT=true`
 only when the Mapbox account is allowed to store geocoding results, because
 profile/listing save actions persist private approximate coordinates in
 Supabase.
+
+Use a dedicated server-side geocoding token. If that token is a public `pk...`
+token, do not expose it through browser code; if it is a secret `sk...` token,
+keep only the minimum scopes needed for Geocoding API use. Do not reuse a token
+from another project.
+
+Mapbox temporary geocoding results are not stored by QMF. Profile/listing
+coordinates are stored only through permanent geocoding, and only when relevant
+location fields are created or changed. Typed `/find` origins use temporary
+geocoding on explicit search submission, not per keystroke.
+
+For hobby-project cost control, check Mapbox Statistics after launch and after
+large QA sessions. Watch the products QMF uses: Mapbox GL JS map loads and
+Geocoding API requests. Configure conservative Mapbox budget or usage alerts if
+available: one alert before any paid usage threshold and another if paid usage
+appears. If usage spikes, restrict or rotate tokens, confirm the public token's
+allowed URLs, and verify `/find` is not repeatedly initializing Map view.
 
 Geocoding provider secrets, if any, must be server-only. Browser-rendered map
 props should contain approximate public labels, regional anchors, rounded

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -125,6 +125,10 @@ Vercel Production and Preview to render the interactive map. This must be a
 public `pk...` token with no secret scopes. `NEXT_PUBLIC_MAPBOX_PROJECTION`
 defaults to `globe` so the primary map is not Web Mercator.
 
+Restrict the public token to the production domain, required Vercel preview
+domains, and localhost development origins. QMF defaults `/find` to list results
+and loads Mapbox GL JS only when the signed-in user opens Map view.
+
 Server-side geocoding uses separate `MAPBOX_GEOCODING_*` values. Geocoding
 secrets should be server-only and must not use the `NEXT_PUBLIC_` prefix.
 

--- a/docs/location-geocoding.md
+++ b/docs/location-geocoding.md
@@ -45,11 +45,16 @@ columns:
 Public discovery views never expose exact coordinates, postal codes, private
 addresses, owner IDs, or recipient contact details.
 
+Profile and listing save actions call permanent geocoding only when the saved
+location fields are new or changed. If a user updates goals, parts,
+availability, visibility, or other non-location fields, the app preserves the
+existing private coordinates and does not make another geocoding request.
+
 ## Radius Search
 
 When a signed-in user enters a search origin and radius on `/find`, the server:
 
-1. Resolves the origin with temporary Mapbox geocoding.
+1. Resolves the origin with temporary Mapbox geocoding on explicit search.
 2. Converts miles to kilometers when needed.
 3. Calls Supabase RPC functions that filter visible records by approximate
    distance.
@@ -87,3 +92,9 @@ Mapbox requests may be billed and rate limited according to the Mapbox account's
 current plan. Search-origin lookups are temporary geocoding requests. Saved
 profile/listing location lookups use `permanent=true` only when
 `MAPBOX_GEOCODING_PERMANENT=true` is set.
+
+Mapbox documentation states that temporary geocoding results are not for stored
+reuse. QMF therefore does not persist typed search-origin geocoding responses.
+Repeated searches for the same typed origin can make repeated temporary
+geocoding requests; keep the UI explicit and avoid live geocoding on every
+keystroke.

--- a/lib/location/geocoding-decision.ts
+++ b/lib/location/geocoding-decision.ts
@@ -1,0 +1,81 @@
+import type {
+  ApproximateGeocodingInput,
+  GeocodingStorageMode,
+} from "@/lib/location/geocoding";
+import type { Coordinates } from "@/lib/location/approximate-location";
+
+export type StoredApproximateLocation = {
+  countryCode?: string | null;
+  countryName?: string | null;
+  latitudePrivate?: number | null;
+  locality?: string | null;
+  locationPrecision?: string | null;
+  longitudePrivate?: number | null;
+  postalCodePrivate?: string | null;
+  region?: string | null;
+};
+
+function normalized(value: string | null | undefined) {
+  const trimmed = value?.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+function sameLocationField(
+  current: string | null | undefined,
+  stored: string | null | undefined,
+) {
+  return normalized(current) === normalized(stored);
+}
+
+export function locationFieldsChanged(
+  input: ApproximateGeocodingInput,
+  stored: StoredApproximateLocation | null,
+) {
+  if (!stored) {
+    return true;
+  }
+
+  return !(
+    sameLocationField(input.countryCode, stored.countryCode) &&
+    sameLocationField(input.countryName, stored.countryName) &&
+    sameLocationField(input.locality, stored.locality) &&
+    sameLocationField(input.postalCodePrivate, stored.postalCodePrivate) &&
+    sameLocationField(input.region, stored.region)
+  );
+}
+
+export function storedApproximateCoordinates(
+  stored: StoredApproximateLocation | null,
+): Coordinates | null {
+  if (
+    typeof stored?.latitudePrivate !== "number" ||
+    typeof stored.longitudePrivate !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    latitude: stored.latitudePrivate,
+    longitude: stored.longitudePrivate,
+  };
+}
+
+export function shouldGeocodeApproximateLocation({
+  input,
+  storageMode,
+  stored,
+}: {
+  input: ApproximateGeocodingInput;
+  storageMode: GeocodingStorageMode;
+  stored: StoredApproximateLocation | null;
+}) {
+  if (storageMode === "temporary") {
+    return true;
+  }
+
+  return (
+    locationFieldsChanged(input, stored) ||
+    !storedApproximateCoordinates(stored)
+  );
+}

--- a/lib/location/geocoding.ts
+++ b/lib/location/geocoding.ts
@@ -1,6 +1,6 @@
 import type { Coordinates } from "@/lib/location/approximate-location";
 
-type GeocodingStorageMode = "permanent" | "temporary";
+export type GeocodingStorageMode = "permanent" | "temporary";
 
 export type ApproximateGeocodingInput = {
   countryCode?: string | null;

--- a/lib/search/discovery-filters.ts
+++ b/lib/search/discovery-filters.ts
@@ -24,10 +24,12 @@ export type DiscoveryFilters = {
   searchFrom: string | null;
   searchOrigin: SearchOrigin;
   travelRadiusKm: number | null;
+  view: DiscoveryView;
 };
 
 export type SearchOrigin = "profile" | "typed";
 export type SearchFromSource = "another" | "quartet_profile" | "singer_profile";
+export type DiscoveryView = "list" | "map";
 
 function normalizeSearchText(value: string | string[] | undefined) {
   const rawValue = Array.isArray(value) ? value[0] : value;
@@ -55,6 +57,12 @@ function parseAllowedValue<T extends string>(
 
 function parseSearchOrigin(value: string | string[] | undefined): SearchOrigin {
   return normalizeSearchText(value) === "profile" ? "profile" : "typed";
+}
+
+function parseDiscoveryView(
+  value: string | string[] | undefined,
+): DiscoveryView {
+  return normalizeSearchText(value) === "map" ? "map" : "list";
 }
 
 function parseSearchFromSource(
@@ -152,6 +160,7 @@ export function parseDiscoveryFilters(
     searchFrom: normalizeSearchText(searchParams.searchFrom),
     searchOrigin,
     travelRadiusKm: parseTravelRadiusKm(searchParams.travelRadiusKm),
+    view: parseDiscoveryView(searchParams.view),
   };
 }
 
@@ -167,6 +176,10 @@ export function hasDiscoveryFilters(filters: DiscoveryFilters) {
 
     if (key === "searchOrigin") {
       return false;
+    }
+
+    if (key === "view") {
+      return value === "map";
     }
 
     if (Array.isArray(value)) {

--- a/test/discovery-filters.test.ts
+++ b/test/discovery-filters.test.ts
@@ -17,6 +17,7 @@ describe("discovery filters", () => {
       searchFromSource: "singer_profile",
       searchFrom: " Manchester, England ",
       travelRadiusKm: "50",
+      view: "map",
     });
 
     expect(filters.country).toBe("United Kingdom");
@@ -32,6 +33,7 @@ describe("discovery filters", () => {
     expect(filters.searchFromSource).toBe("singer_profile");
     expect(filters.searchFrom).toBe("Manchester, England");
     expect(filters.travelRadiusKm).toBe(50);
+    expect(filters.view).toBe("map");
     expect(hasDiscoveryFilters(filters)).toBe(true);
   });
 
@@ -51,7 +53,20 @@ describe("discovery filters", () => {
     expect(filters.distanceUnit).toBe("mi");
     expect(filters.searchOrigin).toBe("typed");
     expect(filters.searchFromSource).toBe("another");
+    expect(filters.view).toBe("list");
     expect(hasDiscoveryFilters(filters)).toBe(false);
+  });
+
+  it("treats Map view as explicit and list view as the default", () => {
+    expect(parseDiscoveryFilters({ view: "map" }).view).toBe("map");
+    expect(parseDiscoveryFilters({ view: "list" }).view).toBe("list");
+    expect(parseDiscoveryFilters({ view: "globe" }).view).toBe("list");
+    expect(hasDiscoveryFilters(parseDiscoveryFilters({ view: "map" }))).toBe(
+      true,
+    );
+    expect(hasDiscoveryFilters(parseDiscoveryFilters({ view: "list" }))).toBe(
+      false,
+    );
   });
 
   it("keeps multiple submitted goals and global text filters", () => {

--- a/test/geocoding-decision.test.ts
+++ b/test/geocoding-decision.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  locationFieldsChanged,
+  shouldGeocodeApproximateLocation,
+  storedApproximateCoordinates,
+} from "@/lib/location/geocoding-decision";
+
+describe("geocoding trigger decisions", () => {
+  const storedLocation = {
+    countryCode: "US",
+    countryName: "United States",
+    latitudePrivate: 40.5853,
+    locality: "Fort Collins",
+    longitudePrivate: -105.0844,
+    postalCodePrivate: "80521",
+    region: "CO",
+  };
+
+  it("preserves stored coordinates when persisted location fields did not change", () => {
+    const input = {
+      countryCode: "US",
+      countryName: " United States ",
+      locality: "Fort Collins",
+      postalCodePrivate: "80521",
+      region: "CO",
+    };
+
+    expect(locationFieldsChanged(input, storedLocation)).toBe(false);
+    expect(
+      shouldGeocodeApproximateLocation({
+        input,
+        storageMode: "permanent",
+        stored: storedLocation,
+      }),
+    ).toBe(false);
+    expect(storedApproximateCoordinates(storedLocation)).toEqual({
+      latitude: 40.5853,
+      longitude: -105.0844,
+    });
+  });
+
+  it("geocodes persisted records only when the location is new or changed", () => {
+    expect(
+      shouldGeocodeApproximateLocation({
+        input: { countryName: "Canada", locality: "Toronto", region: "ON" },
+        storageMode: "permanent",
+        stored: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldGeocodeApproximateLocation({
+        input: {
+          countryCode: "US",
+          countryName: "United States",
+          locality: "Denver",
+          postalCodePrivate: "80202",
+          region: "CO",
+        },
+        storageMode: "permanent",
+        stored: storedLocation,
+      }),
+    ).toBe(true);
+  });
+
+  it("retries unchanged persisted locations that do not have stored coordinates yet", () => {
+    expect(
+      shouldGeocodeApproximateLocation({
+        input: {
+          countryCode: "US",
+          countryName: "United States",
+          locality: "Fort Collins",
+          postalCodePrivate: "80521",
+          region: "CO",
+        },
+        storageMode: "permanent",
+        stored: {
+          ...storedLocation,
+          latitudePrivate: null,
+          longitudePrivate: null,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("always allows temporary search-origin geocoding because results are not stored", () => {
+    expect(
+      shouldGeocodeApproximateLocation({
+        input: {
+          countryCode: "US",
+          countryName: "United States",
+          locality: "Fort Collins",
+          postalCodePrivate: "80521",
+          region: "CO",
+        },
+        storageMode: "temporary",
+        stored: storedLocation,
+      }),
+    ).toBe(true);
+  });
+});

--- a/test/interactive-map.test.ts
+++ b/test/interactive-map.test.ts
@@ -26,4 +26,13 @@ describe("interactive discovery map", () => {
       /postal_code_private|latitude_private|longitude_private/,
     );
   });
+
+  it("initializes one Mapbox map instance and updates markers separately", () => {
+    expect(component).toContain("const [mapReady, setMapReady]");
+    expect(component).toContain("useEffect(() => {");
+    expect(component).toContain("new mapboxgl.Map");
+    expect(component).toContain("}, []);");
+    expect(component).toContain("markerInstancesRef.current = markers.map");
+    expect(component).toContain("}, [markers, mapReady, resultBasePath]);");
+  });
 });


### PR DESCRIPTION
Closes #119

## Summary
- make /find list-first and only render the Mapbox map when Map view is explicitly selected
- keep one Mapbox GL map instance per rendered map view and update markers without recreating the map
- avoid permanent geocoding on profile/listing saves unless location fields are new, changed, or missing stored coordinates
- document Mapbox token restrictions, temporary/permanent geocoding storage behavior, and monitoring/cost-control guidance

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build
- local route check: /find redirects to sign-in; /map redirects to /find

## Mapbox docs checked
- Mapbox GL JS map loads are counted when a Map object initializes
- temporary geocoding results are not for stored reuse; permanent geocoding is required for stored coordinates
- public tokens should use minimum scopes and URL restrictions where possible