### PR TITLE
Cover Find discoverability status

### DIFF
--- a/app/find/page.tsx
+++ b/app/find/page.tsx
@@ -23,6 +23,10 @@ import {
   voicingPartOptions,
   voicingPartValue,
 } from "@/lib/parts/voicings";
+import {
+  discoverabilityExplanation,
+  discoverabilityStatusLabel,
+} from "@/lib/search/discoverability-status";
 import { parseDiscoveryFilters } from "@/lib/search/discovery-filters";
 import {
   profileOriginState,
@@ -288,24 +292,6 @@ function unavailableProfileStatusLine({
   }
 
   return `${label} does not have enough location information for distance search.`;
-}
-
-function discoverabilityLabel({
-  isVisible,
-  state,
-}: {
-  isVisible: boolean | null | undefined;
-  state: ProfileOriginState;
-}) {
-  if (!isVisible) {
-    return "Not shown in Find";
-  }
-
-  if (state.status !== "usable") {
-    return "Shown in Find, but missing location for distance search";
-  }
-
-  return "Shown in Find";
 }
 
 function radiusToKilometers(
@@ -581,7 +567,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             <div>
               <dt className="font-semibold text-[#172023]">Singer Profile</dt>
               <dd>
-                {discoverabilityLabel({
+                {discoverabilityStatusLabel({
                   isVisible: singerOrigin?.is_visible,
                   state: singerSearchOrigin,
                 })}
@@ -590,7 +576,7 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             <div>
               <dt className="font-semibold text-[#172023]">Quartet Profile</dt>
               <dd>
-                {discoverabilityLabel({
+                {discoverabilityStatusLabel({
                   isVisible: quartetOrigin?.is_visible,
                   state: quartetSearchOrigin,
                 })}
@@ -598,9 +584,10 @@ export default async function FindPage({ searchParams }: FindPageProps) {
             </div>
           </dl>
           <p className="mt-3 leading-6">
-            {singerOrigin?.is_visible || quartetOrigin?.is_visible
-              ? "You can search either way. These settings only control whether other people can find your profiles."
-              : "You can still search, but other users will not discover your Singer Profile or Quartet Profile until you turn visibility on."}
+            {discoverabilityExplanation({
+              hasVisibleQuartetProfile: quartetOrigin?.is_visible,
+              hasVisibleSingerProfile: singerOrigin?.is_visible,
+            })}
           </p>
           <div className="mt-3 flex flex-wrap gap-3">
             <a className="font-semibold text-[#2f6f73]" href="/app/profile">

--- a/lib/search/discoverability-status.ts
+++ b/lib/search/discoverability-status.ts
@@ -1,0 +1,33 @@
+import type { ProfileOriginState } from "@/lib/search/profile-origin";
+
+export function discoverabilityStatusLabel({
+  isVisible,
+  state,
+}: {
+  isVisible: boolean | null | undefined;
+  state: ProfileOriginState;
+}) {
+  if (!isVisible) {
+    return "Not shown in Find";
+  }
+
+  if (state.status !== "usable") {
+    return "Shown in Find, but missing location for distance search";
+  }
+
+  return "Shown in Find";
+}
+
+export function discoverabilityExplanation({
+  hasVisibleQuartetProfile,
+  hasVisibleSingerProfile,
+}: {
+  hasVisibleQuartetProfile: boolean | null | undefined;
+  hasVisibleSingerProfile: boolean | null | undefined;
+}) {
+  if (hasVisibleSingerProfile || hasVisibleQuartetProfile) {
+    return "You can search either way. These settings only control whether other people can find your profiles.";
+  }
+
+  return "You can still search, but other users will not discover your Singer Profile or Quartet Profile until you turn visibility on.";
+}

--- a/test/discoverability-status.test.ts
+++ b/test/discoverability-status.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  discoverabilityExplanation,
+  discoverabilityStatusLabel,
+} from "@/lib/search/discoverability-status";
+import type { ProfileOriginState } from "@/lib/search/profile-origin";
+
+function originState(status: ProfileOriginState["status"]): ProfileOriginState {
+  return {
+    coordinates: status === "usable" ? { latitude: 40, longitude: -105 } : null,
+    label: "Fort Collins, CO area",
+    status,
+  };
+}
+
+describe("Find page discoverability status", () => {
+  it("uses Shown in Find and Not shown in Find labels", () => {
+    expect(
+      discoverabilityStatusLabel({
+        isVisible: true,
+        state: originState("usable"),
+      }),
+    ).toBe("Shown in Find");
+    expect(
+      discoverabilityStatusLabel({
+        isVisible: false,
+        state: originState("usable"),
+      }),
+    ).toBe("Not shown in Find");
+    expect(
+      discoverabilityStatusLabel({
+        isVisible: null,
+        state: originState("missing_profile"),
+      }),
+    ).toBe("Not shown in Find");
+  });
+
+  it("notes when a visible profile is missing usable distance-search location", () => {
+    for (const status of [
+      "incomplete_location",
+      "missing_profile",
+      "needs_geocoding",
+    ] satisfies ProfileOriginState["status"][]) {
+      expect(
+        discoverabilityStatusLabel({
+          isVisible: true,
+          state: originState(status),
+        }),
+      ).toBe("Shown in Find, but missing location for distance search");
+    }
+  });
+
+  it("explains that visibility affects being found, not searching", () => {
+    expect(
+      discoverabilityExplanation({
+        hasVisibleQuartetProfile: false,
+        hasVisibleSingerProfile: true,
+      }),
+    ).toBe(
+      "You can search either way. These settings only control whether other people can find your profiles.",
+    );
+    expect(
+      discoverabilityExplanation({
+        hasVisibleQuartetProfile: false,
+        hasVisibleSingerProfile: false,
+      }),
+    ).toBe(
+      "You can still search, but other users will not discover your Singer Profile or Quartet Profile until you turn visibility on.",
+    );
+  });
+});

--- a/test/public-discovery-copy.test.ts
+++ b/test/public-discovery-copy.test.ts
@@ -57,6 +57,9 @@ describe("public discovery copy", () => {
 
   it("consolidates discovery around Search From, map, cards, and details", () => {
     const findPage = source("app/find/page.tsx");
+    const discoverabilityStatus = source(
+      "lib/search/discoverability-status.ts",
+    );
 
     expect(findPage).toContain("Search quartet openings and singers");
     expect(findPage).toContain("Filter discovery results");
@@ -67,8 +70,8 @@ describe("public discovery copy", () => {
     expect(findPage).toContain("Another location");
     expect(findPage).toContain("add location first");
     expect(findPage).toContain("Your discoverability");
-    expect(findPage).toContain("Shown in Find");
-    expect(findPage).toContain("Not shown in Find");
+    expect(discoverabilityStatus).toContain("Shown in Find");
+    expect(discoverabilityStatus).toContain("Not shown in Find");
     expect(findPage).toContain("Edit My Singer Profile");
     expect(findPage).toContain("Edit My Quartet Profile");
     expect(findPage).not.toContain(


### PR DESCRIPTION
Closes #115

## Summary
- extract the Find page discoverability status labels/explanation into a focused helper
- keep the existing Find UI behavior while making Singer Profile and Quartet Profile status states directly testable
- add coverage for Shown in Find, Not shown in Find, missing-location status, and the search-vs-being-found explanation

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npm run format:check
- npm run build